### PR TITLE
this permits the rhel7 spec file to also build on rhel6.5. xmlto otherwi...

### DIFF
--- a/packaging/rhel7/openswan.spec
+++ b/packaging/rhel7/openswan.spec
@@ -22,7 +22,8 @@ Group: System Environment/Daemons
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Summary: Openswan - An IPsec and IKE implementation
 Group: System Environment/Daemons
-BuildRequires: gmp-devel bison flex redhat-rpm-config xmlto
+# lynx is there to make xmlto happy on RHEL6.
+BuildRequires: gmp-devel bison flex redhat-rpm-config xmlto elinks
 Conflicts: libreswan
 Obsoletes: openswan
 

--- a/packaging/rhel7/openswan.spec.in
+++ b/packaging/rhel7/openswan.spec.in
@@ -22,7 +22,8 @@ Group: System Environment/Daemons
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 Summary: Openswan - An IPsec and IKE implementation
 Group: System Environment/Daemons
-BuildRequires: gmp-devel bison flex redhat-rpm-config xmlto
+# lynx is there to make xmlto happy on RHEL6.
+BuildRequires: gmp-devel bison flex redhat-rpm-config xmlto elinks
 Conflicts: libreswan
 Obsoletes: openswan
 


### PR DESCRIPTION
...se can not resolve dependancy for lynx vs elinks. rhel7 does not seem to have lynx