### PR TITLE
Cve 2015 3240

### DIFF
--- a/programs/pluto/crypt_dh.c
+++ b/programs/pluto/crypt_dh.c
@@ -269,6 +269,7 @@ calc_dh_shared(chunk_t *shared, const chunk_t g
 #endif
 
     DBG_cond_dump_chunk(DBG_CRYPT, "DH shared-secret:\n", *shared);
+    return TRUE;
 }
 #endif
 
@@ -1191,9 +1192,9 @@ void calc_dh(struct pluto_crypto_req *r)
     DBG(DBG_CRYPT, DBG_dump_chunk("peer's g: ", g));
 
 #ifdef HAVE_LIBNSS
-    r->success = calc_dh_shared(&shared, g, ltsecret, group, pubk);
+    r->pcr_success = calc_dh_shared(&shared, g, ltsecret, group, pubk);
 #else
-    r->success = calc_dh_shared(&shared, g, &sec, group);
+    r->pcr_success = calc_dh_shared(&shared, g, &sec, group);
     mpz_clear (&sec);
 #endif
 
@@ -1620,11 +1621,11 @@ void calc_dh_v2(struct pluto_crypto_req *r)
     DBG(DBG_CRYPT, DBG_dump_chunk("peer's g: ", g));
 
 #ifndef HAVE_LIBNSS
-    r->success = calc_dh_shared(&shared, g, &sec, group);
+    r->pcr_success = calc_dh_shared(&shared, g, &sec, group);
 #else
-    r->success = calc_dh_shared(&shared, g, ltsecret, group, pubk);
+    r->pcr_success = calc_dh_shared(&shared, g, ltsecret, group, pubk);
 #endif
-    if(!r->success) return;
+    if(!r->pcr_success) return;
 
     memset(&skeyseed,  0, sizeof(skeyseed));
     memset(&SK_d,      0, sizeof(SK_d));
@@ -1670,7 +1671,7 @@ void calc_dh_v2(struct pluto_crypto_req *r)
     freeanychunk(SK_pi);
     freeanychunk(SK_pr);
 
-    r->success = TRUE;
+    r->pcr_success = TRUE;
     return;
 }
 

--- a/programs/pluto/crypt_dh.c
+++ b/programs/pluto/crypt_dh.c
@@ -109,7 +109,7 @@ return mechanism;
  * (see quoted passage at start of ACCEPT_KE).
  */
 #ifdef HAVE_LIBNSS
-static void
+static bool
 calc_dh_shared(chunk_t *shared, const chunk_t g
               , chunk_t secret
               , const struct oakley_group_desc *group
@@ -161,7 +161,10 @@ calc_dh_shared(chunk_t *shared, const chunk_t g
                          , CKM_DH_PKCS_DERIVE, CKM_CONCATENATE_DATA_AND_BASE
                          , CKA_DERIVE, group->bytes
                          , osw_return_nss_password_file_info());
-    PR_ASSERT(dhshared!=NULL);
+    if(dhshared == NULL) {
+        openswan_log("PK11_PubDerive failed, maybe all zero g^x");
+        return FALSE;
+    }
 
     dhshared_len = PK11_GetKeyLength(dhshared);
     if( group->bytes > dhshared_len ) {
@@ -178,7 +181,7 @@ calc_dh_shared(chunk_t *shared, const chunk_t g
 	string_params.ulLen = zeros.len;
 
 	newdhshared = PK11_Derive(dhshared, CKM_CONCATENATE_DATA_AND_BASE, &params, CKM_CONCATENATE_DATA_AND_BASE, CKA_DERIVE, 0);
-	PR_ASSERT(newdhshared!=NULL);
+	PR_ASSERT(newdhshared!=NULL);  /* XXX here? */
 	PK11_FreeSymKey(dhshared);
 	dhshared = newdhshared;
 	freeanychunk(zeros);
@@ -219,9 +222,11 @@ calc_dh_shared(chunk_t *shared, const chunk_t g
 #endif
 
     DBG_cond_dump_chunk(DBG_CRYPT, "DH shared-secret pointer:\n", *shared);
+    return TRUE;
+
 }
 #else
-static void
+static bool
 calc_dh_shared(chunk_t *shared, const chunk_t g
 	       , const MP_INT *sec
 	       , const struct oakley_group_desc *group)
@@ -1087,10 +1092,16 @@ void calc_dh_iv(struct pluto_crypto_req *r)
 #ifndef HAVE_LIBNSS
     DBG(DBG_CRYPT,
     DBG_dump_chunk("long term secret: ", ltsecret));
-    calc_dh_shared(&shared, g, &sec, group);
+    if(!calc_dh_shared(&shared, g, &sec, group)) {
+        r->pcr_success = FALSE;
+        return;
+    }
     mpz_clear (&sec);
 #else
-    calc_dh_shared(&shared, g, ltsecret, group, pubk);
+    if(!calc_dh_shared(&shared, g, ltsecret, group, pubk)) {
+        r->pcr_success = FALSE;
+        return;
+    }
 #endif
 
     memset(&skeyid, 0, sizeof(skeyid));
@@ -1127,6 +1138,8 @@ void calc_dh_iv(struct pluto_crypto_req *r)
     freeanychunk(skeyid_e);
     freeanychunk(new_iv);
     freeanychunk(enc_key);
+
+    r->pcr_success = TRUE;
 
     return;
 }
@@ -1178,9 +1191,9 @@ void calc_dh(struct pluto_crypto_req *r)
     DBG(DBG_CRYPT, DBG_dump_chunk("peer's g: ", g));
 
 #ifdef HAVE_LIBNSS
-    calc_dh_shared(&shared, g, ltsecret, group, pubk);
+    r->success = calc_dh_shared(&shared, g, ltsecret, group, pubk);
 #else
-    calc_dh_shared(&shared, g, &sec, group);
+    r->success = calc_dh_shared(&shared, g, &sec, group);
     mpz_clear (&sec);
 #endif
 
@@ -1607,10 +1620,11 @@ void calc_dh_v2(struct pluto_crypto_req *r)
     DBG(DBG_CRYPT, DBG_dump_chunk("peer's g: ", g));
 
 #ifndef HAVE_LIBNSS
-    calc_dh_shared(&shared, g, &sec, group);
+    r->success = calc_dh_shared(&shared, g, &sec, group);
 #else
-    calc_dh_shared(&shared, g, ltsecret, group, pubk);
+    r->success = calc_dh_shared(&shared, g, ltsecret, group, pubk);
 #endif
+    if(!r->success) return;
 
     memset(&skeyseed,  0, sizeof(skeyseed));
     memset(&SK_d,      0, sizeof(SK_d));
@@ -1656,6 +1670,7 @@ void calc_dh_v2(struct pluto_crypto_req *r)
     freeanychunk(SK_pi);
     freeanychunk(SK_pr);
 
+    r->success = TRUE;
     return;
 }
 

--- a/programs/pluto/ikev1_aggr.c
+++ b/programs/pluto/ikev1_aggr.c
@@ -409,6 +409,9 @@ aggr_inI1_outR1_tail(struct pluto_crypto_req_cont *pcrc
      */
 
     finish_dh_secretiv(st, r);
+    if(!r->pcr_success) {
+        return STF_FAIL + INVALID_KEY_INFORMATION;
+    }
 
     init_pbs(&reply_stream, reply_buffer, sizeof(reply_buffer), "reply packet");
 
@@ -680,6 +683,9 @@ aggr_inR1_outI2_crypto_continue(struct pluto_crypto_req_cont *pcrc
   st->st_calculating = FALSE;
 
   finish_dh_secretiv(st, r);
+  if(!r->pcr_success) {
+      return STF_FAIL + INVALID_KEY_INFORMATION;
+  }
 
   e = aggr_inR1_outI2_tail(md, NULL);
 

--- a/programs/pluto/ikev1_aggr.c
+++ b/programs/pluto/ikev1_aggr.c
@@ -684,10 +684,10 @@ aggr_inR1_outI2_crypto_continue(struct pluto_crypto_req_cont *pcrc
 
   finish_dh_secretiv(st, r);
   if(!r->pcr_success) {
-      return STF_FAIL + INVALID_KEY_INFORMATION;
+      e = STF_FAIL + INVALID_KEY_INFORMATION;
+  } else {
+      e = aggr_inR1_outI2_tail(md, NULL);
   }
-
-  e = aggr_inR1_outI2_tail(md, NULL);
 
   if(dh->md != NULL) {
       complete_v1_state_transition(&dh->md, e);

--- a/programs/pluto/ikev1_main.c
+++ b/programs/pluto/ikev1_main.c
@@ -1334,7 +1334,8 @@ main_inI2_outR2_calcdone(struct pluto_crypto_req_cont *pcrc
 
     finish_dh_secretiv(st, r);
     if(!r->pcr_success) {
-        return STF_FAIL + INVALID_KEY_INFORMATION;
+        loglog(RC_LOG_SERIOUS, "DH crypto failed, invalid keys");
+        return;
     }
 
     st->hidden_variables.st_skeyid_calculated = TRUE;

--- a/programs/pluto/ikev1_main.c
+++ b/programs/pluto/ikev1_main.c
@@ -1333,6 +1333,9 @@ main_inI2_outR2_calcdone(struct pluto_crypto_req_cont *pcrc
     }
 
     finish_dh_secretiv(st, r);
+    if(!r->pcr_success) {
+        return STF_FAIL + INVALID_KEY_INFORMATION;
+    }
 
     st->hidden_variables.st_skeyid_calculated = TRUE;
     update_iv(st);
@@ -1588,6 +1591,9 @@ main_inR2_outI3_continue(struct msg_digest *md
     cert_t mycert = st->st_connection->spd.this.cert;
 
     finish_dh_secretiv(st, r);
+    if(!r->pcr_success) {
+        return STF_FAIL + INVALID_KEY_INFORMATION;
+    }
 
     /* decode certificate requests */
     decode_cr(md, &requested_ca);

--- a/programs/pluto/ikev1_quick.c
+++ b/programs/pluto/ikev1_quick.c
@@ -2267,7 +2267,9 @@ quick_inI1_outR1_cryptotail(struct dh_continuation *dh
 	    return STF_INTERNAL_ERROR;
 
 	finish_dh_secret(st, r);
-
+        if(!r->pcr_success) {
+            return STF_FAIL + INVALID_KEY_INFORMATION;
+        }
     }
 
     /* [ IDci, IDcr ] out */
@@ -2435,6 +2437,9 @@ quick_inR1_outI2_cryptotail(struct dh_continuation *dh
 
     if (st->st_pfs_group != NULL && r!=NULL) {
 	finish_dh_secret(st, r);
+        if(!r->pcr_success) {
+            return STF_FAIL + INVALID_KEY_INFORMATION;
+        }
     }
 
 #ifdef NAT_TRAVERSAL

--- a/programs/pluto/pluto_crypt.h
+++ b/programs/pluto/pluto_crypt.h
@@ -134,6 +134,7 @@ struct pluto_crypto_req {
   pcr_req_id                 pcr_id;
   enum crypto_importance     pcr_pcim;
   int                        pcr_slot;
+  int                        pcr_success;
   union {
       struct pcr_kenonce      kn;
       struct pcr_skeyid_q     dhq;


### PR DESCRIPTION
This is an openswan specific fix for CVE 2015-3240, whereby an initiator sends an invalid g^x.
This code has been validated against the --impair- option created by the DHR for libreswan.
An automated unit test case may be possible in the future, but currently the unit test cases mock all the crypto.
