### PR TITLE
Updating man page in order to remove manual option from auto keyword

### DIFF
--- a/programs/_confread/d.ipsec.conf/auto.xml
+++ b/programs/_confread/d.ipsec.conf/auto.xml
@@ -15,11 +15,6 @@ currently-accepted values are
 (signifying that plus an
 <emphasis remap='B'>ipsec auto</emphasis>
 <option>--up</option>),
-<emphasis remap='B'>manual</emphasis>
-(signifying an
-<emphasis remap='B'>ipsec</emphasis>
-<emphasis remap='B'>manual</emphasis>
-<option>--up</option>),
 and
 <emphasis remap='B'>ignore</emphasis>
 (also the default) (signifying no automatic startup operation).

--- a/programs/_confread/ipsec.conf.5
+++ b/programs/_confread/ipsec.conf.5
@@ -402,11 +402,7 @@ what operation, if any, should be done automatically at IPsec startup; currently
 (signifying that plus an
 \fBipsec auto\fR
 \fB\-\-up\fR),
-\fBmanual\fR
-(signifying an
-\fBipsec\fR
-\fBmanual\fR
-\fB\-\-up\fR), and
+and
 \fBignore\fR
 (also the default) (signifying no automatic startup operation)\&. See the
 \fBconfig\fR


### PR DESCRIPTION
The manual option for auto keyword is no longer supported