### PR TITLE
T4493 problems with eroute ownership

### DIFF
--- a/include/pluto/connections.h
+++ b/include/pluto/connections.h
@@ -124,6 +124,7 @@ extern void fmt_policy_prio(policy_prio_t pp, char buf[POLICY_PRIO_BUF]);
 #include "pgp.h"
 #include "certs.h"
 #include "pluto/defs.h"
+#include "pluto/log.h"
 
 struct virtual_t;
 
@@ -447,11 +448,11 @@ extern struct connection *eclipsed(struct connection *c, struct spd_route **);
 
 /* print connection status */
 
-extern void show_one_connection(struct connection *c);
+extern void show_one_connection(struct connection *c, logfunc logger);
 extern char *fmt_connection_inst_name(struct connection *c
                                       , char *instname
                                       , unsigned int instname_len);
-extern void show_connections_status(void);
+extern void show_connections_status(logfunc logger);
 extern int  connection_compare(const struct connection *ca
 			       , const struct connection *cb);
 #ifdef NAT_TRAVERSAL

--- a/include/pluto/log.h
+++ b/include/pluto/log.h
@@ -147,6 +147,9 @@ extern void close_peerlog(void);
 /* free all per-peer log resources */
 extern void perpeer_logfree(struct connection *c);
 
+/* typedef matches whacklog, and loglog */
+typedef void (*logfunc)(int mess_no, const char *message, ...);
+
 extern void whack_log(int mess_no, const char *message, ...) PRINTF_LIKE(2);
 
 /* Log to both main log and whack log

--- a/lib/libipsecconf/confread.c
+++ b/lib/libipsecconf/confread.c
@@ -534,11 +534,11 @@ static bool validate_end(struct starter_conn *conn_st
 	if (tnatoaddr(value, strlen(value), AF_INET, &(end->nexthop)) != NULL
 	    && tnatoaddr(value, strlen(value), AF_INET6, &(end->nexthop)) != NULL) {
 
-	    er = ttoaddr(value, 0, family, &(end->sourceip));
+	    er = ttoaddr(value, 0, 0, &(end->sourceip));
 	    if (er) ERR_FOUND("bad addr %ssourceip=%s [%s]", leftright, value, er);
 
 	} else {
-		er = tnatoaddr(value, 0, family, &(end->sourceip));
+		er = tnatoaddr(value, 0, 0, &(end->sourceip));
 		if (er) ERR_FOUND("bad numerical addr %ssourceip=%s [%s]", leftright, value, er);
 	}
 

--- a/lib/libipsecconf/confread.c
+++ b/lib/libipsecconf/confread.c
@@ -531,8 +531,8 @@ static bool validate_end(struct starter_conn *conn_st
     {
 	char *value = end->strings[KSCF_SOURCEIP];
 
-	if (tnatoaddr(value, strlen(value), AF_INET, &(end->nexthop)) != NULL
-	    && tnatoaddr(value, strlen(value), AF_INET6, &(end->nexthop)) != NULL) {
+	if (tnatoaddr(value, strlen(value), AF_INET, &(end->sourceip)) != NULL
+	    && tnatoaddr(value, strlen(value), AF_INET6, &(end->sourceip)) != NULL) {
 
 	    er = ttoaddr(value, 0, 0, &(end->sourceip));
 	    if (er) ERR_FOUND("bad addr %ssourceip=%s [%s]", leftright, value, er);

--- a/programs/pluto/Makefile.depend.linux
+++ b/programs/pluto/Makefile.depend.linux
@@ -13,29 +13,56 @@ ac.o: ac.c ../../include/openswan.h \
  ../../include/openswan/passert.h \
  ../../include/oswtime.h \
  ../../include/pluto/defs.h \
- ../../include/oswalloc.h \
- ../../include/asn1.h \
- ../../include/oid.h \
- ../../include/ac.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/certs.h \
+ ../../include/oswalloc.h ../../include/asn1.h \
+ ../../include/oid.h ../../include/ac.h \
+ ../../include/id.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h log.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
+ ../../include/pluto/log.h \
  ../../include/whack.h \
  ../../include/openswan/ipsec_policy.h fetch.h
 adns.o: adns.c ../../include/openswan.h \
+ ../../include/oswlog.h \
+ ../../include/openswan/passert.h \
  ../../include/constants.h \
  ../../include/biglset.h \
  ../../include/openswan/passert.h \
  ../../include/ietf_constants.h \
  ../../include/pluto_constants.h \
- ../../include/names_constant.h adns.h \
+ ../../include/names_constant.h \
+ ../../include/constants.h adns.h \
  ../../include/osw_select.h
+build_ke.o: build_ke.c ../../include/openswan.h \
+ ../../include/openswan/ipsec_policy.h \
+ ../../ports/linux/include/sysdep.h \
+ ../../include/sysqueue.h \
+ ../../include/constants.h \
+ ../../include/biglset.h \
+ ../../include/openswan/passert.h \
+ ../../include/ietf_constants.h \
+ ../../include/pluto_constants.h \
+ ../../include/names_constant.h \
+ ../../include/pluto/defs.h \
+ ../../include/oswalloc.h \
+ ../../include/constants.h \
+ ../../include/packet.h demux.h \
+ ../../include/pluto/server.h quirks.h crypto.h \
+ ../../include/sha1.h ../../include/md5.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ ../../include/pluto/rnd.h state.h \
+ ../../include/id.h pluto_crypt.h \
+ ../../include/osw_select.h \
+ ../../include/oswlog.h \
+ ../../include/openswan/passert.h \
+ ../../include/pluto/log.h timer.h \
+ ../../include/oswtime.h \
+ ../../include/oswcrypto.h \
+ ../../include/klips-crypto/aes.h \
+ ../../include/klips-crypto/aes_cbc.h \
+ ../../include/klips-crypto/aes.h \
+ ../../include/klips-crypto/des.h
 connections.o: connections.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../include/openswan/pfkeyv2.h \
@@ -50,33 +77,28 @@ connections.o: connections.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/oswalloc.h \
  ../../include/constants.h \
- ../../include/oswtime.h \
- ../../include/id.h \
+ ../../include/oswtime.h ../../include/id.h \
  ../../include/pluto/x509lists.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/secrets.h \
- ../../include/pluto/defs.h \
- ../../include/ac.h \
- ../../include/pluto/connections.h pending.h \
- foodgroups.h ../../include/packet.h demux.h \
- ../../include/pluto/server.h quirks.h state.h \
- timer.h ipsec_doi.h ikev1_quick.h kernel.h log.h \
+ ../../include/pluto/defs.h ../../include/ac.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
  ../../include/openswan/passert.h \
+ ../../include/pluto/connections.h pending.h foodgroups.h \
+ ../../include/packet.h demux.h \
+ ../../include/pluto/server.h quirks.h state.h timer.h \
+ ipsec_doi.h ikev1_quick.h kernel.h \
  ../../include/pluto/keys.h adns.h dnskey.h \
- ../../include/whack.h \
- ../../include/alg_info.h spdb.h ike_alg.h \
- plutocerts.h ../../include/kernel_alg.h \
+ ../../include/whack.h ../../include/alg_info.h \
+ spdb.h ike_alg.h plutocerts.h ../../include/kernel_alg.h \
  ../../include/openswan/pfkeyv2.h plutoalg.h xauth.h \
- nat_traversal.h ../../include/pluto/virtual.h \
- hostpair.h
+ ../../include/pluto/libpluto.h nat_traversal.h \
+ ../../include/pluto/virtual.h hostpair.h
 cookie.o: cookie.c ../../include/openswan.h \
  ../../include/constants.h \
  ../../include/biglset.h \
@@ -86,8 +108,7 @@ cookie.o: cookie.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h \
- ../../include/sha1.h \
+ ../../include/constants.h ../../include/sha1.h \
  ../../include/pluto/rnd.h cookie.h
 crypt_dh.o: crypt_dh.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
@@ -104,25 +125,22 @@ crypt_dh.o: crypt_dh.c ../../include/openswan.h \
  ../../include/constants.h \
  ../../include/packet.h demux.h \
  ../../include/pluto/server.h quirks.h crypto.h \
- ../../include/sha1.h \
- ../../include/md5.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h \
- ../../include/pluto/rnd.h state.h pluto_crypt.h \
+ ../../include/sha1.h ../../include/md5.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ ../../include/pluto/rnd.h state.h \
+ ../../include/id.h pluto_crypt.h \
  ../../include/osw_select.h \
  ../../include/oswlog.h \
- ../../include/openswan/passert.h log.h timer.h \
+ ../../include/openswan/passert.h \
+ ../../include/pluto/log.h timer.h \
  ../../include/oswtime.h ike_alg.h \
- ../../include/id.h \
- ../../include/secrets.h \
- ../../include/id.h \
+ ../../include/secrets.h ../../include/id.h \
  ../../include/x509.h \
  ../../include/pluto/keys.h \
- ../../include/x509.h \
- ../../include/certs.h \
+ ../../include/x509.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/pgp.h ikev2_prfplus.h
+ ../../include/secrets.h ../../include/pgp.h \
+ ikev2_prfplus.h
 crypt_ke.o: crypt_ke.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../ports/linux/include/sysdep.h \
@@ -138,22 +156,21 @@ crypt_ke.o: crypt_ke.c ../../include/openswan.h \
  ../../include/constants.h \
  ../../include/packet.h demux.h \
  ../../include/pluto/server.h quirks.h crypto.h \
- ../../include/sha1.h \
- ../../include/md5.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h \
- ../../include/pluto/rnd.h state.h pluto_crypt.h \
+ ../../include/sha1.h ../../include/md5.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ ../../include/pluto/rnd.h state.h \
+ ../../include/id.h pluto_crypt.h \
  ../../include/osw_select.h \
  ../../include/oswlog.h \
- ../../include/openswan/passert.h log.h timer.h \
+ ../../include/openswan/passert.h \
+ ../../include/pluto/log.h timer.h \
  ../../include/oswtime.h \
  ../../include/oswcrypto.h \
  ../../include/klips-crypto/aes.h \
  ../../include/klips-crypto/aes_cbc.h \
  ../../include/klips-crypto/aes.h \
  ../../include/klips-crypto/des.h
-crypt_start_dh.o: crypt_start_dh.c \
- ../../include/openswan.h \
+crypt_start_dh.o: crypt_start_dh.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../ports/linux/include/sysdep.h \
  ../../include/sysqueue.h \
@@ -168,25 +185,21 @@ crypt_start_dh.o: crypt_start_dh.c \
  ../../include/constants.h \
  ../../include/packet.h demux.h \
  ../../include/pluto/server.h quirks.h crypto.h \
- ../../include/sha1.h \
- ../../include/md5.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h \
- ../../include/pluto/rnd.h state.h pluto_crypt.h \
+ ../../include/sha1.h ../../include/md5.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ ../../include/pluto/rnd.h state.h \
+ ../../include/id.h pluto_crypt.h \
  ../../include/osw_select.h \
  ../../include/oswlog.h \
- ../../include/openswan/passert.h log.h timer.h \
+ ../../include/openswan/passert.h \
+ ../../include/pluto/log.h timer.h \
  ../../include/oswtime.h ike_alg.h \
- ../../include/id.h \
- ../../include/secrets.h \
- ../../include/id.h \
+ ../../include/secrets.h ../../include/id.h \
  ../../include/x509.h \
  ../../include/pluto/keys.h \
- ../../include/x509.h \
- ../../include/certs.h \
+ ../../include/x509.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/pgp.h
+ ../../include/secrets.h ../../include/pgp.h
 crypt_utils.o: crypt_utils.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../ports/linux/include/sysdep.h \
@@ -203,13 +216,12 @@ crypt_utils.o: crypt_utils.c ../../include/openswan.h \
  ../../include/packet.h demux.h \
  ../../include/pluto/server.h quirks.h \
  ../../include/oswlog.h \
- ../../include/openswan/passert.h log.h state.h \
- ../../include/pluto/rnd.h pluto_crypt.h \
- ../../include/osw_select.h crypto.h \
- ../../include/sha1.h \
- ../../include/md5.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h
+ ../../include/openswan/passert.h \
+ ../../include/pluto/log.h state.h \
+ ../../include/id.h ../../include/pluto/rnd.h \
+ pluto_crypt.h ../../include/osw_select.h crypto.h \
+ ../../include/sha1.h ../../include/md5.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h
 crypto.o: crypto.c ../../include/openswan.h \
  ../../include/klips-crypto/des.h \
  ../../include/constants.h \
@@ -220,12 +232,12 @@ crypto.o: crypto.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h state.h quirks.h log.h \
+ ../../include/constants.h ../../include/id.h \
+ state.h quirks.h ../../include/pluto/log.h \
  ../../include/oswlog.h \
  ../../include/openswan/passert.h \
- ../../include/md5.h \
- ../../include/sha1.h crypto.h \
- ../../include/sha2.h \
+ ../../include/md5.h ../../include/sha1.h \
+ crypto.h ../../include/sha2.h \
  ../../include/mpzfuncs.h \
  ../../include/alg_info.h ike_alg.h tpm/tpm.h \
  ../../include/oswcrypto.h \
@@ -244,7 +256,8 @@ db_ops.o: db_ops.c ../../include/openswan.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
  ../../include/constants.h state.h quirks.h \
- ../../include/packet.h spdb.h db_ops.h log.h \
+ ../../include/id.h ../../include/packet.h \
+ spdb.h db_ops.h ../../include/pluto/log.h \
  ../../include/oswlog.h \
  ../../include/openswan/passert.h \
  ../../include/whack.h \
@@ -263,22 +276,18 @@ demux.o: demux.c ../../include/openswan.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h cookie.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/certs.h \
+ ../../include/id.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h quirks.h \
- ../../include/packet.h \
- ../../include/md5.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h \
+ ../../include/packet.h ../../include/md5.h \
  ../../include/sha1.h crypto.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h ike_alg.h log.h demux.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ ike_alg.h ../../include/pluto/log.h demux.h \
  ../../include/pluto/server.h ikev1.h pluto_crypt.h \
  ../../include/osw_select.h ikev1_continuations.h \
  ike_continuations.h dnskey.h adns.h ipsec_doi.h ikev1_quick.h timer.h \
@@ -296,20 +305,18 @@ dnskey.o: dnskey.c ../../include/openswan.h \
  ../../include/names_constant.h adns.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h \
- ../../include/id.h log.h \
+ ../../include/constants.h ../../include/id.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
  ../../include/openswan/passert.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
  ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
  ../../include/pluto/keys.h \
  ../../include/secrets.h dnskey.h \
  ../../include/packet.h timer.h \
@@ -328,27 +335,24 @@ dpd.o: dpd.c ../../include/openswan.h \
  ../../include/oswtime.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h state.h quirks.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/certs.h \
+ ../../include/constants.h ../../include/id.h \
+ state.h quirks.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
  ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
+ ../../include/oswlog.h \
+ ../../include/openswan/passert.h \
  ../../include/pluto/keys.h \
- ../../include/secrets.h \
- ../../include/packet.h demux.h \
- ../../include/pluto/server.h adns.h dnskey.h \
- kernel.h log.h ../../include/oswlog.h \
- ../../include/openswan/passert.h cookie.h spdb.h \
- timer.h ../../include/pluto/rnd.h ipsec_doi.h \
- ikev1_quick.h ../../include/whack.h pending.h dpd.h \
- x509more.h ../../include/pluto/x509lists.h
+ ../../include/secrets.h ../../include/packet.h \
+ demux.h ../../include/pluto/server.h adns.h dnskey.h \
+ kernel.h ../../include/pluto/log.h cookie.h spdb.h timer.h \
+ ../../include/pluto/rnd.h ipsec_doi.h ikev1_quick.h \
+ ../../include/whack.h pending.h dpd.h x509more.h \
+ ../../include/pluto/x509lists.h
 dsa.o: dsa.c ../../include/openswan.h \
  ../../include/constants.h \
  ../../include/biglset.h \
@@ -358,7 +362,8 @@ dsa.o: dsa.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h log.h \
+ ../../include/constants.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
  ../../include/openswan/passert.h \
  ../../include/pluto/rnd.h gcryptfix.h dsa.h
@@ -371,7 +376,8 @@ elgamal.o: elgamal.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h log.h \
+ ../../include/constants.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
  ../../include/openswan/passert.h \
  ../../include/pluto/rnd.h gcryptfix.h elgamal.h
@@ -384,20 +390,16 @@ fetch.o: fetch.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h log.h \
+ ../../include/constants.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
  ../../include/openswan/passert.h \
- ../../include/id.h \
- ../../include/asn1.h \
- ../../include/pem.h \
- ../../include/certs.h \
+ ../../include/id.h ../../include/asn1.h \
+ ../../include/pem.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/x509.h \
- ../../include/whack.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
+ ../../include/x509.h ../../include/whack.h \
  ../../include/openswan/ipsec_policy.h \
  ../../include/pluto/ocsp.h fetch.h \
  ../../include/oswtime.h
@@ -412,22 +414,19 @@ foodgroups.o: foodgroups.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/constants.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h foodgroups.h kernel.h \
- ../../include/oswconf.h \
- ../../include/lex.h log.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
- ../../include/openswan/passert.h \
+ ../../include/openswan/passert.h foodgroups.h kernel.h \
+ ../../include/oswconf.h ../../include/lex.h \
+ ../../include/pluto/log.h \
  ../../include/whack.h \
  ../../include/openswan/ipsec_policy.h
 gcryptfix.o: gcryptfix.c ../../include/openswan.h \
@@ -439,7 +438,8 @@ gcryptfix.o: gcryptfix.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h log.h \
+ ../../include/constants.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
  ../../include/openswan/passert.h \
  ../../include/pluto/rnd.h gcryptfix.h
@@ -452,11 +452,9 @@ hmac.o: hmac.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h \
- ../../include/md5.h \
+ ../../include/constants.h ../../include/md5.h \
  ../../include/sha1.h crypto.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
  ../../include/alg_info.h ike_alg.h
 hostpair.o: hostpair.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
@@ -472,33 +470,28 @@ hostpair.o: hostpair.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/oswalloc.h \
  ../../include/constants.h \
- ../../include/oswtime.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/oswtime.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/secrets.h \
- ../../include/pluto/defs.h \
- ../../include/ac.h \
+ ../../include/pluto/defs.h ../../include/ac.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h pending.h foodgroups.h \
- ../../include/packet.h demux.h \
- ../../include/pluto/server.h quirks.h state.h \
- timer.h ipsec_doi.h ikev1_quick.h kernel.h log.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
- ../../include/openswan/passert.h \
+ ../../include/openswan/passert.h pending.h foodgroups.h \
+ ../../include/packet.h demux.h \
+ ../../include/pluto/server.h quirks.h state.h timer.h \
+ ipsec_doi.h ikev1_quick.h kernel.h \
+ ../../include/pluto/log.h \
  ../../include/pluto/keys.h adns.h dnskey.h \
- ../../include/whack.h \
- ../../include/alg_info.h spdb.h ike_alg.h \
- plutocerts.h ../../include/kernel_alg.h \
+ ../../include/whack.h ../../include/alg_info.h \
+ spdb.h ike_alg.h plutocerts.h ../../include/kernel_alg.h \
  ../../include/openswan/pfkeyv2.h plutoalg.h xauth.h \
- nat_traversal.h ../../include/pluto/virtual.h \
- hostpair.h
+ nat_traversal.h ../../include/pluto/virtual.h hostpair.h
 ike_alg.o: ike_alg.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../ports/linux/include/sysdep.h \
@@ -511,27 +504,24 @@ ike_alg.o: ike_alg.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h \
- ../../include/sha1.h \
+ ../../include/constants.h ../../include/sha1.h \
  ../../include/md5.h crypto.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h state.h quirks.h \
- ../../include/packet.h log.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ state.h quirks.h ../../include/id.h \
+ ../../include/packet.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
  ../../include/openswan/passert.h \
  ../../include/whack.h spdb.h \
  ../../include/alg_info.h ike_alg.h db_ops.h \
- ../../include/id.h \
  ../../include/pluto/connections.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/pluto/defs.h kernel.h plutoalg.h
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h kernel.h plutoalg.h
 ike_alg_aes.o: ike_alg_aes.c ../../include/openswan.h \
  ../../include/constants.h \
  ../../include/biglset.h \
@@ -541,14 +531,14 @@ ike_alg_aes.o: ike_alg_aes.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h log.h \
+ ../../include/constants.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
  ../../include/openswan/passert.h \
  ../../include/klips-crypto/aes_cbc.h \
  ../../include/klips-crypto/aes.h \
  ../../include/alg_info.h ike_alg.h
-ike_alg_sha2.o: ike_alg_sha2.c \
- ../../include/openswan.h \
+ike_alg_sha2.o: ike_alg_sha2.c ../../include/openswan.h \
  ../../include/constants.h \
  ../../include/biglset.h \
  ../../include/openswan/passert.h \
@@ -557,13 +547,13 @@ ike_alg_sha2.o: ike_alg_sha2.c \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h log.h \
+ ../../include/constants.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
  ../../include/openswan/passert.h \
- ../../include/sha2.h \
- ../../include/alg_info.h ike_alg.h
-ike_alg_status.o: ike_alg_status.c \
- ../../include/openswan.h \
+ ../../include/sha2.h ../../include/alg_info.h \
+ ike_alg.h
+ike_alg_status.o: ike_alg_status.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../ports/linux/include/sysdep.h \
  ../../include/sysqueue.h \
@@ -575,27 +565,24 @@ ike_alg_status.o: ike_alg_status.c \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h \
- ../../include/sha1.h \
+ ../../include/constants.h ../../include/sha1.h \
  ../../include/md5.h crypto.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h state.h quirks.h \
- ../../include/packet.h log.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ state.h quirks.h ../../include/id.h \
+ ../../include/packet.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
  ../../include/openswan/passert.h \
  ../../include/whack.h spdb.h \
  ../../include/alg_info.h ike_alg.h db_ops.h \
- ../../include/id.h \
  ../../include/pluto/connections.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/pluto/defs.h kernel.h plutoalg.h
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h kernel.h plutoalg.h
 ike_alginit.o: ike_alginit.c
 ikeping.o: ikeping.c ../../include/openswan.h \
  ../../ports/linux/include/sysdep.h \
@@ -611,7 +598,7 @@ ikeping.o: ikeping.c ../../include/openswan.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h cookie.h \
- ../../include/id.h log.h \
+ ../../include/id.h ../../include/pluto/log.h \
  ../../include/packet.h demux.h \
  ../../include/pluto/server.h quirks.h
 ikev1.o: ikev1.c ../../include/openswan.h \
@@ -628,30 +615,25 @@ ikev1.o: ikev1.c ../../include/openswan.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h cookie.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/certs.h \
+ ../../include/id.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h quirks.h \
- ../../include/packet.h \
- ../../include/md5.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h \
+ ../../include/packet.h ../../include/md5.h \
  ../../include/sha1.h crypto.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h ike_alg.h log.h demux.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ ike_alg.h ../../include/pluto/log.h demux.h \
  ../../include/pluto/server.h ikev1.h pluto_crypt.h \
  ../../include/osw_select.h ikev1_continuations.h \
  ike_continuations.h dnskey.h adns.h ipsec_doi.h ikev1_quick.h timer.h \
- ../../include/oswtime.h \
- ../../include/whack.h \
+ ../../include/oswtime.h ../../include/whack.h \
  ../../include/openswan/ipsec_policy.h xauth.h \
- nat_traversal.h vendor.h dpd.h \
- ../../include/udpfromto.h tpm/tpm.h hostpair.h
+ nat_traversal.h vendor.h dpd.h ../../include/udpfromto.h \
+ tpm/tpm.h hostpair.h
 ikev1_aggr.o: ikev1_aggr.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../include/openswan/pfkeyv2.h \
@@ -667,38 +649,121 @@ ikev1_aggr.o: ikev1_aggr.c ../../include/openswan.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
  ../../include/constants.h state.h quirks.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/certs.h \
+ ../../include/id.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
  ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
+ ../../include/oswlog.h \
+ ../../include/openswan/passert.h hostpair.h \
  ../../include/pluto/keys.h \
- ../../include/secrets.h \
- ../../include/packet.h demux.h \
- ../../include/pluto/server.h adns.h dnskey.h \
- kernel.h log.h ../../include/oswlog.h \
- ../../include/openswan/passert.h cookie.h spdb.h \
- timer.h ../../include/oswtime.h \
+ ../../include/secrets.h ../../include/packet.h \
+ demux.h ../../include/pluto/server.h adns.h dnskey.h \
+ kernel.h ../../include/pluto/log.h cookie.h spdb.h timer.h \
+ ../../include/oswtime.h \
  ../../include/pluto/rnd.h ipsec_doi.h ikev1_quick.h \
  ../../include/whack.h fetch.h \
- ../../include/pkcs.h \
- ../../include/asn1.h \
- ../../include/sha1.h \
- ../../include/md5.h crypto.h \
- ../../include/sha2.h \
+ ../../include/pkcs.h ../../include/asn1.h \
+ ../../include/sha1.h ../../include/md5.h \
+ crypto.h ../../include/sha2.h \
  ../../include/mpzfuncs.h ike_alg.h \
  ../../include/kernel_alg.h \
- ../../include/openswan/pfkeyv2.h plutoalg.h \
- pluto_crypt.h ../../include/osw_select.h ikev1.h \
- ikev1_continuations.h ike_continuations.h xauth.h vendor.h \
- nat_traversal.h ../../include/pluto/virtual.h dpd.h \
- x509more.h ../../include/pluto/x509lists.h tpm/tpm.h
+ ../../include/openswan/pfkeyv2.h plutoalg.h pluto_crypt.h \
+ ../../include/osw_select.h ikev1.h ikev1_continuations.h \
+ ike_continuations.h xauth.h vendor.h nat_traversal.h \
+ ../../include/pluto/virtual.h dpd.h x509more.h \
+ ../../include/pluto/x509lists.h tpm/tpm.h
+ikev1_crypto.o: ikev1_crypto.c ../../include/openswan.h \
+ ../../include/openswan/ipsec_policy.h \
+ ../../include/openswan/pfkeyv2.h \
+ ../../include/linux/pfkeyv2.h \
+ ../../ports/linux/include/sysdep.h \
+ ../../include/sysqueue.h \
+ ../../include/constants.h \
+ ../../include/biglset.h \
+ ../../include/openswan/passert.h \
+ ../../include/ietf_constants.h \
+ ../../include/pluto_constants.h \
+ ../../include/names_constant.h \
+ ../../include/pluto/defs.h \
+ ../../include/oswalloc.h \
+ ../../include/constants.h state.h quirks.h \
+ ../../include/id.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
+ ../../include/openswan/ipsec_policy.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
+ ../../include/pluto/connections.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
+ ../../include/oswlog.h \
+ ../../include/openswan/passert.h hostpair.h \
+ ../../include/pluto/keys.h \
+ ../../include/secrets.h \
+ ../../include/pluto/keys.h \
+ ../../include/packet.h demux.h \
+ ../../include/pluto/server.h adns.h dnskey.h kernel.h \
+ ../../include/pluto/log.h cookie.h spdb.h timer.h \
+ ../../include/oswtime.h \
+ ../../include/pluto/rnd.h ipsec_doi.h ikev1_quick.h \
+ ../../include/whack.h fetch.h \
+ ../../include/pkcs.h plutoalg.h pluto_crypt.h \
+ ../../include/osw_select.h crypto.h \
+ ../../include/sha1.h ../../include/md5.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ ike_alg.h ../../include/oswcrypto.h \
+ ../../include/klips-crypto/aes.h \
+ ../../include/klips-crypto/aes_cbc.h \
+ ../../include/klips-crypto/aes.h \
+ ../../include/klips-crypto/des.h ikev1.h \
+ ikev1_continuations.h ike_continuations.h
+ikev1_nss.o: ikev1_nss.c ../../include/openswan.h \
+ ../../include/openswan/ipsec_policy.h \
+ ../../include/openswan/pfkeyv2.h \
+ ../../include/linux/pfkeyv2.h \
+ ../../ports/linux/include/sysdep.h \
+ ../../include/sysqueue.h \
+ ../../include/constants.h \
+ ../../include/biglset.h \
+ ../../include/openswan/passert.h \
+ ../../include/ietf_constants.h \
+ ../../include/pluto_constants.h \
+ ../../include/names_constant.h \
+ ../../include/pluto/defs.h \
+ ../../include/oswalloc.h \
+ ../../include/constants.h state.h quirks.h \
+ ../../include/id.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
+ ../../include/openswan/ipsec_policy.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
+ ../../include/pluto/connections.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
+ ../../include/oswlog.h \
+ ../../include/openswan/passert.h hostpair.h \
+ ../../include/pluto/keys.h \
+ ../../include/secrets.h \
+ ../../include/pluto/keys.h \
+ ../../include/packet.h demux.h \
+ ../../include/pluto/server.h adns.h dnskey.h kernel.h \
+ ../../include/pluto/log.h cookie.h spdb.h timer.h \
+ ../../include/oswtime.h \
+ ../../include/pluto/rnd.h ipsec_doi.h ikev1_quick.h \
+ ../../include/whack.h fetch.h \
+ ../../include/pkcs.h plutoalg.h pluto_crypt.h \
+ ../../include/osw_select.h crypto.h \
+ ../../include/sha1.h ../../include/md5.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ ike_alg.h ../../include/oswcrypto.h \
+ ../../include/klips-crypto/aes.h \
+ ../../include/klips-crypto/aes_cbc.h \
+ ../../include/klips-crypto/aes.h \
+ ../../include/klips-crypto/des.h ikev1.h \
+ ikev1_continuations.h ike_continuations.h
 ikev1_quick.o: ikev1_quick.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../ports/linux/include/sysdep.h \
@@ -712,39 +777,35 @@ ikev1_quick.o: ikev1_quick.c ../../include/openswan.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
  ../../include/constants.h state.h quirks.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/certs.h \
+ ../../include/id.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
  ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
+ ../../include/oswlog.h \
+ ../../include/openswan/passert.h \
  ../../include/pluto/keys.h \
- ../../include/secrets.h \
- ../../include/packet.h demux.h \
- ../../include/pluto/server.h adns.h dnskey.h \
- kernel.h log.h ../../include/oswlog.h \
- ../../include/openswan/passert.h cookie.h spdb.h \
- timer.h ../../include/oswtime.h \
+ ../../include/secrets.h ../../include/packet.h \
+ demux.h ../../include/pluto/server.h adns.h dnskey.h \
+ kernel.h ../../include/pluto/log.h cookie.h \
+ ../../include/pluto/libpluto.h spdb.h timer.h \
+ ../../include/oswtime.h \
  ../../include/pluto/rnd.h ipsec_doi.h ikev1_quick.h \
  ../../include/whack.h fetch.h \
- ../../include/pkcs.h \
- ../../include/asn1.h \
- ../../include/sha1.h \
- ../../include/md5.h crypto.h \
- ../../include/sha2.h \
+ ../../include/pkcs.h ../../include/asn1.h \
+ ../../include/sha1.h ../../include/md5.h \
+ crypto.h ../../include/sha2.h \
  ../../include/mpzfuncs.h ike_alg.h \
  ../../include/kernel_alg.h \
  ../../include/openswan/pfkeyv2.h \
- ../../include/linux/pfkeyv2.h plutoalg.h \
- pluto_crypt.h ../../include/osw_select.h ikev1.h \
- ikev1_continuations.h ike_continuations.h xauth.h vendor.h \
- nat_traversal.h ../../include/pluto/virtual.h dpd.h \
- x509more.h ../../include/pluto/x509lists.h tpm/tpm.h
+ ../../include/linux/pfkeyv2.h plutoalg.h pluto_crypt.h \
+ ../../include/osw_select.h ikev1.h ikev1_continuations.h \
+ ike_continuations.h xauth.h vendor.h nat_traversal.h \
+ ../../include/pluto/virtual.h dpd.h x509more.h \
+ ../../include/pluto/x509lists.h tpm/tpm.h
 ikev2.o: ikev2.c ../../include/openswan.h \
  ../../ports/linux/include/sysdep.h \
  ../../include/sysqueue.h \
@@ -759,28 +820,24 @@ ikev2.o: ikev2.c ../../include/openswan.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h cookie.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/certs.h \
+ ../../include/id.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h quirks.h \
- ../../include/packet.h \
- ../../include/md5.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h \
+ ../../include/packet.h ../../include/md5.h \
  ../../include/sha1.h crypto.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h ike_alg.h log.h demux.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ ike_alg.h ../../include/pluto/log.h demux.h \
  ../../include/pluto/server.h ikev2.h ipsec_doi.h \
  ikev1_quick.h timer.h ../../include/oswtime.h \
  ../../include/whack.h \
  ../../include/openswan/ipsec_policy.h xauth.h \
- nat_traversal.h vendor.h dpd.h \
- ../../include/udpfromto.h tpm/tpm.h
+ nat_traversal.h vendor.h dpd.h ../../include/udpfromto.h \
+ tpm/tpm.h
 ikev2_child.o: ikev2_child.c ../../include/openswan.h \
  ../../ports/linux/include/sysdep.h \
  ../../include/sysqueue.h \
@@ -797,29 +854,25 @@ ikev2_child.o: ikev2_child.c ../../include/openswan.h \
  ../../include/openswan.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h cookie.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/certs.h \
+ ../../include/id.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h quirks.h \
- ../../include/packet.h \
- ../../include/md5.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h \
+ ../../include/packet.h ../../include/md5.h \
  ../../include/sha1.h crypto.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h ike_alg.h log.h demux.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ ike_alg.h ../../include/pluto/log.h demux.h \
  ../../include/pluto/server.h ikev2.h ipsec_doi.h \
  ikev1_quick.h timer.h ../../include/oswtime.h \
  ../../include/whack.h \
  ../../include/openswan/ipsec_policy.h vendor.h dpd.h \
  ../../include/udpfromto.h tpm/tpm.h kernel.h \
  ../../include/pluto/virtual.h hostpair.h
-ikev2_crypto.o: ikev2_crypto.c \
+ikev2_derived_keys.o: ikev2_derived_keys.c \
  ../../include/openswan.h \
  ../../ports/linux/include/sysdep.h \
  ../../include/sysqueue.h \
@@ -836,29 +889,23 @@ ikev2_crypto.o: ikev2_crypto.c \
  ../../include/openswan.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h cookie.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/certs.h \
+ ../../include/id.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h quirks.h \
- ../../include/packet.h \
- ../../include/md5.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h \
+ ../../include/packet.h ../../include/md5.h \
  ../../include/sha1.h crypto.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h demux.h \
- ../../include/pluto/server.h ikev2.h ikev2_prfplus.h \
- ike_alg.h ../../include/alg_info.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ demux.h ../../include/pluto/server.h ikev2.h \
+ ikev2_prfplus.h ike_alg.h ../../include/alg_info.h \
  ../../include/kernel_alg.h \
  ../../include/openswan/pfkeyv2.h \
  ../../include/linux/pfkeyv2.h
-ikev2_parent.o: ikev2_parent.c \
- ../../include/openswan.h \
+ikev2_parent.o: ikev2_parent.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../ports/linux/include/sysdep.h \
  ../../include/sysqueue.h \
@@ -873,35 +920,30 @@ ikev2_parent.o: ikev2_parent.c \
  ../../include/constants.h state.h quirks.h \
  ../../include/id.h \
  ../../include/pluto/connections.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/pluto/defs.h crypto.h \
- ../../include/sha1.h \
- ../../include/md5.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h x509more.h \
- ../../include/packet.h demux.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
+ ../../include/oswlog.h \
+ ../../include/openswan/passert.h hostpair.h crypto.h \
+ ../../include/sha1.h ../../include/md5.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ x509more.h ../../include/packet.h demux.h \
  ../../include/pluto/server.h \
  ../../include/secrets.h \
  ../../include/pluto/x509lists.h ike_alg.h \
  ../../include/kernel_alg.h \
  ../../include/openswan/pfkeyv2.h \
- ../../include/linux/pfkeyv2.h plutoalg.h \
- pluto_crypt.h ../../include/osw_select.h ikev2.h \
- log.h ../../include/oswlog.h \
- ../../include/openswan/passert.h spdb.h ipsec_doi.h \
- ikev1_quick.h vendor.h timer.h \
- ../../include/oswtime.h ike_continuations.h cookie.h \
- ../../include/pluto/rnd.h pending.h kernel.h \
- tpm/tpm.h
-ikev2_prfplus.o: ikev2_prfplus.c \
- ../../include/openswan.h \
+ ../../include/linux/pfkeyv2.h plutoalg.h pluto_crypt.h \
+ ../../include/osw_select.h ikev2.h \
+ ../../include/pluto/log.h spdb.h ipsec_doi.h ikev1_quick.h \
+ vendor.h timer.h ../../include/oswtime.h \
+ ike_continuations.h cookie.h ../../include/pluto/rnd.h \
+ pending.h kernel.h tpm/tpm.h
+ikev2_prfplus.o: ikev2_prfplus.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../ports/linux/include/sysdep.h \
  ../../include/sysqueue.h \
@@ -916,25 +958,22 @@ ikev2_prfplus.o: ikev2_prfplus.c \
  ../../include/constants.h \
  ../../include/packet.h demux.h \
  ../../include/pluto/server.h quirks.h crypto.h \
- ../../include/sha1.h \
- ../../include/md5.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h \
- ../../include/pluto/rnd.h state.h pluto_crypt.h \
+ ../../include/sha1.h ../../include/md5.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ ../../include/pluto/rnd.h state.h \
+ ../../include/id.h pluto_crypt.h \
  ../../include/osw_select.h \
  ../../include/oswlog.h \
- ../../include/openswan/passert.h log.h timer.h \
+ ../../include/openswan/passert.h \
+ ../../include/pluto/log.h timer.h \
  ../../include/oswtime.h ike_alg.h \
- ../../include/id.h \
- ../../include/secrets.h \
- ../../include/id.h \
+ ../../include/secrets.h ../../include/id.h \
  ../../include/x509.h \
  ../../include/pluto/keys.h \
- ../../include/x509.h \
- ../../include/certs.h \
+ ../../include/x509.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/pgp.h ikev2_prfplus.h
+ ../../include/secrets.h ../../include/pgp.h \
+ ikev2_prfplus.h
 ikev2_psk.o: ikev2_psk.c ../../include/openswan.h \
  ../../ports/linux/include/sysdep.h \
  ../../include/sysqueue.h \
@@ -949,22 +988,18 @@ ikev2_psk.o: ikev2_psk.c ../../include/openswan.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h cookie.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/certs.h \
+ ../../include/id.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h quirks.h \
- ../../include/packet.h \
- ../../include/md5.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h \
+ ../../include/packet.h ../../include/md5.h \
  ../../include/sha1.h crypto.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h ike_alg.h log.h demux.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ ike_alg.h ../../include/pluto/log.h demux.h \
  ../../include/pluto/server.h ikev2.h vendor.h dpd.h \
  ../../include/pluto/keys.h \
  ../../include/secrets.h
@@ -982,22 +1017,18 @@ ikev2_rsa.o: ikev2_rsa.c ../../include/openswan.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h cookie.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/certs.h \
+ ../../include/id.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h quirks.h \
- ../../include/packet.h \
- ../../include/md5.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h \
+ ../../include/packet.h ../../include/md5.h \
  ../../include/sha1.h crypto.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h ike_alg.h log.h demux.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ ike_alg.h ../../include/pluto/log.h demux.h \
  ../../include/pluto/server.h ikev2.h vendor.h dpd.h \
  ../../include/pluto/keys.h \
  ../../include/secrets.h \
@@ -1020,27 +1051,23 @@ ikev2_x509.o: ikev2_x509.c ../../include/openswan.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h cookie.h \
- ../../include/id.h \
- ../../include/x509.h x509more.h \
- ../../include/packet.h demux.h \
+ ../../include/id.h ../../include/x509.h \
+ x509more.h ../../include/packet.h demux.h \
  ../../include/pluto/server.h quirks.h \
- ../../include/secrets.h \
- ../../include/id.h \
+ ../../include/secrets.h ../../include/id.h \
  ../../include/x509.h \
  ../../include/pluto/x509lists.h \
- ../../include/pgp.h \
- ../../include/certs.h \
+ ../../include/pgp.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h \
- ../../include/md5.h \
- ../../include/sha1.h crypto.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h ike_alg.h log.h ikev2.h \
- vendor.h dpd.h ../../include/pluto/keys.h \
- ipsec_doi.h ikev1_quick.h
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h \
+ ../../include/md5.h ../../include/sha1.h \
+ crypto.h ../../include/sha2.h \
+ ../../include/mpzfuncs.h ike_alg.h \
+ ../../include/pluto/log.h ikev2.h vendor.h dpd.h \
+ ../../include/pluto/keys.h ipsec_doi.h ikev1_quick.h
 initiate.o: initiate.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../include/openswan/pfkeyv2.h \
@@ -1055,33 +1082,28 @@ initiate.o: initiate.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/oswalloc.h \
  ../../include/constants.h \
- ../../include/oswtime.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/oswtime.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/secrets.h \
- ../../include/pluto/defs.h \
- ../../include/ac.h \
+ ../../include/pluto/defs.h ../../include/ac.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h pending.h foodgroups.h \
- ../../include/packet.h demux.h \
- ../../include/pluto/server.h quirks.h state.h \
- timer.h ipsec_doi.h ikev1_quick.h kernel.h log.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
- ../../include/openswan/passert.h \
+ ../../include/openswan/passert.h pending.h foodgroups.h \
+ ../../include/packet.h demux.h \
+ ../../include/pluto/server.h quirks.h state.h timer.h \
+ ipsec_doi.h ikev1_quick.h kernel.h \
+ ../../include/pluto/log.h \
  ../../include/pluto/keys.h adns.h dnskey.h \
- ../../include/whack.h \
- ../../include/alg_info.h spdb.h ike_alg.h \
- plutocerts.h ../../include/kernel_alg.h \
+ ../../include/whack.h ../../include/alg_info.h \
+ spdb.h ike_alg.h plutocerts.h ../../include/kernel_alg.h \
  ../../include/openswan/pfkeyv2.h plutoalg.h xauth.h \
- nat_traversal.h ../../include/pluto/virtual.h \
- hostpair.h
+ nat_traversal.h ../../include/pluto/virtual.h hostpair.h
 ipsec_doi.o: ipsec_doi.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../include/openswan/pfkeyv2.h \
@@ -1096,39 +1118,35 @@ ipsec_doi.o: ipsec_doi.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h state.h quirks.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/certs.h \
+ ../../include/constants.h ../../include/id.h \
+ state.h quirks.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
  ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
+ ../../include/oswlog.h \
+ ../../include/openswan/passert.h \
  ../../include/packet.h \
  ../../include/pluto/keys.h \
  ../../include/secrets.h demux.h \
- ../../include/pluto/server.h adns.h dnskey.h \
- kernel.h log.h ../../include/oswlog.h \
- ../../include/openswan/passert.h cookie.h spdb.h \
- timer.h ../../include/oswtime.h \
+ ../../include/pluto/server.h adns.h dnskey.h kernel.h \
+ ../../include/pluto/log.h cookie.h spdb.h timer.h \
+ ../../include/oswtime.h \
  ../../include/pluto/rnd.h ipsec_doi.h ikev1_quick.h \
  ../../include/whack.h fetch.h \
- ../../include/pkcs.h \
- ../../include/asn1.h \
- ../../include/sha1.h \
- ../../include/md5.h crypto.h \
- ../../include/sha2.h \
+ ../../include/pkcs.h ../../include/asn1.h \
+ ../../include/sha1.h ../../include/md5.h \
+ crypto.h ../../include/sha2.h \
  ../../include/mpzfuncs.h ike_alg.h \
  ../../include/kernel_alg.h \
- ../../include/openswan/pfkeyv2.h plutoalg.h \
- pluto_crypt.h ../../include/osw_select.h ikev1.h \
- ikev1_continuations.h ike_continuations.h ikev2.h xauth.h vendor.h \
- nat_traversal.h ../../include/pluto/virtual.h dpd.h \
- x509more.h ../../include/pluto/x509lists.h tpm/tpm.h
+ ../../include/openswan/pfkeyv2.h plutoalg.h pluto_crypt.h \
+ ../../include/osw_select.h ikev1.h ikev1_continuations.h \
+ ike_continuations.h ikev2.h xauth.h vendor.h nat_traversal.h \
+ ../../include/pluto/virtual.h dpd.h x509more.h \
+ ../../include/pluto/x509lists.h tpm/tpm.h
 kernel.o: kernel.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../ports/linux/include/sysdep.h \
@@ -1144,21 +1162,19 @@ kernel.o: kernel.c ../../include/openswan.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/pluto/rnd.h \
- ../../include/id.h \
+ ../../include/pluto/rnd.h ../../include/id.h \
  ../../include/pluto/connections.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/pluto/defs.h state.h quirks.h timer.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h timer.h \
  ../../include/oswtime.h kernel.h kernel_netlink.h \
  kernel_pfkey.h kernel_noklips.h kernel_bsdkame.h \
- ../../include/packet.h log.h \
+ ../../include/packet.h \
+ ../../include/pluto/log.h \
  ../../include/pluto/server.h \
  ../../include/whack.h \
  ../../include/pluto/keys.h \
@@ -1167,8 +1183,7 @@ kernel.o: kernel.c ../../include/openswan.h \
  ../../include/kernel_alg.h \
  ../../include/openswan/pfkeyv2.h \
  ../../include/linux/pfkeyv2.h
-kernel_klips.o: kernel_klips.c \
- ../../include/openswan.h \
+kernel_klips.o: kernel_klips.c ../../include/openswan.h \
  ../../include/openswan/pfkeyv2.h \
  ../../include/linux/pfkeyv2.h \
  ../../include/openswan/pfkey.h \
@@ -1185,19 +1200,17 @@ kernel_klips.o: kernel_klips.c \
  ../../include/openswan/passert.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
- ../../include/oswalloc.h \
- ../../include/id.h \
+ ../../include/oswalloc.h ../../include/id.h \
  ../../include/pluto/connections.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/pluto/defs.h state.h quirks.h kernel.h \
- kernel_pfkey.h timer.h ../../include/oswtime.h log.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h kernel.h \
+ kernel_pfkey.h timer.h ../../include/oswtime.h \
+ ../../include/pluto/log.h \
  ../../include/whack.h \
  ../../include/openswan/ipsec_policy.h \
  ../../include/packet.h nat_traversal.h demux.h \
@@ -1222,19 +1235,17 @@ kernel_mast.o: kernel_mast.c ../../include/openswan.h \
  ../../include/openswan/passert.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
- ../../include/oswalloc.h \
- ../../include/id.h \
+ ../../include/oswalloc.h ../../include/id.h \
  ../../include/pluto/connections.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/pluto/defs.h state.h quirks.h kernel.h \
- kernel_pfkey.h timer.h ../../include/oswtime.h log.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h kernel.h \
+ kernel_pfkey.h timer.h ../../include/oswtime.h \
+ ../../include/pluto/log.h \
  ../../include/whack.h \
  ../../include/openswan/ipsec_policy.h \
  ../../include/packet.h nat_traversal.h demux.h \
@@ -1262,30 +1273,27 @@ kernel_netlink.o: kernel_netlink.c \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h \
- ../../include/id.h state.h quirks.h \
- ../../include/pluto/connections.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/constants.h ../../include/id.h \
+ state.h quirks.h ../../include/pluto/connections.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/pluto/defs.h kernel.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
+ ../../include/oswlog.h \
+ ../../include/openswan/passert.h kernel.h \
  ../../include/pluto/server.h nat_traversal.h demux.h \
- ../../include/packet.h kernel_netlink.h \
- kernel_pfkey.h log.h ../../include/oswlog.h \
- ../../include/openswan/passert.h \
+ ../../include/packet.h kernel_netlink.h kernel_pfkey.h \
+ ../../include/pluto/log.h \
  ../../include/whack.h \
  ../../include/openswan/ipsec_policy.h \
  ../../include/kernel_alg.h \
  ../../include/openswan/pfkeyv2.h \
  ../../include/klips-crypto/aes_cbc.h \
  ../../include/klips-crypto/aes.h ike_alg.h
-kernel_noklips.o: kernel_noklips.c \
- ../../include/openswan.h \
+kernel_noklips.o: kernel_noklips.c ../../include/openswan.h \
  ../../include/openswan/pfkeyv2.h \
  ../../include/linux/pfkeyv2.h \
  ../../include/openswan/pfkey.h \
@@ -1300,20 +1308,18 @@ kernel_noklips.o: kernel_noklips.c \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h \
- ../../include/id.h \
+ ../../include/constants.h ../../include/id.h \
  ../../include/pluto/connections.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/pluto/defs.h kernel.h kernel_noklips.h \
- log.h ../../include/oswlog.h \
- ../../include/openswan/passert.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
+ ../../include/oswlog.h \
+ ../../include/openswan/passert.h kernel.h kernel_noklips.h \
+ ../../include/pluto/log.h \
  ../../include/whack.h \
  ../../include/openswan/ipsec_policy.h
 keys.o: keys.c ../../include/openswan.h \
@@ -1328,23 +1334,20 @@ keys.o: keys.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/constants.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h quirks.h \
- ../../include/lex.h \
- ../../include/pluto/keys.h \
- ../../include/secrets.h adns.h dnskey.h log.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
- ../../include/openswan/passert.h \
+ ../../include/openswan/passert.h state.h quirks.h \
+ ../../include/lex.h ../../include/pluto/keys.h \
+ ../../include/secrets.h adns.h dnskey.h \
+ ../../include/pluto/log.h \
  ../../include/whack.h timer.h \
  ../../include/oswtime.h \
  ../../include/mpzfuncs.h fetch.h x509more.h \
@@ -1371,26 +1374,25 @@ log.o: log.c ../../include/openswan.h \
  ../../include/openswan/passert.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
- ../../include/oswalloc.h log.h \
- ../../include/pluto/server.h state.h quirks.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/oswalloc.h \
+ ../../include/pluto/log.h \
+ ../../include/pluto/server.h \
+ ../../include/id.h state.h quirks.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h kernel.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h kernel.h \
  ../../include/whack.h \
  ../../include/openswan/ipsec_policy.h timer.h \
  ../../include/oswtime.h \
  ../../include/kernel_alg.h \
- ../../include/openswan/pfkeyv2.h ike_alg.h \
- plutoalg.h ../../include/pluto/virtual.h db_ops.h \
- spdb.h ../../include/packet.h
+ ../../include/openswan/pfkeyv2.h ike_alg.h plutoalg.h \
+ ../../include/pluto/virtual.h db_ops.h spdb.h \
+ ../../include/packet.h
 msgdigest.o: msgdigest.c ../../include/openswan.h \
  ../../ports/linux/include/sysdep.h \
  ../../include/sysqueue.h \
@@ -1405,22 +1407,18 @@ msgdigest.o: msgdigest.c ../../include/openswan.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h cookie.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/certs.h \
+ ../../include/id.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h quirks.h \
- ../../include/packet.h \
- ../../include/md5.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h \
+ ../../include/packet.h ../../include/md5.h \
  ../../include/sha1.h crypto.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h ike_alg.h log.h demux.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ ike_alg.h ../../include/pluto/log.h demux.h \
  ../../include/pluto/server.h
 myid.o: myid.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
@@ -1436,22 +1434,18 @@ myid.o: myid.c ../../include/openswan.h \
  ../../include/oswalloc.h \
  ../../include/constants.h \
  ../../include/oswlog.h \
- ../../include/openswan/passert.h log.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/openswan/passert.h \
+ ../../include/pluto/log.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
  ../../include/pluto/defs.h \
- ../../include/packet.h \
- ../../include/whack.h
-nat_traversal.o: nat_traversal.c \
- ../../include/openswan.h \
+ ../../include/pluto/log.h \
+ ../../include/packet.h ../../include/whack.h
+nat_traversal.o: nat_traversal.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../include/openswan/pfkeyv2.h \
  ../../include/linux/pfkeyv2.h \
@@ -1471,25 +1465,22 @@ nat_traversal.o: nat_traversal.c \
  ../../include/openswan/passert.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
- ../../include/oswalloc.h log.h \
+ ../../include/oswalloc.h \
+ ../../include/pluto/log.h \
  ../../include/pluto/server.h state.h quirks.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/certs.h \
+ ../../include/id.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
  ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
  ../../include/packet.h demux.h kernel.h \
  ../../include/whack.h timer.h \
  ../../include/oswtime.h ike_alg.h cookie.h \
- ../../include/sha1.h \
- ../../include/md5.h crypto.h \
- ../../include/sha2.h \
+ ../../include/sha1.h ../../include/md5.h \
+ crypto.h ../../include/sha2.h \
  ../../include/mpzfuncs.h vendor.h \
  ../../include/natt_defines.h nat_traversal.h
 pending.o: pending.c ../../include/arpa/nameser.h \
@@ -1505,21 +1496,19 @@ pending.o: pending.c ../../include/arpa/nameser.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/constants.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/ac.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h pending.h log.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
- ../../include/openswan/passert.h state.h quirks.h \
+ ../../include/openswan/passert.h pending.h \
+ ../../include/pluto/log.h state.h quirks.h \
  ../../include/packet.h demux.h \
  ../../include/pluto/server.h ikev1_quick.h timer.h \
  ../../include/oswtime.h
@@ -1539,13 +1528,12 @@ pluto_crypt.o: pluto_crypt.c ../../include/openswan.h \
  ../../include/packet.h demux.h \
  ../../include/pluto/server.h quirks.h \
  ../../include/oswlog.h \
- ../../include/openswan/passert.h log.h state.h \
- ../../include/pluto/rnd.h pluto_crypt.h \
- ../../include/osw_select.h crypto.h \
- ../../include/sha1.h \
- ../../include/md5.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h \
+ ../../include/openswan/passert.h \
+ ../../include/pluto/log.h state.h \
+ ../../include/id.h ../../include/pluto/rnd.h \
+ pluto_crypt.h ../../include/osw_select.h crypto.h \
+ ../../include/sha1.h ../../include/md5.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
  ../../include/oswcrypto.h \
  ../../include/klips-crypto/aes.h \
  ../../include/klips-crypto/aes_cbc.h \
@@ -1567,26 +1555,22 @@ plutoalg.o: plutoalg.c ../../include/openswan.h \
  ../../include/openswan/passert.h \
  ../../include/constants.h \
  ../../include/oswalloc.h \
- ../../include/pluto/defs.h \
- ../../include/id.h \
+ ../../include/pluto/defs.h ../../include/id.h \
  ../../include/pluto/connections.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/pluto/defs.h state.h quirks.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h \
  ../../include/kernel_alg.h \
  ../../include/openswan/pfkeyv2.h \
- ../../include/alg_info.h ike_alg.h plutoalg.h \
- crypto.h ../../include/sha1.h \
- ../../include/md5.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h spdb.h \
- ../../include/packet.h db_ops.h log.h \
+ ../../include/alg_info.h ike_alg.h plutoalg.h crypto.h \
+ ../../include/sha1.h ../../include/md5.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ spdb.h ../../include/packet.h db_ops.h \
+ ../../include/pluto/log.h \
  ../../include/whack.h
 plutomain.o: plutomain.c ../../include/openswan.h \
  ../../include/openswan/pfkeyv2.h \
@@ -1604,33 +1588,29 @@ plutomain.o: plutomain.c ../../include/openswan.h \
  ../../include/oswconf.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
- ../../include/oswalloc.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/oswalloc.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/ac.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h foodgroups.h \
- ../../include/packet.h demux.h \
- ../../include/pluto/server.h quirks.h kernel.h log.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
- ../../include/openswan/passert.h \
+ ../../include/openswan/passert.h foodgroups.h \
+ ../../include/packet.h demux.h \
+ ../../include/pluto/server.h quirks.h kernel.h \
+ ../../include/pluto/log.h \
  ../../include/pluto/keys.h \
  ../../include/secrets.h adns.h dnskey.h \
- ../../include/pluto/rnd.h state.h ipsec_doi.h \
- ikev1_quick.h ../../include/pluto/ocsp.h fetch.h \
- timer.h ../../include/oswtime.h \
- ../../include/sha1.h \
+ ../../include/pluto/rnd.h state.h ipsec_doi.h ikev1_quick.h \
+ ../../include/pluto/ocsp.h fetch.h timer.h \
+ ../../include/oswtime.h ../../include/sha1.h \
  ../../include/md5.h crypto.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h vendor.h pluto_crypt.h \
- ../../include/osw_select.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ vendor.h pluto_crypt.h ../../include/osw_select.h \
  ../../include/pluto/virtual.h nat_traversal.h \
  ../../include/oswcrypto.h \
  ../../include/klips-crypto/aes.h \
@@ -1647,7 +1627,8 @@ primegen.o: primegen.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h log.h \
+ ../../include/constants.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
  ../../include/openswan/passert.h \
  ../../include/pluto/rnd.h gcryptfix.h
@@ -1662,25 +1643,23 @@ rcv_info.o: rcv_info.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h \
- ../../include/id.h \
+ ../../include/constants.h ../../include/id.h \
  ../../include/pluto/connections.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/pluto/defs.h foodgroups.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
+ ../../include/oswlog.h \
+ ../../include/openswan/passert.h foodgroups.h \
  ../../include/whack.h \
  ../../include/openswan/ipsec_policy.h \
  ../../include/packet.h demux.h \
- ../../include/pluto/server.h quirks.h state.h \
- ipsec_doi.h ikev1_quick.h kernel.h rcv_whack.h log.h \
- ../../include/oswlog.h \
- ../../include/openswan/passert.h \
+ ../../include/pluto/server.h quirks.h state.h ipsec_doi.h \
+ ikev1_quick.h kernel.h rcv_whack.h \
+ ../../include/pluto/log.h \
  ../../include/pluto/keys.h \
  ../../include/secrets.h adns.h dnskey.h rcv_info.h
 rcv_whack.o: rcv_whack.c ../../include/openswan.h \
@@ -1697,31 +1676,29 @@ rcv_whack.o: rcv_whack.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
- ../../include/oswalloc.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/oswalloc.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/ac.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h foodgroups.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
+ ../../include/oswlog.h \
+ ../../include/openswan/passert.h foodgroups.h \
  ../../include/whack.h \
  ../../include/openswan/ipsec_policy.h \
  ../../include/packet.h demux.h \
- ../../include/pluto/server.h quirks.h state.h \
- ipsec_doi.h ikev1_quick.h kernel.h rcv_whack.h \
- ../../include/pluto/whackfile.h log.h \
- ../../include/oswlog.h \
- ../../include/openswan/passert.h \
+ ../../include/pluto/server.h quirks.h state.h ipsec_doi.h \
+ ikev1_quick.h kernel.h rcv_whack.h \
+ ../../include/pluto/whackfile.h \
+ ../../include/pluto/log.h \
  ../../include/pluto/keys.h \
  ../../include/secrets.h adns.h dnskey.h fetch.h \
  ../../include/pluto/ocsp.h timer.h \
- ../../include/oswtime.h \
+ ../../include/oswtime.h hostpair.h \
  ../../include/kernel_alg.h \
  ../../include/openswan/pfkeyv2.h ike_alg.h
 security_selinux.o: security_selinux.c
@@ -1737,32 +1714,28 @@ server.o: server.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h state.h quirks.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/certs.h \
+ ../../include/constants.h ../../include/id.h \
+ state.h quirks.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h kernel.h log.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
- ../../include/openswan/passert.h \
+ ../../include/openswan/passert.h kernel.h \
+ ../../include/pluto/log.h \
  ../../include/pluto/server.h timer.h \
- ../../include/oswtime.h \
- ../../include/packet.h demux.h rcv_whack.h \
- rcv_info.h ../../include/openswan/ipsec_policy.h \
+ ../../include/oswtime.h ../../include/packet.h \
+ demux.h rcv_whack.h rcv_info.h \
+ ../../include/openswan/ipsec_policy.h \
  ../../include/pluto/keys.h \
  ../../include/secrets.h adns.h dnskey.h \
  ../../include/whack.h pluto_crypt.h \
  ../../include/osw_select.h crypto.h \
- ../../include/sha1.h \
- ../../include/md5.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h \
+ ../../include/sha1.h ../../include/md5.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
  ../../include/udpfromto.h \
  ../../include/openswan/pfkeyv2.h \
  ../../include/linux/pfkeyv2.h \
@@ -1795,26 +1768,22 @@ spdb.o: spdb.c ../../include/openswan.h \
  ../../include/openswan/passert.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
- ../../include/oswalloc.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/oswalloc.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h quirks.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h \
  ../../include/packet.h \
  ../../include/pluto/keys.h \
- ../../include/secrets.h kernel.h log.h spdb.h \
- ../../include/whack.h \
- ../../include/sha1.h \
+ ../../include/secrets.h kernel.h \
+ ../../include/pluto/log.h spdb.h \
+ ../../include/whack.h ../../include/sha1.h \
  ../../include/md5.h crypto.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
  ../../include/alg_info.h \
  ../../include/kernel_alg.h \
  ../../include/openswan/pfkeyv2.h ike_alg.h db_ops.h \
@@ -1833,26 +1802,22 @@ spdb_print.o: spdb_print.c ../../include/openswan.h \
  ../../include/openswan/passert.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
- ../../include/oswalloc.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/oswalloc.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h quirks.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h \
  ../../include/packet.h \
  ../../include/pluto/keys.h \
- ../../include/secrets.h kernel.h log.h spdb.h \
- ../../include/whack.h \
- ../../include/sha1.h \
+ ../../include/secrets.h kernel.h \
+ ../../include/pluto/log.h spdb.h \
+ ../../include/whack.h ../../include/sha1.h \
  ../../include/md5.h crypto.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
  ../../include/alg_info.h \
  ../../include/kernel_alg.h \
  ../../include/openswan/pfkeyv2.h \
@@ -1873,32 +1838,28 @@ spdb_struct.o: spdb_struct.c ../../include/openswan.h \
  ../../include/openswan/passert.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
- ../../include/oswalloc.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/oswalloc.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h quirks.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h \
  ../../include/packet.h \
  ../../include/pluto/keys.h \
- ../../include/secrets.h kernel.h log.h spdb.h \
+ ../../include/secrets.h kernel.h \
+ ../../include/pluto/log.h spdb.h \
  ../../include/whack.h plutoalg.h \
- ../../include/sha1.h \
- ../../include/md5.h crypto.h \
- ../../include/sha2.h \
+ ../../include/sha1.h ../../include/md5.h \
+ crypto.h ../../include/sha2.h \
  ../../include/mpzfuncs.h \
  ../../include/alg_info.h \
  ../../include/kernel_alg.h \
  ../../include/openswan/pfkeyv2.h ike_alg.h db_ops.h \
  nat_traversal.h demux.h ../../include/pluto/server.h
-spdb_v1_struct.o: spdb_v1_struct.c \
- ../../include/openswan.h \
+spdb_v1_struct.o: spdb_v1_struct.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../include/openswan/pfkeyv2.h \
  ../../include/linux/pfkeyv2.h \
@@ -1914,32 +1875,28 @@ spdb_v1_struct.o: spdb_v1_struct.c \
  ../../include/openswan/passert.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
- ../../include/oswalloc.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/oswalloc.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h quirks.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h \
  ../../include/packet.h \
  ../../include/pluto/keys.h \
- ../../include/secrets.h kernel.h log.h spdb.h \
+ ../../include/secrets.h kernel.h \
+ ../../include/pluto/log.h spdb.h \
  ../../include/whack.h plutoalg.h \
- ../../include/sha1.h \
- ../../include/md5.h crypto.h \
- ../../include/sha2.h \
+ ../../include/sha1.h ../../include/md5.h \
+ crypto.h ../../include/sha2.h \
  ../../include/mpzfuncs.h \
  ../../include/alg_info.h \
  ../../include/kernel_alg.h \
  ../../include/openswan/pfkeyv2.h ike_alg.h db_ops.h \
  nat_traversal.h demux.h ../../include/pluto/server.h
-spdb_v2_struct.o: spdb_v2_struct.c \
- ../../include/openswan.h \
+spdb_v2_struct.o: spdb_v2_struct.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../include/openswan/pfkeyv2.h \
  ../../include/linux/pfkeyv2.h \
@@ -1955,31 +1912,28 @@ spdb_v2_struct.o: spdb_v2_struct.c \
  ../../include/openswan/passert.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
- ../../include/oswalloc.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/oswalloc.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h quirks.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h \
  ../../include/packet.h \
  ../../include/pluto/keys.h \
- ../../include/secrets.h kernel.h log.h spdb.h \
+ ../../include/secrets.h kernel.h \
+ ../../include/pluto/log.h spdb.h \
  ../../include/whack.h plutoalg.h \
- ../../include/sha1.h \
- ../../include/md5.h crypto.h \
- ../../include/sha2.h \
+ ../../include/sha1.h ../../include/md5.h \
+ crypto.h ../../include/sha2.h \
  ../../include/mpzfuncs.h demux.h \
  ../../include/pluto/server.h \
  ../../include/alg_info.h \
  ../../include/kernel_alg.h \
- ../../include/openswan/pfkeyv2.h ike_alg.h db_ops.h \
- ikev2.h nat_traversal.h
+ ../../include/openswan/pfkeyv2.h ike_alg.h db_ops.h ikev2.h \
+ nat_traversal.h
 state.o: state.c ../../include/openswan.h \
  ../../ports/linux/include/sysdep.h \
  ../../include/sysqueue.h \
@@ -1991,32 +1945,29 @@ state.o: state.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/constants.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h quirks.h kernel.h \
- log.h ../../include/oswlog.h \
- ../../include/openswan/passert.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
+ ../../include/oswlog.h \
+ ../../include/openswan/passert.h state.h quirks.h kernel.h \
+ ../../include/pluto/log.h \
  ../../include/packet.h \
  ../../include/pluto/keys.h \
  ../../include/secrets.h \
  ../../include/pluto/rnd.h timer.h \
- ../../include/oswtime.h \
- ../../include/whack.h \
+ ../../include/oswtime.h ../../include/whack.h \
  ../../include/openswan/ipsec_policy.h demux.h \
  ../../include/pluto/server.h pending.h ipsec_doi.h \
  ikev1_quick.h ../../include/sha1.h \
  ../../include/md5.h cookie.h crypto.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h spdb.h
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ spdb.h
 stubs.o: stubs.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../include/openswan/pfkeyv2.h \
@@ -2031,39 +1982,33 @@ stubs.o: stubs.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/constants.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/ac.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h pending.h foodgroups.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
+ ../../include/oswlog.h \
+ ../../include/openswan/passert.h pending.h foodgroups.h \
  ../../include/packet.h demux.h \
- ../../include/pluto/server.h quirks.h state.h \
- timer.h ../../include/oswtime.h ipsec_doi.h \
- ikev1_quick.h kernel.h log.h ../../include/oswlog.h \
- ../../include/openswan/passert.h \
+ ../../include/pluto/server.h quirks.h state.h timer.h \
+ ../../include/oswtime.h ipsec_doi.h ikev1_quick.h kernel.h \
+ ../../include/pluto/log.h \
  ../../include/pluto/keys.h \
  ../../include/secrets.h adns.h dnskey.h \
- ../../include/whack.h \
- ../../include/alg_info.h spdb.h ike_alg.h \
- ../../include/kernel_alg.h \
+ ../../include/whack.h ../../include/alg_info.h \
+ spdb.h ike_alg.h ../../include/kernel_alg.h \
  ../../include/openswan/pfkeyv2.h plutoalg.h xauth.h \
- nat_traversal.h ../../include/pluto/virtual.h \
- pluto_crypt.h ../../include/osw_select.h crypto.h \
- ../../include/sha1.h \
- ../../include/md5.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h ikev1.h \
- ikev1_continuations.h ike_continuations.h
-sysdep_linux.o: sysdep_linux.c \
- ../../include/openswan.h \
+ nat_traversal.h ../../include/pluto/virtual.h pluto_crypt.h \
+ ../../include/osw_select.h crypto.h \
+ ../../include/sha1.h ../../include/md5.h \
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ ikev1.h ikev1_continuations.h ike_continuations.h
+sysdep_linux.o: sysdep_linux.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../ports/linux/include/sysdep.h \
  ../../include/sysqueue.h \
@@ -2079,21 +2024,18 @@ sysdep_linux.o: sysdep_linux.c \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/pluto/rnd.h \
- ../../include/id.h \
+ ../../include/pluto/rnd.h ../../include/id.h \
  ../../include/pluto/connections.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/pluto/defs.h state.h quirks.h timer.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h state.h quirks.h timer.h \
  ../../include/oswtime.h kernel.h kernel_netlink.h \
- kernel_pfkey.h kernel_noklips.h \
- ../../include/packet.h log.h \
+ kernel_pfkey.h kernel_noklips.h ../../include/packet.h \
+ ../../include/pluto/log.h \
  ../../include/pluto/server.h \
  ../../include/whack.h \
  ../../include/pluto/keys.h \
@@ -2112,33 +2054,28 @@ terminate.o: terminate.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/oswalloc.h \
  ../../include/constants.h \
- ../../include/oswtime.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/oswtime.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/secrets.h \
- ../../include/pluto/defs.h \
- ../../include/ac.h \
+ ../../include/pluto/defs.h ../../include/ac.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h pending.h foodgroups.h \
- ../../include/packet.h demux.h \
- ../../include/pluto/server.h quirks.h state.h \
- timer.h ipsec_doi.h ikev1_quick.h kernel.h log.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
- ../../include/openswan/passert.h \
+ ../../include/openswan/passert.h pending.h foodgroups.h \
+ ../../include/packet.h demux.h \
+ ../../include/pluto/server.h quirks.h state.h timer.h \
+ ipsec_doi.h ikev1_quick.h kernel.h \
+ ../../include/pluto/log.h \
  ../../include/pluto/keys.h adns.h dnskey.h \
- ../../include/whack.h \
- ../../include/alg_info.h spdb.h ike_alg.h \
- plutocerts.h ../../include/kernel_alg.h \
+ ../../include/whack.h ../../include/alg_info.h \
+ spdb.h ike_alg.h plutocerts.h ../../include/kernel_alg.h \
  ../../include/openswan/pfkeyv2.h plutoalg.h xauth.h \
- nat_traversal.h ../../include/pluto/virtual.h \
- hostpair.h
+ nat_traversal.h ../../include/pluto/virtual.h hostpair.h
 timer.o: timer.c ../../include/openswan.h \
  ../../ports/linux/include/sysdep.h \
  ../../include/sysqueue.h \
@@ -2150,27 +2087,23 @@ timer.o: timer.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/constants.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h quirks.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
+ ../../include/oswlog.h \
+ ../../include/openswan/passert.h state.h quirks.h \
  ../../include/packet.h demux.h \
- ../../include/pluto/server.h ipsec_doi.h \
- ikev1_quick.h kernel.h log.h ../../include/oswlog.h \
- ../../include/openswan/passert.h \
+ ../../include/pluto/server.h ipsec_doi.h ikev1_quick.h \
+ kernel.h ../../include/pluto/log.h \
  ../../include/pluto/rnd.h timer.h \
- ../../include/oswtime.h \
- ../../include/whack.h \
- ../../include/openswan/ipsec_policy.h dpd.h \
- nat_traversal.h
+ ../../include/oswtime.h ../../include/whack.h \
+ ../../include/openswan/ipsec_policy.h dpd.h nat_traversal.h
 vendor.o: vendor.c ../../include/openswan.h \
  ../../ports/linux/include/sysdep.h \
  ../../include/sysqueue.h \
@@ -2182,26 +2115,24 @@ vendor.o: vendor.c ../../include/openswan.h \
  ../../include/names_constant.h \
  ../../include/pluto/defs.h \
  ../../include/oswalloc.h \
- ../../include/constants.h log.h \
+ ../../include/constants.h \
+ ../../include/pluto/log.h \
  ../../include/oswlog.h \
  ../../include/openswan/passert.h \
- ../../include/md5.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/md5.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
  ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
  ../../include/packet.h demux.h \
  ../../include/pluto/server.h quirks.h \
  ../../include/whack.h \
- ../../include/openswan/ipsec_policy.h vendor.h \
- kernel.h state.h nat_traversal.h
+ ../../include/openswan/ipsec_policy.h vendor.h kernel.h \
+ state.h nat_traversal.h
 virtual.o: virtual.c ../../include/openswan.h \
  ../../ports/linux/include/sysdep.h \
  ../../include/sysqueue.h \
@@ -2215,18 +2146,16 @@ virtual.o: virtual.c ../../include/openswan.h \
  ../../include/openswan/passert.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
- ../../include/oswalloc.h log.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/oswalloc.h \
+ ../../include/pluto/log.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
  ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
  ../../include/whack.h \
  ../../include/openswan/ipsec_policy.h \
  ../../include/pluto/virtual.h
@@ -2244,8 +2173,7 @@ whack.o: whack.c ../../include/openswan.h \
  ../../include/openswan/passert.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
- ../../include/oswalloc.h \
- ../../include/whack.h \
+ ../../include/oswalloc.h ../../include/whack.h \
  ../../include/openswan/ipsec_policy.h
 whackinit.o: whackinit.c ../../include/openswan.h \
  ../../include/socketwrapper.h \
@@ -2259,8 +2187,7 @@ whackinit.o: whackinit.c ../../include/openswan.h \
  ../../include/openswan/passert.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
- ../../include/oswalloc.h \
- ../../include/whack.h \
+ ../../include/oswalloc.h ../../include/whack.h \
  ../../include/openswan/ipsec_policy.h
 x509.o: x509.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
@@ -2277,31 +2204,23 @@ x509.o: x509.c ../../include/openswan.h \
  ../../include/oswlog.h \
  ../../include/openswan/passert.h \
  ../../include/oswtime.h \
- ../../include/oswalloc.h \
- ../../include/id.h \
- ../../include/asn1.h \
- ../../include/mpzfuncs.h \
- ../../include/oid.h \
- ../../include/pluto/defs.h \
+ ../../include/oswalloc.h ../../include/id.h \
+ ../../include/asn1.h ../../include/mpzfuncs.h \
+ ../../include/oid.h ../../include/pluto/defs.h \
  ../../include/x509.h \
  ../../include/pluto/ocsp.h \
  ../../include/pluto/keys.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/certs.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/pgp.h plutocerts.h x509more.h \
- ../../include/packet.h demux.h \
+ ../../include/secrets.h ../../include/pgp.h \
+ plutocerts.h x509more.h ../../include/packet.h demux.h \
  ../../include/pluto/server.h quirks.h \
  ../../include/pluto/x509lists.h \
- ../../include/pgp.h \
- ../../include/md2.h \
- ../../include/md5.h \
- ../../include/sha1.h \
- ../../include/whack.h \
- ../../include/pkcs.h log.h
+ ../../include/pgp.h ../../include/md2.h \
+ ../../include/md5.h ../../include/sha1.h \
+ ../../include/whack.h ../../include/pkcs.h \
+ ../../include/pluto/log.h
 x509keys.o: x509keys.c ../../include/openswan.h \
  ../../include/openswan/ipsec_policy.h \
  ../../ports/linux/include/sysdep.h \
@@ -2316,29 +2235,23 @@ x509keys.o: x509keys.c ../../include/openswan.h \
  ../../include/openswan/passert.h \
  ../../include/constants.h \
  ../../include/pluto/defs.h \
- ../../include/oswalloc.h log.h \
- ../../include/id.h \
- ../../include/asn1.h \
- ../../include/oid.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/oswalloc.h \
+ ../../include/pluto/log.h ../../include/id.h \
+ ../../include/asn1.h ../../include/oid.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/keys.h \
- ../../include/secrets.h \
- ../../include/packet.h demux.h \
- ../../include/pluto/server.h quirks.h \
+ ../../include/secrets.h ../../include/packet.h \
+ demux.h ../../include/pluto/server.h quirks.h \
  ../../include/pluto/connections.h \
- ../../include/pluto/defs.h state.h \
- ../../include/md2.h \
- ../../include/md5.h \
- ../../include/sha1.h \
- ../../include/whack.h fetch.h \
- ../../include/pluto/ocsp.h \
+ ../../include/pluto/defs.h \
+ ../../include/pluto/log.h hostpair.h state.h \
+ ../../include/md2.h ../../include/md5.h \
+ ../../include/sha1.h ../../include/whack.h \
+ fetch.h ../../include/pluto/ocsp.h \
  ../../include/pkcs.h kernel.h x509more.h \
  ../../include/pluto/x509lists.h
 xauth.o: xauth.c ../../include/openswan.h \
@@ -2357,26 +2270,22 @@ xauth.o: xauth.c ../../include/openswan.h \
  ../../include/oswlog.h \
  ../../include/openswan/passert.h \
  ../../include/pluto/defs.h state.h quirks.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
- ../../include/certs.h \
+ ../../include/id.h ../../include/x509.h \
+ ../../include/pgp.h ../../include/certs.h \
  ../../include/openswan/ipsec_policy.h \
- ../../include/secrets.h \
- ../../include/id.h \
- ../../include/x509.h \
- ../../include/pgp.h \
+ ../../include/secrets.h ../../include/id.h \
+ ../../include/x509.h ../../include/pgp.h \
  ../../include/pluto/connections.h \
  ../../include/pluto/defs.h \
+ ../../include/pluto/log.h \
  ../../include/packet.h demux.h \
- ../../include/pluto/server.h kernel.h log.h cookie.h \
- spdb.h timer.h ../../include/oswtime.h \
+ ../../include/pluto/server.h kernel.h \
+ ../../include/pluto/log.h cookie.h spdb.h timer.h \
+ ../../include/oswtime.h \
  ../../include/pluto/rnd.h \
  ../../include/pluto/keys.h \
  ../../include/secrets.h ipsec_doi.h ikev1_quick.h \
- ../../include/whack.h \
- ../../include/sha1.h \
+ ../../include/whack.h ../../include/sha1.h \
  ../../include/md5.h crypto.h \
- ../../include/sha2.h \
- ../../include/mpzfuncs.h ike_alg.h xauth.h \
- ../../include/pluto/virtual.h
+ ../../include/sha2.h ../../include/mpzfuncs.h \
+ ike_alg.h xauth.h ../../include/pluto/virtual.h

--- a/programs/pluto/connections.c
+++ b/programs/pluto/connections.c
@@ -3253,11 +3253,11 @@ show_one_connection(struct connection *c, logfunc logger)
     }
 
     logger(RC_COMMENT
-	      , "\"%s\"%s:   newest ISAKMP SA: #%ld; newest IPsec SA: #%ld; "
+	      , "\"%s\"%s:   newest ISAKMP SA: #%ld; newest IPsec SA: #%ld; eroute owner: #%ld;"
 	      , c->name
 	      , instance
 	      , c->newest_isakmp_sa
-	      , c->newest_ipsec_sa);
+              , c->newest_ipsec_sa, c->spd.eroute_owner);
 
     if(c->connalias) {
 	logger(RC_COMMENT

--- a/programs/pluto/connections.c
+++ b/programs/pluto/connections.c
@@ -819,10 +819,10 @@ check_connection_end(const struct whack_end *this, const struct whack_end *that
 	/* this should have been diagnosed by whack, so we need not be clear
 	 * !!! overloaded use of RC_CLASH
 	 */
-	loglog(RC_CLASH, "address family inconsistency in this connection=%d host=%d/nexthop=%d"
-	       , wm->addr_family
-	       , addrtypeof(&this->host_addr)
-	       , addrtypeof(&this->host_nexthop));
+	loglog(RC_CLASH, "address family inconsistency in this connection=%s host=%s/nexthop=%s"
+	       , aftoinfo(wm->addr_family)->name
+	       , aftoinfo(addrtypeof(&this->host_addr))->name
+	       , aftoinfo(addrtypeof(&this->host_nexthop))->name);
 	return FALSE;
     }
 

--- a/programs/pluto/demux.c
+++ b/programs/pluto/demux.c
@@ -397,11 +397,11 @@ read_packet(struct msg_digest *md)
 
     DBG(DBG_RAW | DBG_CRYPT | DBG_PARSING | DBG_CONTROL,
 	{
-	    DBG_log("*received %d bytes from %s:%u on %s (port=%d)"
+	    DBG_log("*received %d bytes from %s:%u on %s (port=%d) at %s"
 		    , (int) pbs_room(&md->packet_pbs)
 		    , ip_str(cur_from), (unsigned) cur_from_port
 		    , ifp->ip_dev->id_rname
-		    , ifp->port);
+		    , ifp->port, oswtimestr());
 	});
 
     DBG(DBG_RAW,

--- a/programs/pluto/kernel.c
+++ b/programs/pluto/kernel.c
@@ -2934,7 +2934,6 @@ install_ipsec_sa(struct state *parent_st
     }
 
 
-    /* for (sr = &st->st_connection->spd; sr != NULL; sr = sr->next) */
     for (; sr != NULL; sr = sr->next)
     {
         DBG(DBG_CONTROL, DBG_log("sr for #%ld: %s"
@@ -2961,6 +2960,18 @@ install_ipsec_sa(struct state *parent_st
             }
         }
     }
+
+    /*
+     * because desired_sr may have been passed into route_and_eroute, the result
+     * won't have been returned to us properly, so copy it back into structure.
+     */
+    for (sr = &st->st_connection->spd; sr != NULL; sr = sr->next) {
+        if (sr->eroute_owner != st->st_serialno
+            && sr->routing != RT_UNROUTED_KEYED) {
+            sr->eroute_owner = desired_sr.eroute_owner;
+        }
+    }
+
 
    if (st->st_connection->remotepeertype == CISCO) {
 

--- a/programs/pluto/kernel.c
+++ b/programs/pluto/kernel.c
@@ -2181,31 +2181,11 @@ teardown_half_ipsec_sa(struct state *st, struct end *that, bool inbound)
                           , c->spd.this.protocol
                           , ET_UNSPEC
                           , null_proto_info, 0
-                          , ERO_DEL_INBOUND, "delete inbound"
+                          , ERO_DEL_INBOUND, "delete (half) inbound"
 			  , c->policy_label
 			  );
     }
 
-    /* PATRICK: I may have to uncomment the following block: */
-//    if(st->st_ikev2) {
-//        for(sr = &c->spd; sr; sr=sr->next) {
-//            if (kernel_ops->inbound_eroute && inbound
-//                && sr->eroute_owner == SOS_NOBODY)
-//                {
-//                    (void) raw_eroute(&sr->that.host_addr, &sr->that.client
-//                                      , &sr->this.host_addr, &sr->this.client
-//                                      , 256
-//                                      , IPSEC_PROTO_ANY
-//                                      , sr->this.protocol
-//                                      , ET_UNSPEC
-//                                      , null_proto_info, 0
-//                                      , ERO_DEL_INBOUND, "delete inbound"
-//                                      , c->policy_label
-//                                      );
-//                }
-//        }
-//    }
-//
     if (!kernel_ops->grp_sa)
     {
         if (st->st_ah.present)

--- a/programs/pluto/kernel.c
+++ b/programs/pluto/kernel.c
@@ -787,6 +787,12 @@ unroute_connection(struct connection *c)
     struct spd_route *sr;
     enum routing_t cr;
 
+#if 0
+    /* useful for debugging situations where newest_*_SA/eroute is going wrong */
+    DBG_log("unroute connection");
+    show_connections_status(loglog);
+#endif
+
     for (sr = &c->spd; sr; sr = sr->next)
     {
         cr = sr->routing;

--- a/programs/pluto/kernel.c
+++ b/programs/pluto/kernel.c
@@ -2797,10 +2797,9 @@ route_and_eroute(struct connection *c USED_BY_KLIPS
 
             DBG(DBG_CONTROL,
                 char cib[CONN_INST_BUF];
-                DBG_log("route_and_eroute: instance \"%s\"%s, setting eroute_owner {spd=%p,sr=%p} to #%ld (was #%ld) (newest_ipsec_sa=#%ld)"
+                DBG_log("route_and_eroute: instance \"%s\"%s, setting eroute_owner to #%ld (was #%ld) (newest_ipsec_sa=#%ld)"
                         , st->st_connection->name
                         , (fmt_conn_instance(st->st_connection, cib), cib)
-                        , &st->st_connection->spd, sr
                         , st->st_serialno
                         , sr->eroute_owner
                         , st->st_connection->newest_ipsec_sa));

--- a/programs/pluto/kernel.c
+++ b/programs/pluto/kernel.c
@@ -920,25 +920,13 @@ raw_eroute(const ip_address *this_host
     bool result;
 
     set_text_said(text_said, that_host, spi, proto);
+    char mybuf[SUBNETTOT_BUF];
+    char peerbuf[SUBNETTOT_BUF];
+    int sport = ntohs(portof(&this_client->addr));
+    int dport = ntohs(portof(&that_client->addr));
 
-    DBG(DBG_CONTROL | DBG_KLIPS,
-        {
-            int sport = ntohs(portof(&this_client->addr));
-            int dport = ntohs(portof(&that_client->addr));
-            char mybuf[SUBNETTOT_BUF];
-            char peerbuf[SUBNETTOT_BUF];
-
-            subnettot(this_client, 0, mybuf, sizeof(mybuf));
-            subnettot(that_client, 0, peerbuf, sizeof(peerbuf));
-            DBG_log("%s eroute %s:%d --%d-> %s:%d => %s (raw_eroute)"
-                    , opname, mybuf, sport, transport_proto, peerbuf, dport
-                    , text_said);
-#ifdef HAVE_LABELED_IPSEC
-		if(policy_label) {
-                    DBG_log("policy security label %s", policy_label);
-		}
-#endif
-        });
+    subnettot(this_client, 0, mybuf, sizeof(mybuf));
+    subnettot(that_client, 0, peerbuf, sizeof(peerbuf));
 
     result = kernel_ops->raw_eroute(this_host, this_client
                                   , that_host, that_client
@@ -949,7 +937,9 @@ raw_eroute(const ip_address *this_host
 				  , policy_label);
 
     if(result == FALSE || DBGP(DBG_CONTROL|DBG_KLIPS)) {
-	   DBG_log("raw_eroute result=%u\n", result);
+        loglog(RC_COMMENT, "%s eroute %s:%d --%d-> %s:%d => %s %s"
+               , opname, mybuf, sport, transport_proto, peerbuf, dport
+               , text_said, result ? "succeeded" : "FAILED");
     }
 
     return result;

--- a/programs/pluto/log.c
+++ b/programs/pluto/log.c
@@ -376,6 +376,19 @@ open_peerlog(struct connection *c)
     perpeer_count++;
 }
 
+char *oswtimestr(void)
+{
+    static char datebuf[32];
+    time_t n;
+    struct tm *t;
+
+    time(&n);
+    t = localtime(&n);
+
+    strftime(datebuf, sizeof(datebuf), "%Y-%m-%d %T", t);
+    return datebuf;
+}
+
 /* log a line to cur_connection's log */
 static void
 peerlog(const char *prefix, const char *m)
@@ -394,15 +407,7 @@ peerlog(const char *prefix, const char *m)
     /* despite our attempts above, we may not be able to open the file. */
     if (cur_connection->log_file != NULL)
     {
-	char datebuf[32];
-	time_t n;
-	struct tm *t;
-
-	time(&n);
-	t = localtime(&n);
-
-	strftime(datebuf, sizeof(datebuf), "%Y-%m-%d %T", t);
-	fprintf(cur_connection->log_file, "%s %s%s\n", datebuf, prefix, m);
+	fprintf(cur_connection->log_file, "%s %s%s\n", oswtimestr(), prefix, m);
 
 	/* now move it to the front of the list */
 	CIRCLEQ_REMOVE(&perpeer_list, cur_connection, log_link);

--- a/programs/pluto/log.c
+++ b/programs/pluto/log.c
@@ -846,7 +846,7 @@ show_status(void)
     db_ops_show_status();
     whack_log(RC_COMMENT, BLANK_FORMAT);	/* spacer */
 #endif
-    show_connections_status();
+    show_connections_status(whack_log);
     whack_log(RC_COMMENT, BLANK_FORMAT);	/* spacer */
     show_states_status();
 #ifdef KLIPS

--- a/programs/pluto/log.h
+++ b/programs/pluto/log.h
@@ -64,6 +64,8 @@ extern struct connection *cur_connection;	/* current connection, for diagnostics
 extern const ip_address *cur_from;	/* source of current current message */
 extern u_int16_t cur_from_port;	/* host order */
 
+extern char *oswtimestr(void);
+
 extern bool whack_prompt_for(int whackfd
 			     , const char *prompt1
 			     , const char *prompt2

--- a/programs/pluto/state.c
+++ b/programs/pluto/state.c
@@ -712,7 +712,6 @@ delete_states_by_connection(struct connection *c, bool relations)
 {
     so_serial_t parent_sa = c->newest_isakmp_sa;
     enum connection_kind ck = c->kind;
-    struct spd_route *sr;
 
     /* save this connection's isakmp SA,
      * since it will get set to later SOS_NOBODY */
@@ -729,22 +728,21 @@ delete_states_by_connection(struct connection *c, bool relations)
 					  , &parent_sa);
     }
 
+#if 0
     /*
-     * Seems to dump here because 1 of the states is NULL.  Removing the Assert
-     * makes things work.  We should fix this eventually.
-     *
-     *  passert(c->newest_ipsec_sa == SOS_NOBODY
-     *  && c->newest_isakmp_sa == SOS_NOBODY);
-     *
+     * XXX this check is supposed to validate the connection was killed,
+     * but it isn't always the case.
      */
-
-    sr = &c->spd;
-    while (sr != NULL)
     {
-	passert(sr->eroute_owner == SOS_NOBODY);
-	passert(sr->routing != RT_ROUTED_TUNNEL);
-	sr = sr->next;
+        struct spd_route *sr = &c->spd;
+        while (sr != NULL)
+            {
+                passert(sr->eroute_owner == SOS_NOBODY);
+                passert(sr->routing != RT_ROUTED_TUNNEL);
+                sr = sr->next;
+            }
     }
+#endif
 
     if (ck == CK_INSTANCE)
     {

--- a/programs/pluto/timer.c
+++ b/programs/pluto/timer.c
@@ -76,6 +76,7 @@ void
 event_schedule(enum event_type type, time_t tm, struct state *st)
 {
     struct event *ev = alloc_thing(struct event, "struct event in event_schedule()");
+    const char *headqueue;
 
     passert(tm >= 0);
     ev->ev_type = type;
@@ -98,19 +99,24 @@ event_schedule(enum event_type type, time_t tm, struct state *st)
 	    }
     }
 
+    headqueue = "";
+    if (evlist == (struct event *) NULL
+	|| evlist->ev_time >= ev->ev_time) {
+        headqueue = "(head of queue)";
+    }
+
     DBG(DBG_CONTROL,
 	if (st == NULL)
-	    DBG_log("inserting event %s, timeout in %lu seconds"
-		, enum_show(&timer_event_names, type), (unsigned long)tm);
+	    DBG_log("inserting event %s, timeout in %lu seconds %s"
+                    , enum_show(&timer_event_names, type), (unsigned long)tm, headqueue);
 	else
-	    DBG_log("inserting event %s, timeout in %lu seconds for #%lu"
-		, enum_show(&timer_event_names, type), (unsigned long)tm
-		, ev->ev_state->st_serialno));
+	    DBG_log("inserting event %s, timeout in %lu seconds for #%lu %s"
+                    , enum_show(&timer_event_names, type), (unsigned long)tm
+                    , ev->ev_state->st_serialno, headqueue));
 
     if (evlist == (struct event *) NULL
 	|| evlist->ev_time >= ev->ev_time)
     {
-	DBG(DBG_CONTROLMORE, DBG_log("event added at head of queue"));
 	ev->ev_next = evlist;
 	evlist = ev;
     }

--- a/programs/pluto/timer.c
+++ b/programs/pluto/timer.c
@@ -464,8 +464,10 @@ handle_next_timer_event(void)
     type = ev->ev_type;
     st = ev->ev_state;
 
-    DBG(DBG_CONTROL, DBG_log("handling event %s"
-			     , enum_show(&timer_event_names, type)));
+    if(DBGP(DBG_CONTROL)) {
+        DBG_log("at %s handling event %s", oswtimestr()
+                , enum_show(&timer_event_names, type));
+    }
 
     if(DBGP(DBG_CONTROL)) {
 	if (evlist != (struct event *) NULL) {

--- a/tests/functional/05-addconn/Makefile
+++ b/tests/functional/05-addconn/Makefile
@@ -30,6 +30,9 @@ step1:
 step2:
 	@${ADDCONN} --verbose ${CTLBASE} --config ${SAMPLES}/rw.conf --rootdir ${SAMPLES}/rw gateway--any
 
+step2b:
+	@${ADDCONN} --verbose ${CTLBASE} --config ../07-sourceipv6/green.conf --rootdir ../07-sourceipv6 green
+
 step3:
 	@${WHACKBIN} ${CTLBASE} --shutdown
 
@@ -37,7 +40,7 @@ step4:
 	@${WHACKBIN} ${CTLBASE} --status
 
 check: OUTPUT
-	@(make --no-print-directory step1; sleep 1; make --no-print-directory step2; sleep 1; make --no-print-directory step3)| tee ${OUTPUTS}/pluto.addconn.raw | sed -r -f ${TESTUTILS}/openswanver.sed -f ./removehelpers.sed -f ${TESTUTILS}/randomhelper.sed | diff - pluto.addconn.out;
+	@(make --no-print-directory step1; sleep 1; make --no-print-directory step2 step2b; sleep 1; make --no-print-directory step3)| tee ${OUTPUTS}/pluto.addconn.raw | sed -r -f ${TESTUTILS}/openswanver.sed -f ./removehelpers.sed -f ${TESTUTILS}/randomhelper.sed | diff - pluto.addconn.out;
 
 OUTPUT:
 	@mkdir -p ${OUTPUTS}/base

--- a/tests/functional/05-addconn/pluto.addconn.out
+++ b/tests/functional/05-addconn/pluto.addconn.out
@@ -19,5 +19,11 @@ adding connection: "gateway--any"
 setting rootdir=YY
 opening file: ZZ
 loading named conns: gateway--any
+adding connection: "green"
+002 adding connection: "green"
+setting rootdir=YY
+opening file: ZZ
+loading named conns: green
+"green": deleting connection
 "gateway--any": deleting connection
 pluto_crypto_helper: helper [nonnss] (X) is exiting normally 

--- a/tests/functional/07-sourceipv6/Makefile
+++ b/tests/functional/07-sourceipv6/Makefile
@@ -1,0 +1,30 @@
+# Makefile for the Openswan in-tree test cases
+# Copyright (C) 2014 Michael Richardson <mcr@xelerance.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+
+OPENSWANSRCDIR?=$(shell cd ../../..; pwd)
+srcdir?=${OPENSWANSRCDIR}/tests/functional/01-confread
+
+include ${OPENSWANSRCDIR}/Makefile.inc
+
+READWRITE=${OBJDIRTOP}/programs/readwriteconf/readwriteconf
+
+check:
+	mkdir -p ../OUTPUTS
+	${READWRITE} --debug --config green.conf | tee ../OUTPUTS/green.conf.raw | diff - green.conf.out
+
+update:
+	cp ../OUTPUTS/green.conf.raw     green.conf.out
+
+
+
+

--- a/tests/functional/07-sourceipv6/berri.conf
+++ b/tests/functional/07-sourceipv6/berri.conf
@@ -1,0 +1,8 @@
+conn berri
+        left=192.139.46.81
+	leftnexthop=192.139.46.65
+        leftid=@berri.testing.xelerance.com
+	# rsakey AQOAQyMdH
+	leftrsasigkey=0sAQOAQyMdHZds6nHXwqSpuElAD2VgUwfEX/riI4+vI7eJ0hjhTI66pe/hCVW0K3pLssO3QSsNG1Dbu8EJHAdwtkMJJvEeZtUh3wFxV4z5jiRnIOFf7OJ4aexov1YkWvtFGl+mutzO4m8D4wqmRnNxgdSVs/g7E2HSFow2Ww4fyW7qDyPU5jUisjbU+FpWdmCcVTM98U2JE3x6iUwsuiJ5ud75vsqgwZqI+wmAn+hWcnYlddXaKe+CJjspMEKAdXuRKL03b/0AdpPCjINbsIzpsIw2N65PfrcApeT0sKA25hJ2wVDjLU4IHrtimITpLd4Qx+6d+X8wpTWedFB1M5gl2wdWsjFYPpABlyFh56BjGMHy3nFr
+
+

--- a/tests/functional/07-sourceipv6/description.txt
+++ b/tests/functional/07-sourceipv6/description.txt
@@ -1,0 +1,4 @@
+This test validates that left/rightsourceip can be an IPv6 address in
+addition to being an IPv4 address.
+
+

--- a/tests/functional/07-sourceipv6/green.conf
+++ b/tests/functional/07-sourceipv6/green.conf
@@ -1,0 +1,18 @@
+include peel.conf
+include berri.conf
+
+conn green
+        #ikev2=insist
+	connaddrfamily=ipv4
+        also=peel
+        also=berri
+        # at startup, uncomment this.
+        auto=ignore
+	leftsourceip=2620:120:9000:0082::1
+	leftsubnet=2620:120:9000:0082::/64
+	rightsourceip=2620:120:9000:0081::1
+	rightsubnet=2620:120:9000:0081::/64
+	salifetime=10m
+
+
+

--- a/tests/functional/07-sourceipv6/green.conf
+++ b/tests/functional/07-sourceipv6/green.conf
@@ -1,5 +1,5 @@
-include peel.conf
-include berri.conf
+include ../07-sourceipv6/peel.conf
+include ../07-sourceipv6/berri.conf
 
 conn green
         #ikev2=insist

--- a/tests/functional/07-sourceipv6/green.conf.out
+++ b/tests/functional/07-sourceipv6/green.conf.out
@@ -1,0 +1,71 @@
+opening file: green.conf
+#conn peel loaded
+#conn berri loaded
+#conn green loaded
+
+version 2.0
+
+config setup
+
+
+# begin conn peel
+conn peel
+	#left= not set
+	right=192.139.46.82
+	rightid="@peel"
+	rightnexthop=192.139.46.65
+	rightrsakey=0sAQObyWTfI6MuBB5PR/EZDAif4tmNOqUWNsYiZe/Us8l1gqgxUtFXQm7M6RszKsb25KpxV/a5x5ogoP0g1Q9E8ZRXwaeBhsdzP1nTbNwQl14GCHpEzH1frZW5lWeR6s8VHw1ndrZPOOr9RqGRQq4yrSDbZbYRlciAB2dTLwsWWEFsVeVkhh1zBj1YzJS2AB7Gafxe8PMLpWbthwbgRK8hoYpa9qgBMk9YX6FlEB5FJevdfzhdwH15qaUuURJ0cJTzV0Gq4hxkaPvErunAj9WZC0EwVILDaVKCgInewwUdfn1llx6K02rZ1bLNwtp9i6rzWJdydV50cioG9ajt1Jp2ONEysvj33L7LOEr2gRzsDMDhJS41
+	auto=ignore
+	type=tunnel
+	compress=no
+	pfs=yes
+	rekey=yes
+	overlapip=no
+	authby=rsasig
+	phase2=esp
+# end conn peel
+
+# begin conn berri
+conn berri
+	left=192.139.46.81
+	leftid="@berri.testing.xelerance.com"
+	leftnexthop=192.139.46.65
+	leftrsakey=0sAQOAQyMdHZds6nHXwqSpuElAD2VgUwfEX/riI4+vI7eJ0hjhTI66pe/hCVW0K3pLssO3QSsNG1Dbu8EJHAdwtkMJJvEeZtUh3wFxV4z5jiRnIOFf7OJ4aexov1YkWvtFGl+mutzO4m8D4wqmRnNxgdSVs/g7E2HSFow2Ww4fyW7qDyPU5jUisjbU+FpWdmCcVTM98U2JE3x6iUwsuiJ5ud75vsqgwZqI+wmAn+hWcnYlddXaKe+CJjspMEKAdXuRKL03b/0AdpPCjINbsIzpsIw2N65PfrcApeT0sKA25hJ2wVDjLU4IHrtimITpLd4Qx+6d+X8wpTWedFB1M5gl2wdWsjFYPpABlyFh56BjGMHy3nFr
+	#right= not set
+	auto=ignore
+	type=tunnel
+	compress=no
+	pfs=yes
+	rekey=yes
+	overlapip=no
+	authby=rsasig
+	phase2=esp
+# end conn berri
+
+# begin conn green
+conn green
+	#also = peel berri
+	left=192.139.46.81
+	leftid="@berri.testing.xelerance.com"
+	leftnexthop=2620:120:9000:82::1
+	leftsubnet=2620:120:9000:82::/64
+	leftrsakey=0sAQOAQyMdHZds6nHXwqSpuElAD2VgUwfEX/riI4+vI7eJ0hjhTI66pe/hCVW0K3pLssO3QSsNG1Dbu8EJHAdwtkMJJvEeZtUh3wFxV4z5jiRnIOFf7OJ4aexov1YkWvtFGl+mutzO4m8D4wqmRnNxgdSVs/g7E2HSFow2Ww4fyW7qDyPU5jUisjbU+FpWdmCcVTM98U2JE3x6iUwsuiJ5ud75vsqgwZqI+wmAn+hWcnYlddXaKe+CJjspMEKAdXuRKL03b/0AdpPCjINbsIzpsIw2N65PfrcApeT0sKA25hJ2wVDjLU4IHrtimITpLd4Qx+6d+X8wpTWedFB1M5gl2wdWsjFYPpABlyFh56BjGMHy3nFr
+	leftsourceip=2620:120:9000:82::1
+	right=192.139.46.82
+	rightid="@peel"
+	rightnexthop=2620:120:9000:81::1
+	rightsubnet=2620:120:9000:81::/64
+	rightrsakey=0sAQObyWTfI6MuBB5PR/EZDAif4tmNOqUWNsYiZe/Us8l1gqgxUtFXQm7M6RszKsb25KpxV/a5x5ogoP0g1Q9E8ZRXwaeBhsdzP1nTbNwQl14GCHpEzH1frZW5lWeR6s8VHw1ndrZPOOr9RqGRQq4yrSDbZbYRlciAB2dTLwsWWEFsVeVkhh1zBj1YzJS2AB7Gafxe8PMLpWbthwbgRK8hoYpa9qgBMk9YX6FlEB5FJevdfzhdwH15qaUuURJ0cJTzV0Gq4hxkaPvErunAj9WZC0EwVILDaVKCgInewwUdfn1llx6K02rZ1bLNwtp9i6rzWJdydV50cioG9ajt1Jp2ONEysvj33L7LOEr2gRzsDMDhJS41
+	rightsourceip=2620:120:9000:81::1
+	salifetime=600
+	auto=ignore
+	type=tunnel
+	compress=no
+	pfs=yes
+	rekey=yes
+	overlapip=no
+	authby=rsasig
+	phase2=esp
+# end conn green
+
+# end of config

--- a/tests/functional/07-sourceipv6/green.conf.out
+++ b/tests/functional/07-sourceipv6/green.conf.out
@@ -47,13 +47,13 @@ conn green
 	#also = peel berri
 	left=192.139.46.81
 	leftid="@berri.testing.xelerance.com"
-	leftnexthop=2620:120:9000:82::1
+	leftnexthop=192.139.46.65
 	leftsubnet=2620:120:9000:82::/64
 	leftrsakey=0sAQOAQyMdHZds6nHXwqSpuElAD2VgUwfEX/riI4+vI7eJ0hjhTI66pe/hCVW0K3pLssO3QSsNG1Dbu8EJHAdwtkMJJvEeZtUh3wFxV4z5jiRnIOFf7OJ4aexov1YkWvtFGl+mutzO4m8D4wqmRnNxgdSVs/g7E2HSFow2Ww4fyW7qDyPU5jUisjbU+FpWdmCcVTM98U2JE3x6iUwsuiJ5ud75vsqgwZqI+wmAn+hWcnYlddXaKe+CJjspMEKAdXuRKL03b/0AdpPCjINbsIzpsIw2N65PfrcApeT0sKA25hJ2wVDjLU4IHrtimITpLd4Qx+6d+X8wpTWedFB1M5gl2wdWsjFYPpABlyFh56BjGMHy3nFr
 	leftsourceip=2620:120:9000:82::1
 	right=192.139.46.82
 	rightid="@peel"
-	rightnexthop=2620:120:9000:81::1
+	rightnexthop=192.139.46.65
 	rightsubnet=2620:120:9000:81::/64
 	rightrsakey=0sAQObyWTfI6MuBB5PR/EZDAif4tmNOqUWNsYiZe/Us8l1gqgxUtFXQm7M6RszKsb25KpxV/a5x5ogoP0g1Q9E8ZRXwaeBhsdzP1nTbNwQl14GCHpEzH1frZW5lWeR6s8VHw1ndrZPOOr9RqGRQq4yrSDbZbYRlciAB2dTLwsWWEFsVeVkhh1zBj1YzJS2AB7Gafxe8PMLpWbthwbgRK8hoYpa9qgBMk9YX6FlEB5FJevdfzhdwH15qaUuURJ0cJTzV0Gq4hxkaPvErunAj9WZC0EwVILDaVKCgInewwUdfn1llx6K02rZ1bLNwtp9i6rzWJdydV50cioG9ajt1Jp2ONEysvj33L7LOEr2gRzsDMDhJS41
 	rightsourceip=2620:120:9000:81::1

--- a/tests/functional/07-sourceipv6/peel.conf
+++ b/tests/functional/07-sourceipv6/peel.conf
@@ -1,0 +1,10 @@
+conn peel
+        # Left security gateway, subnet behind it, nexthop toward right.
+        right=192.139.46.82
+	rightnexthop=192.139.46.65
+	rightid=@peel
+        # rsakey AQObyWTfI
+        rightrsasigkey=0sAQObyWTfI6MuBB5PR/EZDAif4tmNOqUWNsYiZe/Us8l1gqgxUtFXQm7M6RszKsb25KpxV/a5x5ogoP0g1Q9E8ZRXwaeBhsdzP1nTbNwQl14GCHpEzH1frZW5lWeR6s8VHw1ndrZPOOr9RqGRQq4yrSDbZbYRlciAB2dTLwsWWEFsVeVkhh1zBj1YzJS2AB7Gafxe8PMLpWbthwbgRK8hoYpa9qgBMk9YX6FlEB5FJevdfzhdwH15qaUuURJ0cJTzV0Gq4hxkaPvErunAj9WZC0EwVILDaVKCgInewwUdfn1llx6K02rZ1bLNwtp9i6rzWJdydV50cioG9ajt1Jp2ONEysvj33L7LOEr2gRzsDMDhJS41
+
+
+

--- a/tests/functional/Makefile
+++ b/tests/functional/Makefile
@@ -22,4 +22,5 @@ check:
 	@${MAKE} -C 04-whackwrite check
 	@${MAKE} -C 05-addconn check
 	@${MAKE} -C 06-alsoflip check
+	@${MAKE} -C 07-sourceipv6 check
 

--- a/tests/unit/libpluto/lp02-parentI1/Makefile
+++ b/tests/unit/libpluto/lp02-parentI1/Makefile
@@ -90,7 +90,7 @@ check:	${WHACKFILE} OUTPUT ${EXTRAOBJS} ${TESTNAME}
 
 ifeq (${WHACKREFFILE},)
 ${WHACKFILE}: OUTPUT
-	${READWRITE} --rootdir=${SAMPLEDIR}/${ENDDNAME} --config ${SAMPLEDIR}/${ENDNAME}.conf --whackout=${WHACKFILE} ${CONNNAME}
+	${READWRITE} --rootdir=${SAMPLEDIR}/${ENDNAME} --config ${SAMPLEDIR}/${ENDNAME}.conf --whackout=${WHACKFILE} ${CONNNAME}
 endif
 
 update: OUTPUT

--- a/tests/unit/libpluto/lp02-parentI1/Makefile.testcase
+++ b/tests/unit/libpluto/lp02-parentI1/Makefile.testcase
@@ -1,4 +1,6 @@
 WHACKFILE=${OUTPUTS}/ikev2client.record.${ARCH}
-UNITTESTARGS=-r ${WHACKFILE} parker1--jj2
+CONNNAME=parker1--jj2
+UNITTESTARGS=-r ${WHACKFILE} ${CONNNAME}
+ENDNAME=parker
 
 TESTNAME=parentI1

--- a/tests/unit/libpluto/lp02-parentI1/description.txt
+++ b/tests/unit/libpluto/lp02-parentI1/description.txt
@@ -1,3 +1,3 @@
 This test case initiates a connection from a client to a gateway.
-It uses the configuration file in testconf.conf.
+It uses the configuration file in parker.conf.
 

--- a/tests/unit/libpluto/lp02-parentI1/output.txt
+++ b/tests/unit/libpluto/lp02-parentI1/output.txt
@@ -23,7 +23,6 @@ RC=0 "parker1--jj2": fd68:c9f9:4157:2:0:1::/96===192.168.1.1<192.168.1.1>[@parke
 RC=0 "parker1--jj2":     myip=unset; hisip=unset;
 RC=0 "parker1--jj2":   ike_life: 3600s; ipsec_life: 28800s; rekey_margin: 540s; rekey_fuzz: 100%; keyingtries: 0
 RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 64,96; interface: eth0; kind=CK_PERMANENT
-RC=0 "parker1--jj2":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | creating state object #1 at Z
 | orient parker1--jj2 checking against if: eth0
 | ICOOKIE:  80 01 02 03  04 05 06 07

--- a/tests/unit/libpluto/lp02-parentI1/parentI1_main.c
+++ b/tests/unit/libpluto/lp02-parentI1/parentI1_main.c
@@ -51,7 +51,7 @@ main(int argc, char *argv[])
 #ifndef SKIP_ORIENT_ASSERT
     assert(orient(c1, 500));
 #endif
-    show_one_connection(c1);
+    show_one_connection(c1, whack_log);
 
 #ifndef SKIP_INITIATE
     /* do calculation if not -r for regression */

--- a/tests/unit/libpluto/lp02-parentI1/parentI1_main.c
+++ b/tests/unit/libpluto/lp02-parentI1/parentI1_main.c
@@ -37,7 +37,10 @@ main(int argc, char *argv[])
     conn_name = argv[1];
 
     cur_debugging = DBG_CONTROL|DBG_CONTROLMORE;
-    if(readwhackmsg(infile) == 0) exit(11);
+    if(readwhackmsg(infile) == 0) {
+        fprintf(stderr, "failed to read whack file: %s\n", infile);
+        exit(11);
+    }
 
     send_packet_setup_pcap("OUTPUT/" TESTNAME ".pcap");
 

--- a/tests/unit/libpluto/lp07-orient/orienttest.c
+++ b/tests/unit/libpluto/lp07-orient/orienttest.c
@@ -78,7 +78,7 @@ main(int argc, char *argv[])
         conn_name = *argv++;
         printf("processing %s\n", conn_name);
         c1 = con_by_name(conn_name, TRUE);
-        show_one_connection(c1);
+        show_one_connection(c1, whack_log);
         assert(c1 != NULL);
         assert(orient(c1, pluto_port500));
     }

--- a/tests/unit/libpluto/lp07-orient/output.txt
+++ b/tests/unit/libpluto/lp07-orient/output.txt
@@ -17,7 +17,6 @@ RC=0 "parker1--jj2": fd68:c9f9:4157:2:0:1::/96===192.168.1.1<192.168.1.1>[@parke
 RC=0 "parker1--jj2":     myip=unset; hisip=unset;
 RC=0 "parker1--jj2":   ike_life: 3600s; ipsec_life: 28800s; rekey_margin: 540s; rekey_fuzz: 100%; keyingtries: 0
 RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 64,96; interface: eth0; kind=CK_PERMANENT
-RC=0 "parker1--jj2":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 ./orienttest deleting connection
 ./orienttest leak: 2 * keep id name, item size: X
 ./orienttest leak: ID host_pair, item size: X

--- a/tests/unit/libpluto/lp08-parentR1/output1.txt
+++ b/tests/unit/libpluto/lp08-parentR1/output1.txt
@@ -26,7 +26,6 @@ RC=0 "parker1--jj2": fd68:c9f9:4157::/64===132.213.238.7<132.213.238.7>[@jamesjo
 RC=0 "parker1--jj2":     myip=unset; hisip=unset;
 RC=0 "parker1--jj2":   ike_life: 3600s; ipsec_life: 28800s; rekey_margin: 540s; rekey_fuzz: 100%; keyingtries: 0
 RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 64,96; interface: eth0; kind=CK_PERMANENT
-RC=0 "parker1--jj2":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | *received 772 bytes from 192.168.1.1:500 on eth0 (port=500)
 |   00 01 02 03  04 05 06 07  00 00 00 00  00 00 00 00
 |   21 20 22 08  00 00 00 00  00 00 03 04  22 00 01 fc

--- a/tests/unit/libpluto/lp08-parentR1/output2.txt
+++ b/tests/unit/libpluto/lp08-parentR1/output2.txt
@@ -26,7 +26,6 @@ RC=0 "parker1--jj2": fd68:c9f9:4157::/64===132.213.238.7<132.213.238.7>[@jamesjo
 RC=0 "parker1--jj2":     myip=unset; hisip=unset;
 RC=0 "parker1--jj2":   ike_life: 3600s; ipsec_life: 28800s; rekey_margin: 540s; rekey_fuzz: 100%; keyingtries: 0
 RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 64,96; interface: eth0; kind=CK_PERMANENT
-RC=0 "parker1--jj2":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | *received 836 bytes from 192.168.1.1:500 on eth0 (port=500)
 |   80 01 02 03  04 05 06 07  00 00 00 00  00 00 00 00
 |   21 20 22 08  00 00 00 00  00 00 03 44  22 00 01 fc

--- a/tests/unit/libpluto/lp08-parentR1/output3.txt
+++ b/tests/unit/libpluto/lp08-parentR1/output3.txt
@@ -29,7 +29,6 @@ RC=0 "any1--jj2": fd68:c9f9:4157::/64===132.213.238.7<132.213.238.7>[@jamesjohns
 RC=0 "any1--jj2":     myip=unset; hisip=unset;
 RC=0 "any1--jj2":   ike_life: 3600s; ipsec_life: 28800s; rekey_margin: 540s; rekey_fuzz: 100%; keyingtries: 0
 RC=0 "any1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 64,96; interface: eth0; kind=CK_PERMANENT
-RC=0 "any1--jj2":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | *received 836 bytes from 10.10.5.4:500 on eth0 (port=500)
 |   56 11 47 13  4b 1d 6d 52  00 00 00 00  00 00 00 00
 |   21 20 22 08  00 00 00 00  00 00 03 44  22 00 01 fc

--- a/tests/unit/libpluto/lp08-parentR1/parentR1_main.c
+++ b/tests/unit/libpluto/lp08-parentR1/parentR1_main.c
@@ -68,7 +68,7 @@ main(int argc, char *argv[])
     assert(c1 != NULL);
 
     assert(orient(c1, 500));
-    show_one_connection(c1);
+    show_one_connection(c1, whack_log);
 
     send_packet_setup_pcap(argv[4]);
 

--- a/tests/unit/libpluto/lp10-parentI2/output1.txt
+++ b/tests/unit/libpluto/lp10-parentI2/output1.txt
@@ -26,7 +26,6 @@ RC=0 "parker1--jj2": fd68:c9f9:4157:2:0:1::/96===192.168.1.1<192.168.1.1>[@parke
 RC=0 "parker1--jj2":     myip=unset; hisip=unset;
 RC=0 "parker1--jj2":   ike_life: 3600s; ipsec_life: 28800s; rekey_margin: 540s; rekey_fuzz: 100%; keyingtries: 0
 RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 64,96; interface: eth0; kind=CK_PERMANENT
-RC=0 "parker1--jj2":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | creating state object #1 at Z
 | orient parker1--jj2 checking against if: eth0
 | ICOOKIE:  80 01 02 03  04 05 06 07

--- a/tests/unit/libpluto/lp10-parentI2/parentI2_main.c
+++ b/tests/unit/libpluto/lp10-parentI2/parentI2_main.c
@@ -72,7 +72,7 @@ main(int argc, char *argv[])
     assert(c1 != NULL);
 
     assert(orient(c1, 500));
-    show_one_connection(c1);
+    show_one_connection(c1, whack_log);
     init_loaded();
 
     st = sendI1(c1, DBG_CONTROL, regression == 0);

--- a/tests/unit/libpluto/lp11-parentI2dup/output1.txt
+++ b/tests/unit/libpluto/lp11-parentI2dup/output1.txt
@@ -24,7 +24,6 @@ RC=0 "parker1--jj2": fd68:c9f9:4157:2:0:1::/96===192.168.1.1<192.168.1.1>[@parke
 RC=0 "parker1--jj2":     myip=unset; hisip=unset;
 RC=0 "parker1--jj2":   ike_life: 3600s; ipsec_life: 28800s; rekey_margin: 540s; rekey_fuzz: 100%; keyingtries: 0
 RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 64,96; interface: eth0; kind=CK_PERMANENT
-RC=0 "parker1--jj2":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | creating state object #1 at Z
 | orient parker1--jj2 checking against if: eth0
 | ICOOKIE:  80 01 02 03  04 05 06 07

--- a/tests/unit/libpluto/lp11-parentI2dup/parentI2duplicate.c
+++ b/tests/unit/libpluto/lp11-parentI2dup/parentI2duplicate.c
@@ -114,7 +114,7 @@ main(int argc, char *argv[])
     assert(c1 != NULL);
 
     assert(orient(c1, 500));
-    show_one_connection(c1);
+    show_one_connection(c1, whack_log);
 
     st = sendI1(c1, DBG_CONTROL, regression == 0);
 

--- a/tests/unit/libpluto/lp12-parentR2/output1.txt
+++ b/tests/unit/libpluto/lp12-parentR2/output1.txt
@@ -26,7 +26,6 @@ RC=0 "parker1--jj2": fd68:c9f9:4157::/64===132.213.238.7<132.213.238.7>[@jamesjo
 RC=0 "parker1--jj2":     myip=unset; hisip=unset;
 RC=0 "parker1--jj2":   ike_life: 3600s; ipsec_life: 28800s; rekey_margin: 540s; rekey_fuzz: 100%; keyingtries: 0
 RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 64,96; interface: eth0; kind=CK_PERMANENT
-RC=0 "parker1--jj2":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | *received 836 bytes from 192.168.1.1:500 on eth0 (port=500)
 |   80 01 02 03  04 05 06 07  00 00 00 00  00 00 00 00
 |   21 20 22 08  00 00 00 00  00 00 03 44  22 00 01 fc

--- a/tests/unit/libpluto/lp12-parentR2/parentR2_main.c
+++ b/tests/unit/libpluto/lp12-parentR2/parentR2_main.c
@@ -109,7 +109,7 @@ main(int argc, char *argv[])
     assert(c1 != NULL);
 
     assert(orient(c1, 500));
-    show_one_connection(c1);
+    show_one_connection(c1, whack_log);
     init_loaded();
 
     for(i=0; i<PCAP_INPUT_COUNT; i++) {

--- a/tests/unit/libpluto/lp13-parentI3/output1.txt
+++ b/tests/unit/libpluto/lp13-parentI3/output1.txt
@@ -26,7 +26,6 @@ RC=0 "parker1--jj2": fd68:c9f9:4157:2:0:1::/96===192.168.1.1<192.168.1.1>[@parke
 RC=0 "parker1--jj2":     myip=unset; hisip=unset;
 RC=0 "parker1--jj2":   ike_life: 3600s; ipsec_life: 28800s; rekey_margin: 540s; rekey_fuzz: 100%; keyingtries: 0
 RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 64,96; interface: eth0; kind=CK_PERMANENT
-RC=0 "parker1--jj2":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | creating state object #1 at Z
 | orient parker1--jj2 checking against if: eth0
 | ICOOKIE:  80 01 02 03  04 05 06 07

--- a/tests/unit/libpluto/lp13-parentI3/parentI3.c
+++ b/tests/unit/libpluto/lp13-parentI3/parentI3.c
@@ -133,7 +133,7 @@ main(int argc, char *argv[])
     assert(c1 != NULL);
 
     assert(orient(c1, 500));
-    show_one_connection(c1);
+    show_one_connection(c1, whack_log);
 
     /* output first packets to /dev/null */
     send_packet_setup_pcap("/dev/null");

--- a/tests/unit/libpluto/lp14-initiateself/output.txt
+++ b/tests/unit/libpluto/lp14-initiateself/output.txt
@@ -28,7 +28,6 @@ RC=0 "gateway--any": %any[@example.com]...132.213.238.7<132.213.238.7>[@jamesjoh
 RC=0 "gateway--any":     myip=unset; hisip=unset;
 RC=0 "gateway--any":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "gateway--any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 16,32; interface: eth0; kind=CK_PERMANENT
-RC=0 "gateway--any":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | creating state object #1 at Z
 | orient gateway--any checking against if: eth0
 | orient gateway--any matching on public/private keys

--- a/tests/unit/libpluto/lp15-respondself/output1.txt
+++ b/tests/unit/libpluto/lp15-respondself/output1.txt
@@ -29,7 +29,6 @@ RC=0 "gateway--any": 10.2.0.0/16===132.213.238.7<132.213.238.7>[@jamesjohnson.em
 RC=0 "gateway--any":     myip=unset; hisip=unset;
 RC=0 "gateway--any":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "gateway--any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 16,32; interface: eth0; kind=CK_PERMANENT
-RC=0 "gateway--any":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | *received 836 bytes from 93.184.216.34:500 on eth0 (port=500)
 |   80 01 02 03  04 05 06 07  00 00 00 00  00 00 00 00
 |   21 20 22 08  00 00 00 00  00 00 03 44  22 00 01 fc

--- a/tests/unit/libpluto/lp16-initiateselfI2/output1.txt
+++ b/tests/unit/libpluto/lp16-initiateselfI2/output1.txt
@@ -31,7 +31,6 @@ RC=0 "gateway--any": %any[@example.com]...132.213.238.7<132.213.238.7>[@jamesjoh
 RC=0 "gateway--any":     myip=unset; hisip=unset;
 RC=0 "gateway--any":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "gateway--any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 16,32; interface: eth0; kind=CK_PERMANENT
-RC=0 "gateway--any":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | creating state object #1 at Z
 | orient gateway--any checking against if: eth0
 | orient gateway--any matching on public/private keys

--- a/tests/unit/libpluto/lp17-childselfpolicy/Makefile
+++ b/tests/unit/libpluto/lp17-childselfpolicy/Makefile
@@ -78,7 +78,7 @@ include Makefile.testcase
 EF_DISABLE_BANNER=1
 export EF_DISABLE_BANNER
 
-programs ${TESTNAME}: ${TESTNAME}.c $(wildcard ../seam_*.c) ${EXTRALIBS}
+programs ${TESTNAME}: ${TESTNAME}.c $(wildcard ../seam_*.c) ${EXTRAOBJS}
 	@${CC} -c -g -O0 ${TESTNAME}.c ${EXTRAFLAGS}
 	@${CC} -g -O0 -o ${TESTNAME} ${TESTNAME}.o ${EXTRAFLAGS} ${EXTRAOBJS} ${EXTRALIBS}
 

--- a/tests/unit/libpluto/lp17-childselfpolicy/output1.txt
+++ b/tests/unit/libpluto/lp17-childselfpolicy/output1.txt
@@ -29,7 +29,6 @@ RC=0 "gateway--any": 10.2.0.0/16===132.213.238.7<132.213.238.7>[@jamesjohnson.em
 RC=0 "gateway--any":     myip=unset; hisip=unset;
 RC=0 "gateway--any":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "gateway--any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 16,32; interface: eth0; kind=CK_PERMANENT
-RC=0 "gateway--any":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | *received 836 bytes from 93.184.216.34:500 on eth0 (port=500)
 |   80 01 02 03  04 05 06 07  00 00 00 00  00 00 00 00
 |   21 20 22 08  00 00 00 00  00 00 03 44  22 00 01 fc

--- a/tests/unit/libpluto/lp17-childselfpolicy/output2.txt
+++ b/tests/unit/libpluto/lp17-childselfpolicy/output2.txt
@@ -29,7 +29,6 @@ RC=0 "gateway--any": 10.2.0.0/16===132.213.238.7<132.213.238.7>[@jamesjohnson.em
 RC=0 "gateway--any":     myip=unset; hisip=unset;
 RC=0 "gateway--any":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "gateway--any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 16,32; interface: eth0; kind=CK_PERMANENT
-RC=0 "gateway--any":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | *received 836 bytes from 93.184.216.34:500 on eth0 (port=500)
 |   80 01 02 03  04 05 06 07  00 00 00 00  00 00 00 00
 |   21 20 22 08  00 00 00 00  00 00 03 44  22 00 01 fc

--- a/tests/unit/libpluto/lp18-certificateselfI1/output.txt
+++ b/tests/unit/libpluto/lp18-certificateselfI1/output.txt
@@ -29,7 +29,6 @@ RC=0 "home":     myip=unset; hisip=unset; mycert=carolCert.pem;
 RC=0 "home":   CAs: 'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'...'%any'
 RC=0 "home":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "home":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+SAREFTRACK+lKOD+rKOD; prio: 16,0; interface: eth0; kind=CK_PERMANENT
-RC=0 "home":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | creating state object #1 at Z
 | orient home checking against if: eth0
 | orient home matching on public/private keys

--- a/tests/unit/libpluto/lp19-certreplyselfR1/output1.txt
+++ b/tests/unit/libpluto/lp19-certreplyselfR1/output1.txt
@@ -32,7 +32,6 @@ RC=0 "rw-any":     myip=unset; hisip=unset; mycert=moonCert.pem;
 RC=0 "rw-any":   CAs: 'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'...'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'
 RC=0 "rw-any":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "rw-any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+SAREFTRACK+lKOD+rKOD; prio: 16,32; interface: eth0; kind=CK_TEMPLATE
-RC=0 "rw-any":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | *received 836 bytes from 93.184.216.34:500 on eth0 (port=500)
 |   80 01 02 03  04 05 06 07  00 00 00 00  00 00 00 00
 |   21 20 22 08  00 00 00 00  00 00 03 44  22 00 01 fc

--- a/tests/unit/libpluto/lp20-certificateselfI2/output1.txt
+++ b/tests/unit/libpluto/lp20-certificateselfI2/output1.txt
@@ -32,7 +32,6 @@ RC=0 "home":     myip=unset; hisip=unset; mycert=carolCert.pem;
 RC=0 "home":   CAs: 'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'...'%any'
 RC=0 "home":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "home":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+SAREFTRACK+lKOD+rKOD; prio: 16,0; interface: eth0; kind=CK_PERMANENT
-RC=0 "home":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | creating state object #1 at Z
 | orient home checking against if: eth0
 | orient home matching on public/private keys

--- a/tests/unit/libpluto/lp21-certreplyselfR2/output1.txt
+++ b/tests/unit/libpluto/lp21-certreplyselfR2/output1.txt
@@ -32,7 +32,6 @@ RC=0 "rw-any":     myip=unset; hisip=unset; mycert=moonCert.pem;
 RC=0 "rw-any":   CAs: 'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'...'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'
 RC=0 "rw-any":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "rw-any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+SAREFTRACK+lKOD+rKOD; prio: 16,32; interface: eth0; kind=CK_TEMPLATE
-RC=0 "rw-any":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | Changed path to directory '../samples/gatewaycert/cacerts'
 ./certreplyselfR2   loaded CA cert file 'strongswanCert.pem' (1350 bytes)
 | *received 836 bytes from 93.184.216.34:500 on eth0 (port=500)

--- a/tests/unit/libpluto/lp21-certreplyselfR2/output2.txt
+++ b/tests/unit/libpluto/lp21-certreplyselfR2/output2.txt
@@ -32,7 +32,6 @@ RC=0 "rw-any":     myip=unset; hisip=unset; mycert=moonCert.pem;
 RC=0 "rw-any":   CAs: 'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'...'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'
 RC=0 "rw-any":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "rw-any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+SAREFTRACK+lKOD+rKOD; prio: 16,32; interface: eth0; kind=CK_TEMPLATE
-RC=0 "rw-any":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | Changed path to directory '../samples/gatewaycert/cacerts'
 ./certreplyselfR2   loaded CA cert file 'strongswanCert.pem' (1350 bytes)
 | *received 836 bytes from 93.184.216.34:500 on eth0 (port=500)

--- a/tests/unit/libpluto/lp22-certreplymanyR2/output1.txt
+++ b/tests/unit/libpluto/lp22-certreplymanyR2/output1.txt
@@ -75,7 +75,6 @@ RC=0 "rw-any":     myip=unset; hisip=unset; mycert=moonCert.pem;
 RC=0 "rw-any":   CAs: 'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'...'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'
 RC=0 "rw-any":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "rw-any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+SAREFTRACK+lKOD+rKOD; prio: 16,32; interface: eth0; kind=CK_TEMPLATE
-RC=0 "rw-any":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | Changed path to directory '../samples/gatewaycert/cacerts'
 ./certreplyR2   loaded CA cert file 'strongswanCert.pem' (1350 bytes)
 | *received 836 bytes from 93.184.216.34:500 on eth0 (port=500)

--- a/tests/unit/libpluto/lp23-davecertI1/output.txt
+++ b/tests/unit/libpluto/lp23-davecertI1/output.txt
@@ -29,7 +29,6 @@ RC=0 "home":     myip=unset; hisip=unset; mycert=daveCert.pem;
 RC=0 "home":   CAs: 'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'...'%any'
 RC=0 "home":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "home":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+SAREFTRACK+lKOD+rKOD; prio: 16,0; interface: eth0; kind=CK_PERMANENT
-RC=0 "home":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | creating state object #1 at Z
 | orient home checking against if: eth0
 | orient home matching on public/private keys

--- a/tests/unit/libpluto/lp24-certreplydaveR2/certreplydaveR2.c
+++ b/tests/unit/libpluto/lp24-certreplydaveR2/certreplydaveR2.c
@@ -86,11 +86,11 @@ static void init_loaded(void)
 
     c = con_by_name("rw-carol", TRUE);
     assert(c != NULL);
-    show_one_connection(c);
+    show_one_connection(c, whack_log);
 
     c = con_by_name("rw-dave", TRUE);
     assert(c != NULL);
-    show_one_connection(c);
+    show_one_connection(c, whack_log);
 
     hostpair_list();
 }

--- a/tests/unit/libpluto/lp24-certreplydaveR2/output1.txt
+++ b/tests/unit/libpluto/lp24-certreplydaveR2/output1.txt
@@ -75,7 +75,6 @@ RC=0 "rw-any":     myip=unset; hisip=unset; mycert=moonCert.pem;
 RC=0 "rw-any":   CAs: 'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'...'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'
 RC=0 "rw-any":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "rw-any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+SAREFTRACK+lKOD+rKOD; prio: 16,32; interface: eth0; kind=CK_TEMPLATE
-RC=0 "rw-any":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | Changed path to directory '../samples/gatewaycert/cacerts'
 ./certreplydaveR2   loaded CA cert file 'strongswanCert.pem' (1350 bytes)
 RC=0 "rw-carol": 10.2.0.0/16===132.213.238.7<132.213.238.7>[@moon.strongswan.org]...93.184.216.34<93.184.216.34>; unrouted; eroute owner: #0
@@ -83,13 +82,11 @@ RC=0 "rw-carol":     myip=unset; hisip=unset; mycert=moonCert.pem; hiscert=carol
 RC=0 "rw-carol":   CAs: 'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'...'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'
 RC=0 "rw-carol":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "rw-carol":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+SAREFTRACK+lKOD+rKOD; prio: 16,32; interface: eth0; kind=CK_PERMANENT
-RC=0 "rw-carol":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 RC=0 "rw-dave": 10.2.0.0/16===132.213.238.7<132.213.238.7>[@moon.strongswan.org]...192.168.0.200<192.168.0.200>[C=CA, ST=ON, L=Ottawa, O=Xelerance Corporation, OU=Openswan, CN=dave@openswan.org]; unrouted; eroute owner: #0
 RC=0 "rw-dave":     myip=unset; hisip=unset; mycert=moonCert.pem;
 RC=0 "rw-dave":   CAs: 'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'...'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'
 RC=0 "rw-dave":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "rw-dave":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+SAREFTRACK+lKOD+rKOD; prio: 16,32; interface: eth0; kind=CK_PERMANENT
-RC=0 "rw-dave":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 RC=2 IP hostpairs:
 RC=2   IPpair: 132.213.238.7:500  192.168.0.200:500
 RC=2      rw-dave[]

--- a/tests/unit/libpluto/lp25-wrongcacert/output1.txt
+++ b/tests/unit/libpluto/lp25-wrongcacert/output1.txt
@@ -32,7 +32,6 @@ RC=0 "rw-any":     myip=unset; hisip=unset; mycert=moonCert.pem;
 RC=0 "rw-any":   CAs: 'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'...'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'
 RC=0 "rw-any":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "rw-any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+SAREFTRACK+lKOD+rKOD; prio: 16,32; interface: eth0; kind=CK_TEMPLATE
-RC=0 "rw-any":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | *received 836 bytes from 93.184.216.34:500 on eth0 (port=500)
 |   80 01 02 03  04 05 06 07  00 00 00 00  00 00 00 00
 |   21 20 22 08  00 00 00 00  00 00 03 44  22 00 01 fc

--- a/tests/unit/libpluto/lp26-davecertI2/output1.txt
+++ b/tests/unit/libpluto/lp26-davecertI2/output1.txt
@@ -32,7 +32,6 @@ RC=0 "home":     myip=unset; hisip=unset; mycert=daveCert.pem;
 RC=0 "home":   CAs: 'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'...'%any'
 RC=0 "home":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "home":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+SAREFTRACK+lKOD+rKOD; prio: 16,0; interface: eth0; kind=CK_PERMANENT
-RC=0 "home":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | Changed path to directory '../samples/davecert/cacerts'
 ./davecertI2   loaded CA cert file 'strongswanCert.pem' (1350 bytes)
 | creating state object #1 at Z

--- a/tests/unit/libpluto/seam_log.c
+++ b/tests/unit/libpluto/seam_log.c
@@ -21,3 +21,18 @@ pexpect_log(const char *pred_str, const char *file_str, unsigned long line_no)
 
 void daily_log_event(void) {}
 
+/* verbatish copy from log.c, only set date constant */
+char *oswtimestr(void)
+{
+    static char datebuf[32];
+    time_t n;
+    struct tm *t;
+
+    n = 1448316734L;
+    t = localtime(&n);
+
+    strftime(datebuf, sizeof(datebuf), "%Y-%m-%d %T", t);
+    return datebuf;
+}
+
+

--- a/tests/utils/whack-processing.sed
+++ b/tests/utils/whack-processing.sed
@@ -5,3 +5,4 @@ s/processing whack message of size: .*/processing whack message of size: A/
 s/ *$//
 /kernel_alg_esp_info/d
 s/releasing whack for .* (sock=.*)/releasing whack for #X (sock=Y)/
+/newest ISAKMP SA/d


### PR DESCRIPTION
The apparent policies disappearing were the result of old keys expiring.
Upon a rekey, a new SA is installed, and the new state is supposed to become the owner of the policy (SAD) entry.  This was not occuring correctly as the new state number wasn't getting written in the *right* spd_eroute entry: in 2.6.44, a temporary "desired_sr" was created to hold the *actual* values for the end points (taking in account NAT translation), vs the intended policy.   Probably raw_eroute should be modified to take an entirely different structure than an spd_route ('sr').  The eroute owner was being written into this temporary structure, and not being propogating back into the connection.
The result was when the old keys actually expired the clean up of those keys saw that the state in question owned the eroute, and dutifully removed it.  So it wasn't rekeying that killed the SA, so much as the old keys disappearing.
This pull request also refactors show_one_connection() to take a function to which to log: it can go to whack ("whack_log") or to the log file ("loglog"). 