### PR TITLE
T4681 v4 on v6 rebase

### DIFF
--- a/include/pluto/connections.h
+++ b/include/pluto/connections.h
@@ -240,6 +240,7 @@ struct connection {
     policy_prio_t prio;
     bool instance_initiation_ok;	/* this is an instance of a policy that mandates initiate */
     enum connection_kind kind;
+    bool                   ip_oriented; /* true iff oriented by IP address */
     const struct iface_port *interface;	/* filled in iff oriented */
 
     bool initiated;

--- a/include/pluto/connections.h
+++ b/include/pluto/connections.h
@@ -296,6 +296,7 @@ struct connection {
 };
 
 #define oriented(c) ((c).interface != NULL)
+extern bool orient_same_addr_ok;
 extern bool orient(struct connection *c, unsigned int pluto_port);
 
 extern bool same_peer_ids(const struct connection *c

--- a/include/pluto/server.h
+++ b/include/pluto/server.h
@@ -55,6 +55,7 @@ struct iface_dev {
 
 struct iface_port {
     struct iface_dev   *ip_dev;
+  char                addrname[ADDRTOT_BUF];
     u_int16_t           port;    /* host byte order */
     ip_address          ip_addr;   /* interface IP address */
     int fd;	        /* file descriptor of socket for IKE UDP messages */
@@ -71,6 +72,7 @@ extern void show_ifaces_status(void);
 extern void free_ifaces(void);
 extern void show_debug_status(void);
 extern void call_server(void);
+extern void init_iface_port(struct iface_port *q);
 
 /* in rcv_info.c */
 extern err_t init_info_socket(void);

--- a/lib/libpluto/Makefile
+++ b/lib/libpluto/Makefile
@@ -32,7 +32,7 @@ MANDIR=$(MANTREE)/man3
 ONEFILE=pluto_constants.c
 SRCS=defs.c pluto_constants.c x509support.c packet.c
 SRCS+=readwhackmsg.c rnd.c writewhackmsg.c orient.c spd_format.c
-SRCS+=endclienttot.c
+SRCS+=endclienttot.c iface.c
 
 #enable to get lots more debugging about semantics.
 #CFLAGS+=-DPARSER_TYPE_DEBUG

--- a/lib/libpluto/iface.c
+++ b/lib/libpluto/iface.c
@@ -1,0 +1,47 @@
+/* routines to manipulate a struct iface_port.
+ *
+ * Copyright (C) 2016 Michael Richardson <mcr@xelerance.com>
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2 of the License, or (at your
+ * option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * for more details.
+ *
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/stat.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <resolv.h>
+
+#include <openswan.h>
+#include <openswan/ipsec_policy.h>
+#include "openswan/pfkeyv2.h"
+
+#include "sysdep.h"
+#include "constants.h"
+#include "oswalloc.h"
+#include "oswtime.h"
+#include "oswlog.h"
+#include "pluto/keys.h"
+
+#include "pluto/server.h"
+
+void init_iface_port(struct iface_port *q)
+{
+  sin_addrtot(&q->ip_addr, 0, q->addrname, sizeof(q->addrname));
+}
+
+

--- a/lib/libpluto/iface.c
+++ b/lib/libpluto/iface.c
@@ -42,6 +42,17 @@
 void init_iface_port(struct iface_port *q)
 {
   sin_addrtot(&q->ip_addr, 0, q->addrname, sizeof(q->addrname));
+
+  switch(q->ip_addr.u.v4.sin_family) {
+  case AF_INET6:
+    q->ip_addr.u.v4.sin_port = q->port;
+    break;
+
+  default:
+  case AF_INET:
+    q->ip_addr.u.v6.sin6_port = q->port;
+    break;
+  }
 }
 
 

--- a/lib/libpluto/orient.c
+++ b/lib/libpluto/orient.c
@@ -54,9 +54,21 @@ struct iface_port *pick_matching_interfacebyfamily(struct iface_port *iflist,
                                                    struct spd_route *sr)
 {
     struct iface_port *ifp = interfaces;
+    unsigned int       desired_port;
     struct end        *e1 = &sr->this;
     int family = sr->this.host_addr.u.v4.sin_family;
     int family2= sr->that.host_addr.u.v4.sin_family;
+
+    switch(family) {
+    case AF_INET6:
+        desired_port = e1->host_addr.u.v6.sin6_port;
+        break;
+
+    default:
+    case AF_INET:
+        desired_port = e1->host_addr.u.v4.sin_port;
+        break;
+    }
 
     if(family == 0) {
         family = family2;
@@ -67,17 +79,8 @@ struct iface_port *pick_matching_interfacebyfamily(struct iface_port *iflist,
     while(iflist) {
         if(iflist->ip_addr.u.v4.sin_family == family) {
             ifp = iflist;
-            switch(family) {
-            case AF_INET6:
-                if(iflist->ip_addr.u.v6.sin6_port == e1->host_addr.u.v6.sin6_port) {
-                    return iflist;
-                }
-                break;
-            case AF_INET:
-                if(iflist->ip_addr.u.v4.sin_port == e1->host_addr.u.v4.sin_port) {
-                    return iflist;
-                }
-                break;
+            if(iflist->port == desired_port) {
+                return iflist;
             }
         }
         iflist = iflist->next;

--- a/lib/libpluto/orient.c
+++ b/lib/libpluto/orient.c
@@ -153,8 +153,9 @@ orient(struct connection *c, unsigned int pluto_port)
                     || sr->this.host_type == KH_ANY)
                    && osw_end_has_private_key(&sr->this)) {
                     /*
-                     * orientated is determined by selecting an interface, and this will pick
-                     * first interface in the list...  want to pick wildcard outgoing interface.
+                     * orientated is determined by selecting an interface,
+                     * and this will pick first interface in the list...
+                     * want to pick wildcard outgoing interface.
                      */
                     c->interface = interfaces;
                     c->ip_oriented = FALSE;
@@ -163,21 +164,27 @@ orient(struct connection *c, unsigned int pluto_port)
                            || sr->that.host_type == KH_ANY)
                           && osw_end_has_private_key(&sr->that)) {
                     swap_ends(sr);
+
                     c->interface = interfaces;
                     c->ip_oriented = FALSE;
 
                 } else if(!osw_end_has_private_key(&sr->that)
                           && sr->this.host_type==KH_DEFAULTROUTE) {
-                    /* if still not oriented, then look for an end that hasn't a key, but which
-                     * hasn't a private key, and defaultroute */
+                    /* if still not oriented, then look for an end
+                     * that hasn't a key, but which hasn't a private key,
+                     * and defaultroute */
+
                     c->interface = interfaces;
                     c->ip_oriented = FALSE;
 
                 } else if(!osw_end_has_private_key(&sr->this)
                           && sr->that.host_type==KH_DEFAULTROUTE) {
-                    /* if still not oriented, then look for an end that hasn't a key, but which
-                     * hasn't a private key, and defaultroute */
+                    /* if still not oriented, then look for an end that
+                     * hasn't a key, but which hasn't a private key,
+                     and defaultroute */
+
                     swap_ends(sr);
+
                     c->interface = interfaces;
                     c->ip_oriented = FALSE;
                 }

--- a/lib/libpluto/orient.c
+++ b/lib/libpluto/orient.c
@@ -100,14 +100,14 @@ orient(struct connection *c, unsigned int pluto_port)
 	     */
 	    for (p = interfaces; p != NULL; p = p->next)
 	    {
-                DBG(DBG_CONTROLMORE, DBG_log("orient %s checking against if: %s", c->name, p->ip_dev->id_rname));
+                DBG(DBG_CONTROLMORE, DBG_log("orient %s checking against if: %s (%s:%u)", c->name, p->ip_dev->id_rname, p->addrname, p->port));
 #ifdef NAT_TRAVERSAL
 		if (p->ike_float) continue;
 #endif
 
 #ifdef HAVE_LABELED_IPSEC
 		if (c->loopback && sameaddr(&sr->this.host_addr, &p->ip_addr)) {
-		DBG(DBG_CONTROLMORE,
+                    DBG(DBG_CONTROLMORE,
 			DBG_log("loopback connections \"%s\" with interface %s!"
 			 , c->name, p->ip_dev->id_rname));
 			c->interface = p;

--- a/lib/libpluto/orient.c
+++ b/lib/libpluto/orient.c
@@ -51,8 +51,11 @@ static void swap_ends(struct spd_route *sr)
 
 
 struct iface_port *pick_matching_interfacebyfamily(struct iface_port *iflist,
-                                                   int family)
+                                                   int family, int family2)
 {
+    if(family == 0) family = family2;
+    if(family == 0) family = AF_INET;
+
     while(iflist && iflist->ip_addr.u.v4.sin_family != family) {
         iflist = iflist->next;
     }
@@ -167,7 +170,9 @@ orient(struct connection *c, unsigned int pluto_port)
                      * and this will pick first interface in the list...
                      * want to pick wildcard outgoing interface.
                      */
-                    c->interface   = pick_matching_interfacebyfamily(interfaces, sr->this.host_addr.u.v4.sin_family);
+                    c->interface   = pick_matching_interfacebyfamily(interfaces
+                                                                     , sr->this.host_addr.u.v4.sin_family
+                                                                     , sr->that.host_addr.u.v4.sin_family);
                     c->ip_oriented = FALSE;
 
                 } else if((sr->that.host_type == KH_DEFAULTROUTE
@@ -175,7 +180,7 @@ orient(struct connection *c, unsigned int pluto_port)
                           && osw_end_has_private_key(&sr->that)) {
                     swap_ends(sr);
 
-                    c->interface   = pick_matching_interfacebyfamily(interfaces, sr->this.host_addr.u.v4.sin_family);
+                    c->interface   = pick_matching_interfacebyfamily(interfaces, sr->this.host_addr.u.v4.sin_family, sr->that.host_addr.u.v4.sin_family);
                     c->ip_oriented = FALSE;
 
                 } else if(!osw_end_has_private_key(&sr->that)
@@ -184,7 +189,10 @@ orient(struct connection *c, unsigned int pluto_port)
                      * that hasn't a key, but which hasn't a private key,
                      * and defaultroute */
 
-                    c->interface   = pick_matching_interfacebyfamily(interfaces, sr->that.host_addr.u.v4.sin_family);
+                    c->interface   =
+                        pick_matching_interfacebyfamily(interfaces
+                                                        , sr->that.host_addr.u.v4.sin_family
+                                                        , sr->that.host_addr.u.v4.sin_family);
                     c->ip_oriented = FALSE;
 
                 } else if(!osw_end_has_private_key(&sr->this)
@@ -195,7 +203,10 @@ orient(struct connection *c, unsigned int pluto_port)
 
                     swap_ends(sr);
 
-                    c->interface   = pick_matching_interfacebyfamily(interfaces, sr->this.host_addr.u.v4.sin_family);
+                    c->interface   =
+                        pick_matching_interfacebyfamily(interfaces
+                                                        , sr->this.host_addr.u.v4.sin_family
+                                                        , sr->that.host_addr.u.v4.sin_family);
                     c->ip_oriented = FALSE;
                 }
             }

--- a/lib/libpluto/orient.c
+++ b/lib/libpluto/orient.c
@@ -41,6 +41,14 @@
 #include "pluto/server.h"
 #include "pluto/connections.h"	/* needs id.h */
 
+/*
+ * this variable is set in production pluto when using
+ * kern_interface == NO_KERNEL,  but must remain unset
+ * at other times, including regression testing.
+ *
+ */
+bool orient_same_addr_ok = FALSE;
+
 static void swap_ends(struct spd_route *sr)
 {
     struct end t = sr->this;
@@ -150,8 +158,8 @@ orient(struct connection *c, unsigned int pluto_port)
 		{
 		    /* check if this interface matches this end */
 		    if (sameaddr(&sr->this.host_addr, &p->ip_addr)
-			&& (kern_interface != NO_KERNEL
-			    || sr->this.host_port == pluto_port))
+			&& (orient_same_addr_ok
+                            || sr->this.host_port == p->port))
 		    {
 			if (oriented(*c))
 			{
@@ -168,12 +176,14 @@ orient(struct connection *c, unsigned int pluto_port)
 			}
 			c->interface = p;
                         c->ip_oriented = TRUE;
+                        DBG(DBG_CONTROLMORE,
+                            DBG_log("    orient matched"));
 		    }
 
 		    /* done with this interface if it doesn't match that end */
 		    if (!(sameaddr(&sr->that.host_addr, &p->ip_addr)
-			  && (kern_interface!=NO_KERNEL
-			      || sr->that.host_port == pluto_port)))
+			  && (orient_same_addr_ok
+			      || sr->that.host_port == p->port)))
 			break;
 
 		    /* swap ends and try again.

--- a/lib/libpluto/orient.c
+++ b/lib/libpluto/orient.c
@@ -50,6 +50,16 @@ static void swap_ends(struct spd_route *sr)
 }
 
 
+struct iface_port *pick_matching_interfacebyfamily(struct iface_port *iflist,
+                                                   int family)
+{
+    while(iflist && iflist->ip_addr.u.v4.sin_family != family) {
+        iflist = iflist->next;
+    }
+
+    return iflist;
+}
+
 
 static bool osw_end_has_private_key(struct end *him)
 {
@@ -157,7 +167,7 @@ orient(struct connection *c, unsigned int pluto_port)
                      * and this will pick first interface in the list...
                      * want to pick wildcard outgoing interface.
                      */
-                    c->interface = interfaces;
+                    c->interface   = pick_matching_interfacebyfamily(interfaces, sr->this.host_addr.u.v4.sin_family);
                     c->ip_oriented = FALSE;
 
                 } else if((sr->that.host_type == KH_DEFAULTROUTE
@@ -165,7 +175,7 @@ orient(struct connection *c, unsigned int pluto_port)
                           && osw_end_has_private_key(&sr->that)) {
                     swap_ends(sr);
 
-                    c->interface = interfaces;
+                    c->interface   = pick_matching_interfacebyfamily(interfaces, sr->this.host_addr.u.v4.sin_family);
                     c->ip_oriented = FALSE;
 
                 } else if(!osw_end_has_private_key(&sr->that)
@@ -174,7 +184,7 @@ orient(struct connection *c, unsigned int pluto_port)
                      * that hasn't a key, but which hasn't a private key,
                      * and defaultroute */
 
-                    c->interface = interfaces;
+                    c->interface   = pick_matching_interfacebyfamily(interfaces, sr->that.host_addr.u.v4.sin_family);
                     c->ip_oriented = FALSE;
 
                 } else if(!osw_end_has_private_key(&sr->this)
@@ -185,7 +195,7 @@ orient(struct connection *c, unsigned int pluto_port)
 
                     swap_ends(sr);
 
-                    c->interface = interfaces;
+                    c->interface   = pick_matching_interfacebyfamily(interfaces, sr->this.host_addr.u.v4.sin_family);
                     c->ip_oriented = FALSE;
                 }
             }

--- a/lib/libpluto/orient.c
+++ b/lib/libpluto/orient.c
@@ -101,6 +101,7 @@ orient(struct connection *c, unsigned int pluto_port)
 			DBG_log("loopback connections \"%s\" with interface %s!"
 			 , c->name, p->ip_dev->id_rname));
 			c->interface = p;
+                        c->ip_oriented = TRUE;
 			break;
 		}
 #endif
@@ -126,6 +127,7 @@ orient(struct connection *c, unsigned int pluto_port)
 			    return FALSE;
 			}
 			c->interface = p;
+                        c->ip_oriented = TRUE;
 		    }
 
 		    /* done with this interface if it doesn't match that end */
@@ -155,23 +157,29 @@ orient(struct connection *c, unsigned int pluto_port)
                      * first interface in the list...  want to pick wildcard outgoing interface.
                      */
                     c->interface = interfaces;
+                    c->ip_oriented = FALSE;
 
                 } else if((sr->that.host_type == KH_DEFAULTROUTE
                            || sr->that.host_type == KH_ANY)
                           && osw_end_has_private_key(&sr->that)) {
                     swap_ends(sr);
                     c->interface = interfaces;
+                    c->ip_oriented = FALSE;
+
                 } else if(!osw_end_has_private_key(&sr->that)
                           && sr->this.host_type==KH_DEFAULTROUTE) {
                     /* if still not oriented, then look for an end that hasn't a key, but which
                      * hasn't a private key, and defaultroute */
                     c->interface = interfaces;
+                    c->ip_oriented = FALSE;
+
                 } else if(!osw_end_has_private_key(&sr->this)
                           && sr->that.host_type==KH_DEFAULTROUTE) {
                     /* if still not oriented, then look for an end that hasn't a key, but which
                      * hasn't a private key, and defaultroute */
                     swap_ends(sr);
                     c->interface = interfaces;
+                    c->ip_oriented = FALSE;
                 }
             }
         }

--- a/programs/pluto/kernel_bsdkame.c
+++ b/programs/pluto/kernel_bsdkame.c
@@ -169,6 +169,7 @@ bsdkame_process_raw_ifaces(struct raw_iface *rifaces)
 
 		    q->ip_addr = ifp->addr;
 		    q->fd = fd;
+                    init_iface_port(q);
 		    q->next = interfaces;
 		    q->change = IFN_ADD;
 		    q->port = pluto_port500;

--- a/programs/pluto/kernel_klips.c
+++ b/programs/pluto/kernel_klips.c
@@ -230,6 +230,7 @@ add_entry:
 
 		    q->ip_addr = ifp->addr;
 		    q->fd = fd;
+                    init_iface_port(q);
 		    q->next = interfaces;
 		    q->change = IFN_ADD;
 		    q->port = pluto_port500;

--- a/programs/pluto/kernel_mast.c
+++ b/programs/pluto/kernel_mast.c
@@ -320,6 +320,7 @@ mast_process_raw_ifaces(struct raw_iface *rifaces)
 		id->id_count++;
 
 		q->ip_addr = ifp->addr;
+                init_iface_port(q);
 		q->change = IFN_ADD;
 		q->port = pluto_port500;
 		q->ike_float = FALSE;

--- a/programs/pluto/kernel_netlink.c
+++ b/programs/pluto/kernel_netlink.c
@@ -2309,6 +2309,7 @@ add_entry:
 
 		    q->ip_addr = ifp->addr;
 		    q->fd = fd;
+                    init_iface_port(q);
 		    q->next = interfaces;
 		    q->change = IFN_ADD;
 		    q->port = pluto_port500;

--- a/programs/pluto/plutomain.c
+++ b/programs/pluto/plutomain.c
@@ -618,6 +618,12 @@ main(int argc, char **argv)
 
 	case 'n':	/* --use-nostack */
 	    kern_interface = NO_KERNEL;
+
+            /* this permits interfaces to match even if ports do not, so
+             * that pluto can be tested against another pluto, all on
+             * 127.0.0.1
+             */
+            orient_same_addr_ok = TRUE;
 	    continue;
 
 	case 'D':	/* --force_busy */

--- a/programs/pluto/server.c
+++ b/programs/pluto/server.c
@@ -484,8 +484,9 @@ show_ifaces_status(void)
 
     for (p = interfaces; p != NULL; p = p->next)
 	whack_log(RC_COMMENT, "interface %s/%s %s"
-	    , p->ip_dev->id_vname, p->ip_dev->id_rname, ip_str(&p->ip_addr));
+	    , p->ip_dev->id_vname, p->ip_dev->id_rname, p->addrname);
 }
+
 
 void
 show_debug_status(void)

--- a/tests/unit/libpluto/lp02-parentI1/output.txt
+++ b/tests/unit/libpluto/lp02-parentI1/output.txt
@@ -10,7 +10,10 @@ processing whack msg time: X size: Y
 | Added new connection parker1--jj2 with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | counting wild cards for @jamesjohnson.emmjay.credil.org is 0
 | counting wild cards for @parker01.emmjay.credil.org is 0
-| orient parker1--jj2 checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946:500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:4500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:500)
+|     orient matched
 | find_host_pair: looking for me=192.168.1.1:500 %address him=132.213.238.7:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 192.168.1.1:500 %address 132.213.238.7:500 -> hp:none
@@ -24,7 +27,10 @@ RC=0 "parker1--jj2":     myip=unset; hisip=unset;
 RC=0 "parker1--jj2":   ike_life: 3600s; ipsec_life: 28800s; rekey_margin: 540s; rekey_fuzz: 100%; keyingtries: 0
 RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 64,96; interface: eth0; kind=CK_PERMANENT
 | creating state object #1 at Z
-| orient parker1--jj2 checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946:500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:4500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:500)
+|     orient matched
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4

--- a/tests/unit/libpluto/lp06-parentR1notchosen/output.txt
+++ b/tests/unit/libpluto/lp06-parentR1notchosen/output.txt
@@ -8,7 +8,10 @@ processing whack msg time: X size: Y
 | Added new connection parker1--jj2 with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | counting wild cards for @jamesjohnson.emmjay.credil.org is 0
 | counting wild cards for @parker01.emmjay.credil.org is 0
-| orient parker1--jj2 checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946:500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:4500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:500)
+|     orient matched
 | find_host_pair: looking for me=192.168.1.1:500 %address him=132.213.238.7:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 192.168.1.1:500 %address 132.213.238.7:500 -> hp:none
@@ -22,7 +25,10 @@ RC=0 "parker1--jj2":     myip=unset; hisip=unset;
 RC=0 "parker1--jj2":   ike_life: 3600s; ipsec_life: 28800s; rekey_margin: 540s; rekey_fuzz: 100%; keyingtries: 0
 RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 64,96; interface: eth0; kind=CK_PERMANENT
 | creating state object #1 at Z
-| orient parker1--jj2 checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946:500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:4500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:500)
+|     orient matched
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4

--- a/tests/unit/libpluto/lp07-orient/output.txt
+++ b/tests/unit/libpluto/lp07-orient/output.txt
@@ -25,6 +25,7 @@ RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SA
 ./orienttest leak: struct connection, item size: X
 ./orienttest leak: 2 * keep id name, item size: X
 ./orienttest leak: ID host_pair, item size: X
+./orienttest leak: host_pair, item size: X
 ./orienttest leak: policies path, item size: X
 ./orienttest leak: ocspcerts path, item size: X
 ./orienttest leak: aacerts path, item size: X

--- a/tests/unit/libpluto/lp07-orient/output.txt
+++ b/tests/unit/libpluto/lp07-orient/output.txt
@@ -25,7 +25,6 @@ RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SA
 ./orienttest leak: struct connection, item size: X
 ./orienttest leak: 2 * keep id name, item size: X
 ./orienttest leak: ID host_pair, item size: X
-./orienttest leak: host_pair, item size: X
 ./orienttest leak: policies path, item size: X
 ./orienttest leak: ocspcerts path, item size: X
 ./orienttest leak: aacerts path, item size: X

--- a/tests/unit/libpluto/lp08-parentR1/output1.txt
+++ b/tests/unit/libpluto/lp08-parentR1/output1.txt
@@ -13,7 +13,8 @@ processing whack msg time: X size: Y
 | Added new connection parker1--jj2 with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | counting wild cards for @jamesjohnson.emmjay.credil.org is 0
 | counting wild cards for @parker01.emmjay.credil.org is 0
-| orient parker1--jj2 checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %address him=192.168.1.1:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 132.213.238.7:500 %address 192.168.1.1:500 -> hp:none
@@ -104,7 +105,8 @@ RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SA
 | find_host_connection2 returns parker1--jj2
 ./parentR1 tentatively considering connection: parker1--jj2
 | creating state object #1 at Z
-| orient parker1--jj2 checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | ICOOKIE:  00 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28

--- a/tests/unit/libpluto/lp08-parentR1/output2.txt
+++ b/tests/unit/libpluto/lp08-parentR1/output2.txt
@@ -13,7 +13,8 @@ processing whack msg time: X size: Y
 | Added new connection parker1--jj2 with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | counting wild cards for @jamesjohnson.emmjay.credil.org is 0
 | counting wild cards for @parker01.emmjay.credil.org is 0
-| orient parker1--jj2 checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %address him=192.168.1.1:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 132.213.238.7:500 %address 192.168.1.1:500 -> hp:none
@@ -108,7 +109,8 @@ RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SA
 | find_host_connection2 returns parker1--jj2
 ./parentR1 tentatively considering connection: parker1--jj2
 | creating state object #1 at Z
-| orient parker1--jj2 checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28

--- a/tests/unit/libpluto/lp08-parentR1/output3.txt
+++ b/tests/unit/libpluto/lp08-parentR1/output3.txt
@@ -16,7 +16,8 @@ processing whack msg time: X size: Y
 | Added new connection any1--jj2 with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | counting wild cards for @jamesjohnson.emmjay.credil.org is 0
 | counting wild cards for @parker01.emmjay.credil.org is 0
-| orient any1--jj2 checking against if: eth0
+| orient any1--jj2 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 132.213.238.7:500 %any 0.0.0.0:500 -> hp:none
@@ -111,7 +112,8 @@ RC=0 "any1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREF
 | find_host_connection2 returns any1--jj2
 ./parentR1 tentatively considering connection: any1--jj2
 | creating state object #1 at Z
-| orient any1--jj2 checking against if: eth0
+| orient any1--jj2 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | ICOOKIE:  56 11 47 13  4b 1d 6d 52
 | RCOOKIE:  a9 e1 ff 4d  1c 8b b8 19
 | state hash entry 12

--- a/tests/unit/libpluto/lp09-I1notify/output1.txt
+++ b/tests/unit/libpluto/lp09-I1notify/output1.txt
@@ -1,13 +1,29 @@
+./parent_outI1inR1 ike_alg_register_enc(): Activating OAKLEY_AES_CBC: Ok (ret=0)
+./parent_outI1inR1 ike_alg_register_hash(): Activating OAKLEY_SHA2_512: Ok (ret=0)
+./parent_outI1inR1 ike_alg_register_hash(): Activating OAKLEY_SHA2_256: Ok (ret=0)
+./parent_outI1inR1 loading secrets from "../samples/parker.secrets"
+./parent_outI1inR1 loaded private key for keyid: PPK_RSA:AQN7wUerV
 | processing whack message of size: A
+| processing whack message of size: A
+processing whack msg time: X size: Y
+| processing whack message of size: A
+processing whack msg time: X size: Y
 | processing whack message of size: A
 processing whack msg time: X size: Y
 | Added new connection parker1--jj2 with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | counting wild cards for @jamesjohnson.emmjay.credil.org is 0
 | counting wild cards for @parker01.emmjay.credil.org is 0
-| checking against if: eth0
-| connect_to_host_pair: 192.168.1.1:500 132.213.238.7:500 -> hp:none
-./parent_outI1inR1 added connection description "parker1--jj2"
-| fd68:c9f9:4157:2:0:1::/96===192.168.1.1<192.168.1.1>[@parker01.emmjay.credil.org]...132.213.238.7<132.213.238.7>[@jamesjohnson.emmjay.credil.org]===fd68:c9f9:4157::/64
+| orient parker1--jj2 checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946:500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:4500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:500)
+|     orient matched
+| find_host_pair: looking for me=192.168.1.1:500 %address him=132.213.238.7:500 exact-match
+| find_host_pair: concluded with <none>
+| connect_to_host_pair: 192.168.1.1:500 %address 132.213.238.7:500 -> hp:none
+| find_ID_host_pair: looking for me=@parker01.emmjay.credil.org him=@jamesjohnson.emmjay.credil.org (exact)
+|   concluded with <none>
+./parent_outI1inR1 adding connection: "parker1--jj2"
+| fd68:c9f9:4157:2:0:1::/96===192.168.1.1[@parker01.emmjay.credil.org]...132.213.238.7[@jamesjohnson.emmjay.credil.org]===fd68:c9f9:4157::/64
 | ike_life: 3600s; ipsec_life: 28800s; rekey_margin: 540s; rekey_fuzz: 100%; keyingtries: 0; policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 RC=0 "parker1--jj2": fd68:c9f9:4157:2:0:1::/96===192.168.1.1<192.168.1.1>[@parker01.emmjay.credil.org]...132.213.238.7<132.213.238.7>[@jamesjohnson.emmjay.credil.org]===fd68:c9f9:4157::/64; unrouted; eroute owner: #0
 RC=0 "parker1--jj2":     myip=unset; hisip=unset;
@@ -15,7 +31,8 @@ RC=0 "parker1--jj2":   ike_life: 3600s; ipsec_life: 28800s; rekey_margin: 540s; 
 RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 64,96; interface: eth0;
 RC=0 "parker1--jj2":   newest ISAKMP SA: #0; newest IPsec SA: #0;
 | creating state object #1 at Z
-| checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1)
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4

--- a/tests/unit/libpluto/lp10-parentI2/output1.txt
+++ b/tests/unit/libpluto/lp10-parentI2/output1.txt
@@ -13,7 +13,10 @@ processing whack msg time: X size: Y
 | Added new connection parker1--jj2 with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | counting wild cards for @jamesjohnson.emmjay.credil.org is 0
 | counting wild cards for @parker01.emmjay.credil.org is 0
-| orient parker1--jj2 checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946:500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:4500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:500)
+|     orient matched
 | find_host_pair: looking for me=192.168.1.1:500 %address him=132.213.238.7:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 192.168.1.1:500 %address 132.213.238.7:500 -> hp:none
@@ -27,7 +30,10 @@ RC=0 "parker1--jj2":     myip=unset; hisip=unset;
 RC=0 "parker1--jj2":   ike_life: 3600s; ipsec_life: 28800s; rekey_margin: 540s; rekey_fuzz: 100%; keyingtries: 0
 RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 64,96; interface: eth0; kind=CK_PERMANENT
 | creating state object #1 at Z
-| orient parker1--jj2 checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946:500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:4500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:500)
+|     orient matched
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4

--- a/tests/unit/libpluto/lp11-parentI2dup/output1.txt
+++ b/tests/unit/libpluto/lp11-parentI2dup/output1.txt
@@ -11,7 +11,10 @@ processing whack msg time: X size: Y
 | Added new connection parker1--jj2 with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | counting wild cards for @jamesjohnson.emmjay.credil.org is 0
 | counting wild cards for @parker01.emmjay.credil.org is 0
-| orient parker1--jj2 checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946:500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:4500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:500)
+|     orient matched
 | find_host_pair: looking for me=192.168.1.1:500 %address him=132.213.238.7:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 192.168.1.1:500 %address 132.213.238.7:500 -> hp:none
@@ -25,7 +28,10 @@ RC=0 "parker1--jj2":     myip=unset; hisip=unset;
 RC=0 "parker1--jj2":   ike_life: 3600s; ipsec_life: 28800s; rekey_margin: 540s; rekey_fuzz: 100%; keyingtries: 0
 RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 64,96; interface: eth0; kind=CK_PERMANENT
 | creating state object #1 at Z
-| orient parker1--jj2 checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946:500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:4500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:500)
+|     orient matched
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4

--- a/tests/unit/libpluto/lp12-parentR2/output1.txt
+++ b/tests/unit/libpluto/lp12-parentR2/output1.txt
@@ -13,7 +13,8 @@ processing whack msg time: X size: Y
 | Added new connection parker1--jj2 with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | counting wild cards for @jamesjohnson.emmjay.credil.org is 0
 | counting wild cards for @parker01.emmjay.credil.org is 0
-| orient parker1--jj2 checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %address him=192.168.1.1:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 132.213.238.7:500 %address 192.168.1.1:500 -> hp:none
@@ -108,7 +109,8 @@ RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SA
 | find_host_connection2 returns parker1--jj2
 ./parentR2 tentatively considering connection: parker1--jj2
 | creating state object #1 at Z
-| orient parker1--jj2 checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28

--- a/tests/unit/libpluto/lp13-parentI3/output1.txt
+++ b/tests/unit/libpluto/lp13-parentI3/output1.txt
@@ -13,7 +13,10 @@ processing whack msg time: X size: Y
 | Added new connection parker1--jj2 with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | counting wild cards for @jamesjohnson.emmjay.credil.org is 0
 | counting wild cards for @parker01.emmjay.credil.org is 0
-| orient parker1--jj2 checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946:500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:4500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:500)
+|     orient matched
 | find_host_pair: looking for me=192.168.1.1:500 %address him=132.213.238.7:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 192.168.1.1:500 %address 132.213.238.7:500 -> hp:none
@@ -27,7 +30,10 @@ RC=0 "parker1--jj2":     myip=unset; hisip=unset;
 RC=0 "parker1--jj2":   ike_life: 3600s; ipsec_life: 28800s; rekey_margin: 540s; rekey_fuzz: 100%; keyingtries: 0
 RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 64,96; interface: eth0; kind=CK_PERMANENT
 | creating state object #1 at Z
-| orient parker1--jj2 checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946:500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:4500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:500)
+|     orient matched
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4

--- a/tests/unit/libpluto/lp14-initiateself/output.txt
+++ b/tests/unit/libpluto/lp14-initiateself/output.txt
@@ -13,7 +13,7 @@ processing whack msg time: X size: Y
 | Added new connection gateway--any with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | counting wild cards for @jamesjohnson.emmjay.credil.org is 0
 | counting wild cards for @example.com is 0
-| orient gateway--any checking against if: eth0
+| orient gateway--any checking against if: eth0 (93.184.216.34:500)
 | orient gateway--any matching on public/private keys
 |   trusted_ca called with a=(empty) b=(empty)
 | find_host_pair: looking for me=0.0.0.0:500 %address him=132.213.238.7:500 exact-match
@@ -29,7 +29,7 @@ RC=0 "gateway--any":     myip=unset; hisip=unset;
 RC=0 "gateway--any":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "gateway--any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 16,32; interface: eth0; kind=CK_PERMANENT
 | creating state object #1 at Z
-| orient gateway--any checking against if: eth0
+| orient gateway--any checking against if: eth0 (93.184.216.34:500)
 | orient gateway--any matching on public/private keys
 |   trusted_ca called with a=(empty) b=(empty)
 | ICOOKIE:  80 01 02 03  04 05 06 07

--- a/tests/unit/libpluto/lp15-respondself/output1.txt
+++ b/tests/unit/libpluto/lp15-respondself/output1.txt
@@ -16,7 +16,8 @@ processing whack msg time: X size: Y
 | Added new connection gateway--any with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | counting wild cards for @jamesjohnson.emmjay.credil.org is 0
 | counting wild cards for @example.com is 0
-| orient gateway--any checking against if: eth0
+| orient gateway--any checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 132.213.238.7:500 %any 0.0.0.0:500 -> hp:none
@@ -111,7 +112,8 @@ RC=0 "gateway--any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SA
 | find_host_connection2 returns gateway--any
 ./respondselfR1 tentatively considering connection: gateway--any
 | creating state object #1 at Z
-| orient gateway--any checking against if: eth0
+| orient gateway--any checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5

--- a/tests/unit/libpluto/lp16-initiateselfI2/output1.txt
+++ b/tests/unit/libpluto/lp16-initiateselfI2/output1.txt
@@ -16,7 +16,7 @@ processing whack msg time: X size: Y
 | Added new connection gateway--any with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | counting wild cards for @jamesjohnson.emmjay.credil.org is 0
 | counting wild cards for @example.com is 0
-| orient gateway--any checking against if: eth0
+| orient gateway--any checking against if: eth0 (93.184.216.34:500)
 | orient gateway--any matching on public/private keys
 |   trusted_ca called with a=(empty) b=(empty)
 | find_host_pair: looking for me=0.0.0.0:500 %address him=132.213.238.7:500 exact-match
@@ -32,7 +32,7 @@ RC=0 "gateway--any":     myip=unset; hisip=unset;
 RC=0 "gateway--any":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "gateway--any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK; prio: 16,32; interface: eth0; kind=CK_PERMANENT
 | creating state object #1 at Z
-| orient gateway--any checking against if: eth0
+| orient gateway--any checking against if: eth0 (93.184.216.34:500)
 | orient gateway--any matching on public/private keys
 |   trusted_ca called with a=(empty) b=(empty)
 | ICOOKIE:  80 01 02 03  04 05 06 07

--- a/tests/unit/libpluto/lp17-childselfpolicy/output1.txt
+++ b/tests/unit/libpluto/lp17-childselfpolicy/output1.txt
@@ -16,7 +16,8 @@ processing whack msg time: X size: Y
 | Added new connection gateway--any with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | counting wild cards for @jamesjohnson.emmjay.credil.org is 0
 | counting wild cards for @example.com is 0
-| orient gateway--any checking against if: eth0
+| orient gateway--any checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 132.213.238.7:500 %any 0.0.0.0:500 -> hp:none
@@ -111,7 +112,8 @@ RC=0 "gateway--any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SA
 | find_host_connection2 returns gateway--any
 ./respondselfR2 tentatively considering connection: gateway--any
 | creating state object #1 at Z
-| orient gateway--any checking against if: eth0
+| orient gateway--any checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5

--- a/tests/unit/libpluto/lp17-childselfpolicy/output2.txt
+++ b/tests/unit/libpluto/lp17-childselfpolicy/output2.txt
@@ -16,7 +16,8 @@ processing whack msg time: X size: Y
 | Added new connection gateway--any with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | counting wild cards for @jamesjohnson.emmjay.credil.org is 0
 | counting wild cards for @example.com is 0
-| orient gateway--any checking against if: eth0
+| orient gateway--any checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 132.213.238.7:500 %any 0.0.0.0:500 -> hp:none
@@ -111,7 +112,8 @@ RC=0 "gateway--any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SA
 | find_host_connection2 returns gateway--any
 ./respondselfR2 tentatively considering connection: gateway--any
 | creating state object #1 at Z
-| orient gateway--any checking against if: eth0
+| orient gateway--any checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5

--- a/tests/unit/libpluto/lp18-certificateselfI1/output.txt
+++ b/tests/unit/libpluto/lp18-certificateselfI1/output.txt
@@ -14,7 +14,7 @@ processing whack msg time: X size: Y
 | certificate is valid
 | counting wild cards for carol@strongswan.org is 0
 | counting wild cards for @moon.strongswan.org is 0
-| orient home checking against if: eth0
+| orient home checking against if: eth0 (93.184.216.34:500)
 | orient home matching on public/private keys
 | find_host_pair: looking for me=<invalid>:500 %address him=132.213.238.7:500 exact-match
 | find_host_pair: concluded with <none>
@@ -30,7 +30,7 @@ RC=0 "home":   CAs: 'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'...'%any'
 RC=0 "home":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "home":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+SAREFTRACK+lKOD+rKOD; prio: 16,0; interface: eth0; kind=CK_PERMANENT
 | creating state object #1 at Z
-| orient home checking against if: eth0
+| orient home checking against if: eth0 (93.184.216.34:500)
 | orient home matching on public/private keys
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00

--- a/tests/unit/libpluto/lp19-certreplyselfR1/output1.txt
+++ b/tests/unit/libpluto/lp19-certreplyselfR1/output1.txt
@@ -18,7 +18,8 @@ processing whack msg time: X size: Y
 | counting wild cards for @moon.strongswan.org is 0
 | counting wild cards for (none) is 15
 | based upon ID_wildcard policy, the connection is a template.
-| orient rw-any checking against if: eth0
+| orient rw-any checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 132.213.238.7:500 %any 0.0.0.0:500 -> hp:none
@@ -114,7 +115,8 @@ RC=0 "rw-any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+S
 | find_host_connection2 returns rw-any
 ./certreplyselfR1 tentatively considering connection: rw-any
 | creating state object #1 at Z
-| orient rw-any checking against if: eth0
+| orient rw-any checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5

--- a/tests/unit/libpluto/lp20-certificateselfI2/output1.txt
+++ b/tests/unit/libpluto/lp20-certificateselfI2/output1.txt
@@ -17,7 +17,7 @@ processing whack msg time: X size: Y
 | certificate is valid
 | counting wild cards for carol@strongswan.org is 0
 | counting wild cards for @moon.strongswan.org is 0
-| orient home checking against if: eth0
+| orient home checking against if: eth0 (93.184.216.34:500)
 | orient home matching on public/private keys
 | find_host_pair: looking for me=<invalid>:500 %address him=132.213.238.7:500 exact-match
 | find_host_pair: concluded with <none>
@@ -33,7 +33,7 @@ RC=0 "home":   CAs: 'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'...'%any'
 RC=0 "home":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "home":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+SAREFTRACK+lKOD+rKOD; prio: 16,0; interface: eth0; kind=CK_PERMANENT
 | creating state object #1 at Z
-| orient home checking against if: eth0
+| orient home checking against if: eth0 (93.184.216.34:500)
 | orient home matching on public/private keys
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00

--- a/tests/unit/libpluto/lp21-certreplyselfR2/output1.txt
+++ b/tests/unit/libpluto/lp21-certreplyselfR2/output1.txt
@@ -18,7 +18,8 @@ processing whack msg time: X size: Y
 | counting wild cards for @moon.strongswan.org is 0
 | counting wild cards for (none) is 15
 | based upon ID_wildcard policy, the connection is a template.
-| orient rw-any checking against if: eth0
+| orient rw-any checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 132.213.238.7:500 %any 0.0.0.0:500 -> hp:none
@@ -116,7 +117,8 @@ RC=0 "rw-any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+S
 | find_host_connection2 returns rw-any
 ./certreplyselfR2 tentatively considering connection: rw-any
 | creating state object #1 at Z
-| orient rw-any checking against if: eth0
+| orient rw-any checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5

--- a/tests/unit/libpluto/lp21-certreplyselfR2/output2.txt
+++ b/tests/unit/libpluto/lp21-certreplyselfR2/output2.txt
@@ -18,7 +18,8 @@ processing whack msg time: X size: Y
 | counting wild cards for @moon.strongswan.org is 0
 | counting wild cards for (none) is 15
 | based upon ID_wildcard policy, the connection is a template.
-| orient rw-any checking against if: eth0
+| orient rw-any checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 132.213.238.7:500 %any 0.0.0.0:500 -> hp:none
@@ -116,7 +117,8 @@ RC=0 "rw-any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+S
 | find_host_connection2 returns rw-any
 ./certreplyselfR2 tentatively considering connection: rw-any
 | creating state object #1 at Z
-| orient rw-any checking against if: eth0
+| orient rw-any checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5

--- a/tests/unit/libpluto/lp22-certreplymanyR2/output1.txt
+++ b/tests/unit/libpluto/lp22-certreplymanyR2/output1.txt
@@ -18,7 +18,8 @@ processing whack msg time: X size: Y
 | counting wild cards for @moon.strongswan.org is 0
 | counting wild cards for (none) is 15
 | based upon ID_wildcard policy, the connection is a template.
-| orient rw-any checking against if: eth0
+| orient rw-any checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 132.213.238.7:500 %any 0.0.0.0:500 -> hp:none
@@ -35,7 +36,8 @@ processing whack msg time: X size: Y
 | certificate is valid
 | counting wild cards for @moon.strongswan.org is 0
 | counting wild cards for C=CA, ST=ON, L=Ottawa, O=Xelerance Corporation, OU=Openswan, CN=dave@openswan.org is 0
-| orient rw-dave checking against if: eth0
+| orient rw-dave checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %address him=192.168.0.200:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with <none>
@@ -58,7 +60,8 @@ processing whack msg time: X size: Y
 ./certreplyR2   loaded host cert file '../samples/gatewaycert/certs/carolCert.pem' (1493 bytes)
 | certificate is valid
 | counting wild cards for 93.184.216.34 is 0
-| orient rw-carol checking against if: eth0
+| orient rw-carol checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %address him=93.184.216.34:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %address him=192.168.0.200:500
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
@@ -176,7 +179,8 @@ RC=2      rw-any
 | find_host_connection2 returns rw-carol
 ./certreplyR2 tentatively considering connection: rw-carol
 | creating state object #1 at Z
-| orient rw-carol checking against if: eth0
+| orient rw-carol checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5

--- a/tests/unit/libpluto/lp23-davecertI1/output.txt
+++ b/tests/unit/libpluto/lp23-davecertI1/output.txt
@@ -14,7 +14,7 @@ processing whack msg time: X size: Y
 | certificate is valid
 | counting wild cards for C=CA, ST=ON, L=Ottawa, O=Xelerance Corporation, OU=Openswan, CN=dave@openswan.org is 0
 | counting wild cards for @moon.strongswan.org is 0
-| orient home checking against if: eth0
+| orient home checking against if: eth0 (0.0.0.0:500)
 | orient home matching on public/private keys
 | find_host_pair: looking for me=<invalid>:500 %address him=132.213.238.7:500 exact-match
 | find_host_pair: concluded with <none>
@@ -30,7 +30,7 @@ RC=0 "home":   CAs: 'C=CH, O=Linux strongSwan, CN=strongSwan Root CA'...'%any'
 RC=0 "home":   ike_life: 3600s; ipsec_life: 1200s; rekey_margin: 180s; rekey_fuzz: 100%; keyingtries: 1
 RC=0 "home":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+SAREFTRACK+lKOD+rKOD; prio: 16,0; interface: eth0; kind=CK_PERMANENT
 | creating state object #1 at Z
-| orient home checking against if: eth0
+| orient home checking against if: eth0 (0.0.0.0:500)
 | orient home matching on public/private keys
 | ICOOKIE:  8d 0e 0f 10  11 12 13 14
 | RCOOKIE:  00 00 00 00  00 00 00 00

--- a/tests/unit/libpluto/lp24-certreplydaveR2/output1.txt
+++ b/tests/unit/libpluto/lp24-certreplydaveR2/output1.txt
@@ -18,7 +18,8 @@ processing whack msg time: X size: Y
 | counting wild cards for @moon.strongswan.org is 0
 | counting wild cards for (none) is 15
 | based upon ID_wildcard policy, the connection is a template.
-| orient rw-any checking against if: eth0
+| orient rw-any checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 132.213.238.7:500 %any 0.0.0.0:500 -> hp:none
@@ -38,7 +39,8 @@ processing whack msg time: X size: Y
 ./certreplydaveR2   loaded host cert file '../samples/gatewaycert/certs/carolCert.pem' (1493 bytes)
 | certificate is valid
 | counting wild cards for 93.184.216.34 is 0
-| orient rw-carol checking against if: eth0
+| orient rw-carol checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %address him=93.184.216.34:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with <none>
@@ -57,7 +59,8 @@ processing whack msg time: X size: Y
 | certificate is valid
 | counting wild cards for @moon.strongswan.org is 0
 | counting wild cards for C=CA, ST=ON, L=Ottawa, O=Xelerance Corporation, OU=Openswan, CN=dave@openswan.org is 0
-| orient rw-dave checking against if: eth0
+| orient rw-dave checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %address him=192.168.0.200:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %address him=93.184.216.34:500
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
@@ -184,7 +187,8 @@ RC=2      rw-any
 | find_host_connection2 returns rw-carol
 ./certreplydaveR2 tentatively considering connection: rw-carol
 | creating state object #1 at Z
-| orient rw-carol checking against if: eth0
+| orient rw-carol checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5
@@ -1682,7 +1686,8 @@ sending 1452 bytes for STATE_PARENT_R1 through eth0:500 to 93.184.216.34:500 (us
 | find_host_connection2 returns rw-any
 ./certreplydaveR2 tentatively considering connection: rw-any
 | creating state object #3 at Z
-| orient rw-any checking against if: eth0
+| orient rw-any checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | ICOOKIE:  8d 0e 0f 10  11 12 13 14
 | RCOOKIE:  5d 73 ce 75  3d b1 db 6d
 | state hash entry 15

--- a/tests/unit/libpluto/lp25-wrongcacert/output1.txt
+++ b/tests/unit/libpluto/lp25-wrongcacert/output1.txt
@@ -18,7 +18,8 @@ processing whack msg time: X size: Y
 | counting wild cards for @moon.strongswan.org is 0
 | counting wild cards for (none) is 15
 | based upon ID_wildcard policy, the connection is a template.
-| orient rw-any checking against if: eth0
+| orient rw-any checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 132.213.238.7:500 %any 0.0.0.0:500 -> hp:none
@@ -114,7 +115,8 @@ RC=0 "rw-any":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+S
 | find_host_connection2 returns rw-any
 ./wrongcacert tentatively considering connection: rw-any
 | creating state object #1 at Z
-| orient rw-any checking against if: eth0
+| orient rw-any checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5

--- a/tests/unit/libpluto/lp26-davecertI2/output1.txt
+++ b/tests/unit/libpluto/lp26-davecertI2/output1.txt
@@ -17,7 +17,7 @@ processing whack msg time: X size: Y
 | certificate is valid
 | counting wild cards for C=CA, ST=ON, L=Ottawa, O=Xelerance Corporation, OU=Openswan, CN=dave@openswan.org is 0
 | counting wild cards for @moon.strongswan.org is 0
-| orient home checking against if: eth0
+| orient home checking against if: eth0 (0.0.0.0:500)
 | orient home matching on public/private keys
 | find_host_pair: looking for me=<invalid>:500 %address him=132.213.238.7:500 exact-match
 | find_host_pair: concluded with <none>
@@ -35,7 +35,7 @@ RC=0 "home":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+SAR
 | Changed path to directory '../samples/davecert/cacerts'
 ./davecertI2   loaded CA cert file 'strongswanCert.pem' (1350 bytes)
 | creating state object #1 at Z
-| orient home checking against if: eth0
+| orient home checking against if: eth0 (0.0.0.0:500)
 | orient home matching on public/private keys
 | ICOOKIE:  8d 0e 0f 10  11 12 13 14
 | RCOOKIE:  00 00 00 00  00 00 00 00

--- a/tests/unit/libpluto/lp27-IDhostpair/output.txt
+++ b/tests/unit/libpluto/lp27-IDhostpair/output.txt
@@ -13,7 +13,10 @@ processing whack msg time: X size: Y
 | Added new connection mytunnel with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for @openswan.testing.xelerance.com is 0
 | counting wild cards for @dnsh2h2 is 0
-| orient mytunnel checking against if: eth0
+| orient mytunnel checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946:500)
+| orient mytunnel checking against if: eth0 (192.168.1.1:4500)
+| orient mytunnel checking against if: eth0 (192.168.1.1:500)
+|     orient matched
 | find_host_pair: looking for me=192.168.1.1:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 192.168.1.1:500 %any 0.0.0.0:500 -> hp:none
@@ -35,7 +38,10 @@ processing whack msg time: X size: Y
 | Added new connection mytunnel2 with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for @openswan.testing.xelerance.com is 0
 | counting wild cards for @oswclient2 is 0
-| orient mytunnel2 checking against if: eth0
+| orient mytunnel2 checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946:500)
+| orient mytunnel2 checking against if: eth0 (192.168.1.1:4500)
+| orient mytunnel2 checking against if: eth0 (192.168.1.1:500)
+|     orient matched
 | find_host_pair: looking for me=192.168.1.1:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=192.168.1.1:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with mytunnel

--- a/tests/unit/libpluto/lp28-parentR2anychoice/output1.txt
+++ b/tests/unit/libpluto/lp28-parentR2anychoice/output1.txt
@@ -16,7 +16,8 @@ processing whack msg time: X size: Y
 | Added new connection any1--jj2 with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | counting wild cards for @jamesjohnson.emmjay.credil.org is 0
 | counting wild cards for @parker01.emmjay.credil.org is 0
-| orient any1--jj2 checking against if: eth0
+| orient any1--jj2 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 132.213.238.7:500 %any 0.0.0.0:500 -> hp:none
@@ -38,7 +39,8 @@ processing whack msg time: X size: Y
 | Added new connection maryjane1--jj2 with policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | counting wild cards for @jamesjohnson.emmjay.credil.org is 0
 | counting wild cards for @maryjane01.emmjay.credil.org is 0
-| orient maryjane1--jj2 checking against if: eth0
+| orient maryjane1--jj2 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with any1--jj2
@@ -135,7 +137,8 @@ RC=0 "any1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREF
 | find_host_connection2 returns maryjane1--jj2
 ./parentR2anychoice tentatively considering connection: maryjane1--jj2
 | creating state object #1 at Z
-| orient maryjane1--jj2 checking against if: eth0
+| orient maryjane1--jj2 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28

--- a/tests/unit/libpluto/lp33-IDanypair/output.txt
+++ b/tests/unit/libpluto/lp33-IDanypair/output.txt
@@ -12,7 +12,8 @@ processing whack msg time: X size: Y
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for (none) is 15
 | based upon ID_wildcard policy, the connection is a template.
-| orient OpenswanServer checking against if: eth0
+| orient OpenswanServer checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 132.213.238.7:500 %any 0.0.0.0:500 -> hp:none
@@ -32,7 +33,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDARM00000000000010 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDARM00000000000010 is 0
-| orient MPDARM00000000000010 checking against if: eth0
+| orient MPDARM00000000000010 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with OpenswanServer
@@ -54,7 +56,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDSIN00000120121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDSIN00000120121210 is 0
-| orient MPDSIN00000120121210 checking against if: eth0
+| orient MPDSIN00000120121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDARM00000000000010
@@ -77,7 +80,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDLOG00000220120210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDLOG00000220120210 is 0
-| orient MPDLOG00000220120210 checking against if: eth0
+| orient MPDLOG00000220120210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDSIN00000120121210
@@ -101,7 +105,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDHUE00000620111110 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDHUE00000620111110 is 0
-| orient MPDHUE00000620111110 checking against if: eth0
+| orient MPDHUE00000620111110 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDLOG00000220120210
@@ -126,7 +131,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDSAN00000820120410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDSAN00000820120410 is 0
-| orient MPDSAN00000820120410 checking against if: eth0
+| orient MPDSAN00000820120410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDHUE00000620111110
@@ -152,7 +158,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDSAN00001420120910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDSAN00001420120910 is 0
-| orient MPDSAN00001420120910 checking against if: eth0
+| orient MPDSAN00001420120910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDSAN00000820120410
@@ -179,7 +186,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDSAN00001520120910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDSAN00001520120910 is 0
-| orient MPDSAN00001520120910 checking against if: eth0
+| orient MPDSAN00001520120910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDSAN00001420120910
@@ -207,7 +215,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDLAR00001820130110 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDLAR00001820130110 is 0
-| orient MPDLAR00001820130110 checking against if: eth0
+| orient MPDLAR00001820130110 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDSAN00001520120910
@@ -236,7 +245,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDGUI00002020121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDGUI00002020121210 is 0
-| orient MPDGUI00002020121210 checking against if: eth0
+| orient MPDGUI00002020121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDLAR00001820130110
@@ -266,7 +276,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDTEN00002120120210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDTEN00002120120210 is 0
-| orient MPDTEN00002120120210 checking against if: eth0
+| orient MPDTEN00002120120210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDGUI00002020121210
@@ -297,7 +308,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDGIR00002220130410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDGIR00002220130410 is 0
-| orient MPDGIR00002220130410 checking against if: eth0
+| orient MPDGIR00002220130410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDTEN00002120120210
@@ -329,7 +341,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDCIU00002320120910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDCIU00002320120910 is 0
-| orient MPDCIU00002320120910 checking against if: eth0
+| orient MPDCIU00002320120910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDGIR00002220130410
@@ -362,7 +375,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDCIU00002420120910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDCIU00002420120910 is 0
-| orient MPDCIU00002420120910 checking against if: eth0
+| orient MPDCIU00002420120910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDCIU00002320120910
@@ -396,7 +410,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDHUE00002520121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDHUE00002520121210 is 0
-| orient MPDHUE00002520121210 checking against if: eth0
+| orient MPDHUE00002520121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDCIU00002420120910
@@ -431,7 +446,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDORE00002620120210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDORE00002620120210 is 0
-| orient MPDORE00002620120210 checking against if: eth0
+| orient MPDORE00002620120210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDHUE00002520121210
@@ -467,7 +483,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDTER00002820131010 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDTER00002820131010 is 0
-| orient MPDTER00002820131010 checking against if: eth0
+| orient MPDTER00002820131010 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDORE00002620120210
@@ -504,7 +521,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDJAE00002920100510 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDJAE00002920100510 is 0
-| orient MPDJAE00002920100510 checking against if: eth0
+| orient MPDJAE00002920100510 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDTER00002820131010
@@ -542,7 +560,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDLOG00003020121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDLOG00003020121210 is 0
-| orient MPDLOG00003020121210 checking against if: eth0
+| orient MPDLOG00003020121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDJAE00002920100510
@@ -581,7 +600,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDSEV00003220110110 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDSEV00003220110110 is 0
-| orient MPDSEV00003220110110 checking against if: eth0
+| orient MPDSEV00003220110110 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDLOG00003020121210
@@ -621,7 +641,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDBCN00003320061110 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDBCN00003320061110 is 0
-| orient MPDBCN00003320061110 checking against if: eth0
+| orient MPDBCN00003320061110 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDSEV00003220110110
@@ -662,7 +683,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDVIZ00003420120910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDVIZ00003420120910 is 0
-| orient MPDVIZ00003420120910 checking against if: eth0
+| orient MPDVIZ00003420120910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDBCN00003320061110
@@ -704,7 +726,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMEL00003620091210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMEL00003620091210 is 0
-| orient MPDMEL00003620091210 checking against if: eth0
+| orient MPDMEL00003620091210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDVIZ00003420120910
@@ -747,7 +770,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDZGZ00004020121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDZGZ00004020121210 is 0
-| orient MPDZGZ00004020121210 checking against if: eth0
+| orient MPDZGZ00004020121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMEL00003620091210
@@ -791,7 +815,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDORE00004120121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDORE00004120121210 is 0
-| orient MPDORE00004120121210 checking against if: eth0
+| orient MPDORE00004120121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDZGZ00004020121210
@@ -836,7 +861,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAL00004220090610 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAL00004220090610 is 0
-| orient MPDMAL00004220090610 checking against if: eth0
+| orient MPDMAL00004220090610 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDORE00004120121210
@@ -882,7 +908,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDVAL00004320080110 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDVAL00004320080110 is 0
-| orient MPDVAL00004320080110 checking against if: eth0
+| orient MPDVAL00004320080110 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAL00004220090610
@@ -929,7 +956,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAL00004420090610 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAL00004420090610 is 0
-| orient MPDMAL00004420090610 checking against if: eth0
+| orient MPDMAL00004420090610 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDVAL00004320080110
@@ -977,7 +1005,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDTEN00004520120810 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDTEN00004520120810 is 0
-| orient MPDTEN00004520120810 checking against if: eth0
+| orient MPDTEN00004520120810 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAL00004420090610
@@ -1026,7 +1055,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDTEN00004620120810 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDTEN00004620120810 is 0
-| orient MPDTEN00004620120810 checking against if: eth0
+| orient MPDTEN00004620120810 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDTEN00004520120810
@@ -1076,7 +1106,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAL00004720090610 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAL00004720090610 is 0
-| orient MPDMAL00004720090610 checking against if: eth0
+| orient MPDMAL00004720090610 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDTEN00004620120810
@@ -1127,7 +1158,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAL00004820090610 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAL00004820090610 is 0
-| orient MPDMAL00004820090610 checking against if: eth0
+| orient MPDMAL00004820090610 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAL00004720090610
@@ -1179,7 +1211,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAL00004920090610 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAL00004920090610 is 0
-| orient MPDMAL00004920090610 checking against if: eth0
+| orient MPDMAL00004920090610 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAL00004820090610
@@ -1232,7 +1265,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAL00005020090610 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAL00005020090610 is 0
-| orient MPDMAL00005020090610 checking against if: eth0
+| orient MPDMAL00005020090610 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAL00004920090610
@@ -1286,7 +1320,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAL00005120090610 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAL00005120090610 is 0
-| orient MPDMAL00005120090610 checking against if: eth0
+| orient MPDMAL00005120090610 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAL00005020090610
@@ -1341,7 +1376,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMUR00005420071010 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMUR00005420071010 is 0
-| orient MPDMUR00005420071010 checking against if: eth0
+| orient MPDMUR00005420071010 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAL00005120090610
@@ -1397,7 +1433,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDCOR00005920090610 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDCOR00005920090610 is 0
-| orient MPDCOR00005920090610 checking against if: eth0
+| orient MPDCOR00005920090610 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMUR00005420071010
@@ -1454,7 +1491,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDALM00006220130110 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDALM00006220130110 is 0
-| orient MPDALM00006220130110 checking against if: eth0
+| orient MPDALM00006220130110 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDCOR00005920090610
@@ -1512,7 +1550,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDALM00006320130110 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDALM00006320130110 is 0
-| orient MPDALM00006320130110 checking against if: eth0
+| orient MPDALM00006320130110 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDALM00006220130110
@@ -1571,7 +1610,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDALM00006420130110 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDALM00006420130110 is 0
-| orient MPDALM00006420130110 checking against if: eth0
+| orient MPDALM00006420130110 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDALM00006320130110
@@ -1631,7 +1671,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDBAL00007220120910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDBAL00007220120910 is 0
-| orient MPDBAL00007220120910 checking against if: eth0
+| orient MPDBAL00007220120910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDALM00006420130110
@@ -1692,7 +1733,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDBAL00007320120910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDBAL00007320120910 is 0
-| orient MPDBAL00007320120910 checking against if: eth0
+| orient MPDBAL00007320120910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDBAL00007220120910
@@ -1754,7 +1796,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDBAL00007420120910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDBAL00007420120910 is 0
-| orient MPDBAL00007420120910 checking against if: eth0
+| orient MPDBAL00007420120910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDBAL00007320120910
@@ -1817,7 +1860,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDVIZ00007620131010 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDVIZ00007620131010 is 0
-| orient MPDVIZ00007620131010 checking against if: eth0
+| orient MPDVIZ00007620131010 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDBAL00007420120910
@@ -1881,7 +1925,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDALI00007720100510 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDALI00007720100510 is 0
-| orient MPDALI00007720100510 checking against if: eth0
+| orient MPDALI00007720100510 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDVIZ00007620131010
@@ -1946,7 +1991,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDVAL00007920080710 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDVAL00007920080710 is 0
-| orient MPDVAL00007920080710 checking against if: eth0
+| orient MPDVAL00007920080710 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDALI00007720100510
@@ -2012,7 +2058,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDVAL00008020080710 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDVAL00008020080710 is 0
-| orient MPDVAL00008020080710 checking against if: eth0
+| orient MPDVAL00008020080710 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDVAL00007920080710
@@ -2079,7 +2126,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDGRA00008720121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDGRA00008720121210 is 0
-| orient MPDGRA00008720121210 checking against if: eth0
+| orient MPDGRA00008720121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDVAL00008020080710
@@ -2147,7 +2195,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDLAS00009020120410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDLAS00009020120410 is 0
-| orient MPDLAS00009020120410 checking against if: eth0
+| orient MPDLAS00009020120410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDGRA00008720121210
@@ -2216,7 +2265,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDLAS00009120120410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDLAS00009120120410 is 0
-| orient MPDLAS00009120120410 checking against if: eth0
+| orient MPDLAS00009120120410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDLAS00009020120410
@@ -2286,7 +2336,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDLAS00009220120410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDLAS00009220120410 is 0
-| orient MPDLAS00009220120410 checking against if: eth0
+| orient MPDLAS00009220120410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDLAS00009120120410
@@ -2357,7 +2408,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDBAL00009820121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDBAL00009820121210 is 0
-| orient MPDBAL00009820121210 checking against if: eth0
+| orient MPDBAL00009820121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDLAS00009220120410
@@ -2429,7 +2481,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDCAD00009920120910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDCAD00009920120910 is 0
-| orient MPDCAD00009920120910 checking against if: eth0
+| orient MPDCAD00009920120910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDBAL00009820121210
@@ -2502,7 +2555,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDBAL00010020121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDBAL00010020121210 is 0
-| orient MPDBAL00010020121210 checking against if: eth0
+| orient MPDBAL00010020121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDCAD00009920120910
@@ -2576,7 +2630,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDBAL00010120121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDBAL00010120121210 is 0
-| orient MPDBAL00010120121210 checking against if: eth0
+| orient MPDBAL00010120121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDBAL00010020121210
@@ -2651,7 +2706,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDVAL00012020081210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDVAL00012020081210 is 0
-| orient MPDVAL00012020081210 checking against if: eth0
+| orient MPDVAL00012020081210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDBAL00010120121210
@@ -2727,7 +2783,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAD00012820101210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAD00012820101210 is 0
-| orient MPDMAD00012820101210 checking against if: eth0
+| orient MPDMAD00012820101210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDVAL00012020081210
@@ -2804,7 +2861,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDBCN00013220120410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDBCN00013220120410 is 0
-| orient MPDBCN00013220120410 checking against if: eth0
+| orient MPDBCN00013220120410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAD00012820101210
@@ -2882,7 +2940,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDLAS00013520121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDLAS00013520121210 is 0
-| orient MPDLAS00013520121210 checking against if: eth0
+| orient MPDLAS00013520121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDBCN00013220120410
@@ -2961,7 +3020,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDBAL00015120131010 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDBAL00015120131010 is 0
-| orient MPDBAL00015120131010 checking against if: eth0
+| orient MPDBAL00015120131010 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDLAS00013520121210
@@ -3041,7 +3101,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMUR00015420120210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMUR00015420120210 is 0
-| orient MPDMUR00015420120210 checking against if: eth0
+| orient MPDMUR00015420120210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDBAL00015120131010
@@ -3122,7 +3183,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMUR00016120120410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMUR00016120120410 is 0
-| orient MPDMUR00016120120410 checking against if: eth0
+| orient MPDMUR00016120120410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMUR00015420120210
@@ -3204,7 +3266,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMUR00016220120410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMUR00016220120410 is 0
-| orient MPDMUR00016220120410 checking against if: eth0
+| orient MPDMUR00016220120410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMUR00016120120410
@@ -3287,7 +3350,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDALI00016520101210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDALI00016520101210 is 0
-| orient MPDALI00016520101210 checking against if: eth0
+| orient MPDALI00016520101210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMUR00016220120410
@@ -3371,7 +3435,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDVAL00017320090910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDVAL00017320090910 is 0
-| orient MPDVAL00017320090910 checking against if: eth0
+| orient MPDVAL00017320090910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDALI00016520101210
@@ -3456,7 +3521,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDVAL00017420090910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDVAL00017420090910 is 0
-| orient MPDVAL00017420090910 checking against if: eth0
+| orient MPDVAL00017420090910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDVAL00017320090910
@@ -3542,7 +3608,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDCAD00017620130910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDCAD00017620130910 is 0
-| orient MPDCAD00017620130910 checking against if: eth0
+| orient MPDCAD00017620130910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDVAL00017420090910
@@ -3629,7 +3696,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAL00020220120210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAL00020220120210 is 0
-| orient MPDMAL00020220120210 checking against if: eth0
+| orient MPDMAL00020220120210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDCAD00017620130910
@@ -3717,7 +3785,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMUR00021120121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMUR00021120121210 is 0
-| orient MPDMUR00021120121210 checking against if: eth0
+| orient MPDMUR00021120121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAL00020220120210
@@ -3806,7 +3875,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMUR00021220121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMUR00021220121210 is 0
-| orient MPDMUR00021220121210 checking against if: eth0
+| orient MPDMUR00021220121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMUR00021120121210
@@ -3896,7 +3966,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDCAS00022220120410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDCAS00022220120410 is 0
-| orient MPDCAS00022220120410 checking against if: eth0
+| orient MPDCAS00022220120410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMUR00021220121210
@@ -3987,7 +4058,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDCOR00023320120510 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDCOR00023320120510 is 0
-| orient MPDCOR00023320120510 checking against if: eth0
+| orient MPDCOR00023320120510 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDCAS00022220120410
@@ -4079,7 +4151,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDCOR00023420120510 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDCOR00023420120510 is 0
-| orient MPDCOR00023420120510 checking against if: eth0
+| orient MPDCOR00023420120510 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDCOR00023320120510
@@ -4172,7 +4245,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDCOR00023520120510 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDCOR00023520120510 is 0
-| orient MPDCOR00023520120510 checking against if: eth0
+| orient MPDCOR00023520120510 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDCOR00023420120510
@@ -4266,7 +4340,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMUR00024120130410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMUR00024120130410 is 0
-| orient MPDMUR00024120130410 checking against if: eth0
+| orient MPDMUR00024120130410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDCOR00023520120510
@@ -4361,7 +4436,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAL00026020120910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAL00026020120910 is 0
-| orient MPDMAL00026020120910 checking against if: eth0
+| orient MPDMAL00026020120910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMUR00024120130410
@@ -4457,7 +4533,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAL00026120120910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAL00026120120910 is 0
-| orient MPDMAL00026120120910 checking against if: eth0
+| orient MPDMAL00026120120910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAL00026020120910
@@ -4554,7 +4631,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAL00026220120910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAL00026220120910 is 0
-| orient MPDMAL00026220120910 checking against if: eth0
+| orient MPDMAL00026220120910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAL00026120120910
@@ -4652,7 +4730,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAD00026320120910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAD00026320120910 is 0
-| orient MPDMAD00026320120910 checking against if: eth0
+| orient MPDMAD00026320120910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAL00026220120910
@@ -4751,7 +4830,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAD00026420120910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAD00026420120910 is 0
-| orient MPDMAD00026420120910 checking against if: eth0
+| orient MPDMAD00026420120910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAD00026320120910
@@ -4851,7 +4931,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDCAS00027920130410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDCAS00027920130410 is 0
-| orient MPDCAS00027920130410 checking against if: eth0
+| orient MPDCAS00027920130410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAD00026420120910
@@ -4952,7 +5033,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDALI00030220120410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDALI00030220120410 is 0
-| orient MPDALI00030220120410 checking against if: eth0
+| orient MPDALI00030220120410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDCAS00027920130410
@@ -5054,7 +5136,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAL00032520130410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAL00032520130410 is 0
-| orient MPDMAL00032520130410 checking against if: eth0
+| orient MPDMAL00032520130410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDALI00030220120410
@@ -5157,7 +5240,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDALI00033520120910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDALI00033520120910 is 0
-| orient MPDALI00033520120910 checking against if: eth0
+| orient MPDALI00033520120910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAL00032520130410
@@ -5261,7 +5345,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAD00034520121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAD00034520121210 is 0
-| orient MPDMAD00034520121210 checking against if: eth0
+| orient MPDMAD00034520121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDALI00033520120910
@@ -5366,7 +5451,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAD00034620121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAD00034620121210 is 0
-| orient MPDMAD00034620121210 checking against if: eth0
+| orient MPDMAD00034620121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAD00034520121210
@@ -5472,7 +5558,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDALI00036120130110 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDALI00036120130110 is 0
-| orient MPDALI00036120130110 checking against if: eth0
+| orient MPDALI00036120130110 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAD00034620121210
@@ -5579,7 +5666,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAD00043520130410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAD00043520130410 is 0
-| orient MPDMAD00043520130410 checking against if: eth0
+| orient MPDMAD00043520130410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDALI00036120130110
@@ -5687,7 +5775,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAD00043620130410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAD00043620130410 is 0
-| orient MPDMAD00043620130410 checking against if: eth0
+| orient MPDMAD00043620130410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAD00043520130410
@@ -5796,7 +5885,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAD00043720130410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAD00043720130410 is 0
-| orient MPDMAD00043720130410 checking against if: eth0
+| orient MPDMAD00043720130410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAD00043620130410
@@ -5906,7 +5996,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAD00045620130510 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAD00045620130510 is 0
-| orient MPDMAD00045620130510 checking against if: eth0
+| orient MPDMAD00045620130510 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAD00043720130410
@@ -6017,7 +6108,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAD00045720130510 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAD00045720130510 is 0
-| orient MPDMAD00045720130510 checking against if: eth0
+| orient MPDMAD00045720130510 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAD00045620130510
@@ -6129,7 +6221,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDMAD00050320130910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDMAD00050320130910 is 0
-| orient MPDMAD00050320130910 checking against if: eth0
+| orient MPDMAD00050320130910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAD00045720130510
@@ -6242,7 +6335,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDVAL00052720111110 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDVAL00052720111110 is 0
-| orient MPDVAL00052720111110 checking against if: eth0
+| orient MPDVAL00052720111110 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDMAD00050320130910
@@ -6356,7 +6450,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDVAL00058020120410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDVAL00058020120410 is 0
-| orient MPDVAL00058020120410 checking against if: eth0
+| orient MPDVAL00058020120410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDVAL00052720111110
@@ -6471,7 +6566,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDVAL00064020120910 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDVAL00064020120910 is 0
-| orient MPDVAL00064020120910 checking against if: eth0
+| orient MPDVAL00064020120910 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDVAL00058020120410
@@ -6587,7 +6683,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDVAL00067120121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDVAL00067120121210 is 0
-| orient MPDVAL00067120121210 checking against if: eth0
+| orient MPDVAL00067120121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDVAL00064020120910
@@ -6704,7 +6801,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDVAL00067220121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDVAL00067220121210 is 0
-| orient MPDVAL00067220121210 checking against if: eth0
+| orient MPDVAL00067220121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDVAL00067120121210
@@ -6822,7 +6920,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDVAL00067320121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDVAL00067320121210 is 0
-| orient MPDVAL00067320121210 checking against if: eth0
+| orient MPDVAL00067320121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDVAL00067220121210
@@ -6941,7 +7040,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDVAL00067420121210 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDVAL00067420121210 is 0
-| orient MPDVAL00067420121210 checking against if: eth0
+| orient MPDVAL00067420121210 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDVAL00067320121210
@@ -7061,7 +7161,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDVAL00072220130410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDVAL00072220130410 is 0
-| orient MPDVAL00072220130410 checking against if: eth0
+| orient MPDVAL00072220130410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDVAL00067420121210
@@ -7182,7 +7283,8 @@ processing whack msg time: X size: Y
 | Added new connection MPDVAL00072320130410 with policy RSASIG+ENCRYPT+TUNNEL+PFS+DONTREKEY+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for 132.213.238.7 is 0
 | counting wild cards for @MPDVAL00072320130410 is 0
-| orient MPDVAL00072320130410 checking against if: eth0
+| orient MPDVAL00072320130410 checking against if: eth0 (132.213.238.7:500)
+|     orient matched
 | find_host_pair: looking for me=132.213.238.7:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=132.213.238.7:500 %any him=0.0.0.0:500
 | find_host_pair: concluded with MPDVAL00072220130410

--- a/tests/unit/libpluto/lp35-threeconns/output.txt
+++ b/tests/unit/libpluto/lp35-threeconns/output.txt
@@ -10,7 +10,7 @@ processing whack msg time: X size: Y
 | Added new connection vzhost1-vzhost-mondev with policy RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK
 | counting wild cards for @vzhost1.xelerance.com is 0
 | counting wild cards for @vzhost-mondev.xelerance.com is 0
-| orient vzhost1-vzhost-mondev checking against if: eth0
+| orient vzhost1-vzhost-mondev checking against if: eth0 (:500)
 | orient vzhost1-vzhost-mondev matching on public/private keys
 | find_ID_host_pair: looking for me=@vzhost1.xelerance.com him=@vzhost-mondev.xelerance.com (exact)
 |   concluded with <none>
@@ -22,7 +22,8 @@ processing whack msg time: X size: Y
 | Added new connection patrickn-vzhost1 with policy PSK+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+SAREFTRACK
 | counting wild cards for @vzhost1 is 0
 | counting wild cards for @patrickn is 0
-| orient patrickn-vzhost1 checking against if: eth0
+| orient patrickn-vzhost1 checking against if: eth0 (:500)
+|     orient matched
 | find_host_pair: looking for me=173.230.133.71:500 %address him=69.165.217.138:500 exact-match
 | find_host_pair: concluded with <none>
 | connect_to_host_pair: 173.230.133.71:500 %address 69.165.217.138:500 -> hp:none
@@ -41,7 +42,8 @@ processing whack msg time: X size: Y
 | Added new connection jason-vzhost1 with policy PSK+ENCRYPT+TUNNEL+PFS+SAREFTRACK
 | counting wild cards for @jason is 0
 | counting wild cards for @vzhost1.xelerance.com is 0
-| orient jason-vzhost1 checking against if: eth0
+| orient jason-vzhost1 checking against if: eth0 (:500)
+|     orient matched
 | find_host_pair: looking for me=173.230.133.71:500 %any him=0.0.0.0:500 exact-match
 | find_host_pair: comparing to me=173.230.133.71:500 %address him=69.165.217.138:500
 | find_host_pair: concluded with <none>

--- a/tests/unit/libpluto/lp40-orientafterprivate/output.txt
+++ b/tests/unit/libpluto/lp40-orientafterprivate/output.txt
@@ -36,7 +36,8 @@ RC=2      parker1--jj2
 listening now
 Pre-amble (offset: X): #!-pluto-whack-file- recorded on FOO
 ./orienttest listening for IKE messages
-| orient ikev2:parker--jj checking against if: eth0
+| orient ikev2:parker--jj checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946)
+| orient ikev2:parker--jj checking against if: eth0 (192.168.1.1)
 | orient ikev2:parker--jj matching on public/private keys
 | connection ikev2:parker--jj is now oriented
 | find_host_pair: looking for me=<invalid>:500 %address him=132.213.238.7:500 exact-match
@@ -46,7 +47,8 @@ Pre-amble (offset: X): #!-pluto-whack-file- recorded on FOO
 |                   comparing to me=@parker01.emmjay.credil.org him=@jamesjohnson.emmjay.credil.org (ikev2:parker--jj)
 |     now best match
 |   concluded with ikev2:parker--jj
-| orient parker1--jj2 checking against if: eth0
+| orient parker1--jj2 checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1)
 | connection parker1--jj2 is now oriented
 | find_host_pair: looking for me=192.168.1.1:500 %address him=132.213.238.7:500 exact-match
 | find_host_pair: comparing to me=<invalid>:500 %address him=132.213.238.7:500

--- a/tests/unit/libpluto/lp40-orientafterprivate/output.txt
+++ b/tests/unit/libpluto/lp40-orientafterprivate/output.txt
@@ -36,8 +36,9 @@ RC=2      parker1--jj2
 listening now
 Pre-amble (offset: X): #!-pluto-whack-file- recorded on FOO
 ./orienttest listening for IKE messages
-| orient ikev2:parker--jj checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946)
-| orient ikev2:parker--jj checking against if: eth0 (192.168.1.1)
+| orient ikev2:parker--jj checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946:500)
+| orient ikev2:parker--jj checking against if: eth0 (192.168.1.1:4500)
+| orient ikev2:parker--jj checking against if: eth0 (192.168.1.1:500)
 | orient ikev2:parker--jj matching on public/private keys
 | connection ikev2:parker--jj is now oriented
 | find_host_pair: looking for me=<invalid>:500 %address him=132.213.238.7:500 exact-match
@@ -47,8 +48,10 @@ Pre-amble (offset: X): #!-pluto-whack-file- recorded on FOO
 |                   comparing to me=@parker01.emmjay.credil.org him=@jamesjohnson.emmjay.credil.org (ikev2:parker--jj)
 |     now best match
 |   concluded with ikev2:parker--jj
-| orient parker1--jj2 checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946)
-| orient parker1--jj2 checking against if: eth0 (192.168.1.1)
+| orient parker1--jj2 checking against if: eth0 (2606:2800:220:1:248:1893:25c8:1946:500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:4500)
+| orient parker1--jj2 checking against if: eth0 (192.168.1.1:500)
+|     orient matched
 | connection parker1--jj2 is now oriented
 | find_host_pair: looking for me=192.168.1.1:500 %address him=132.213.238.7:500 exact-match
 | find_host_pair: comparing to me=<invalid>:500 %address him=132.213.238.7:500

--- a/tests/unit/libpluto/seam_host_dave.c
+++ b/tests/unit/libpluto/seam_host_dave.c
@@ -16,6 +16,7 @@ struct iface_port dave_if1 = {
 
 void init_dave_interface(void)
 {
+  init_iface_port(&dave_if1);
   dave_if1.next = interfaces;
   dave_if1.ip_addr.u.v4.sin_addr.s_addr=htonl(0x5db8d823); /* 93.184.216.35 example.com */
   interfaces = &dave_if1;

--- a/tests/unit/libpluto/seam_host_jamesjohnson.c
+++ b/tests/unit/libpluto/seam_host_jamesjohnson.c
@@ -17,7 +17,8 @@ struct iface_port jj_if1 = {
 
 void init_jamesjohnson_interface(void)
 {
-  jj_if1.ip_addr.u.v4.sin_addr.s_addr = htonl(jj_if1.ip_addr.u.v4.sin_addr.s_addr);
+  inet_pton(AF_INET, "132.213.238.7", &jj_if1.ip_addr.u.v4.sin_addr);
+  init_iface_port(&jj_if1);
   jj_if1.next = interfaces;
   interfaces = &jj_if1;
 }

--- a/tests/unit/libpluto/seam_host_parker.c
+++ b/tests/unit/libpluto/seam_host_parker.c
@@ -15,6 +15,17 @@ struct iface_port parker_if1 = {
 	.change    = IFN_KEEP
 };
 
+struct iface_port parker_if1b = {
+	.ip_dev = &parker_ifd1,
+	.port   = 4500,
+	.ip_addr.u.v4.sin_family = AF_INET,
+	.ip_addr.u.v4.sin_addr.s_addr = 0xc0a80101, /* 192.168.1.1 -- see htonl() below */
+	.fd     = -1,
+	.next   = NULL,
+	.ike_float = 0,
+	.change    = IFN_KEEP
+};
+
 struct iface_port parker_if2 = {
 	.ip_dev = &parker_ifd1,
 	.port   = 500,
@@ -31,12 +42,17 @@ void init_parker_interface(void)
   inet_pton(AF_INET6, "2606:2800:220:1:248:1893:25c8:1946", &parker_if2.ip_addr.u.v6.sin6_addr);
   init_iface_port(&parker_if2);
 
+  parker_if1b.ip_addr.u.v4.sin_addr.s_addr = htonl(parker_if1b.ip_addr.u.v4.sin_addr.s_addr);
+  init_iface_port(&parker_if1b);
+
   parker_if1.ip_addr.u.v4.sin_addr.s_addr = htonl(parker_if1.ip_addr.u.v4.sin_addr.s_addr);
   init_iface_port(&parker_if1);
 
 
   parker_if1.next = interfaces;
   interfaces = &parker_if1;
+  parker_if1b.next = interfaces;
+  interfaces = &parker_if1b;
   parker_if2.next = interfaces;
   interfaces = &parker_if2;
 }

--- a/tests/unit/libpluto/seam_host_parker.c
+++ b/tests/unit/libpluto/seam_host_parker.c
@@ -1,3 +1,5 @@
+#include <arpa/inet.h>
+
 struct iface_dev  parker_ifd1 = {
 	.id_count = 1,
 	.id_vname = "ipsec0",

--- a/tests/unit/libpluto/seam_host_parker.c
+++ b/tests/unit/libpluto/seam_host_parker.c
@@ -15,9 +15,28 @@ struct iface_port parker_if1 = {
 	.change    = IFN_KEEP
 };
 
+struct iface_port parker_if2 = {
+	.ip_dev = &parker_ifd1,
+	.port   = 500,
+	.ip_addr.u.v6.sin6_family = AF_INET6,
+        /* filled in below */
+	.fd     = -1,
+	.next   = NULL,
+	.ike_float = 0,
+	.change    = IFN_KEEP
+};
+
 void init_parker_interface(void)
 {
+  inet_pton(AF_INET6, "2606:2800:220:1:248:1893:25c8:1946", &parker_if2.ip_addr.u.v6.sin6_addr);
+  init_iface_port(&parker_if2);
+
   parker_if1.ip_addr.u.v4.sin_addr.s_addr = htonl(parker_if1.ip_addr.u.v4.sin_addr.s_addr);
+  init_iface_port(&parker_if1);
+
+
   parker_if1.next = interfaces;
   interfaces = &parker_if1;
+  parker_if2.next = interfaces;
+  interfaces = &parker_if2;
 }

--- a/tests/unit/libpluto/seam_host_rw.c
+++ b/tests/unit/libpluto/seam_host_rw.c
@@ -16,8 +16,8 @@ struct iface_port rw_if1 = {
 
 void init_rw_interface(void)
 {
+  rw_if1.ip_addr.u.v4.sin_addr.s_addr=htonl(0x5db8d822); /* 93.184.216.34 example.com */
   init_iface_port(&rw_if1);
   rw_if1.next = interfaces;
-  rw_if1.ip_addr.u.v4.sin_addr.s_addr=htonl(0x5db8d822); /* 93.184.216.34 example.com */
   interfaces = &rw_if1;
 }

--- a/tests/unit/libpluto/seam_host_rw.c
+++ b/tests/unit/libpluto/seam_host_rw.c
@@ -16,6 +16,7 @@ struct iface_port rw_if1 = {
 
 void init_rw_interface(void)
 {
+  init_iface_port(&rw_if1);
   rw_if1.next = interfaces;
   rw_if1.ip_addr.u.v4.sin_addr.s_addr=htonl(0x5db8d822); /* 93.184.216.34 example.com */
   interfaces = &rw_if1;


### PR DESCRIPTION
This deals with problm #4681 -- the origin of the problem is that when orient is based upon private key possession, that the interface was simply the first one available. But the interface is used to find a socket on which to send the packet, and if an IPv6 socket was first, then it would try to send an IPv4 packet down an IPv6, which on Linux results on a network unreachable.
It would also have resulted in a packet from port 4500 when it should have been port 500.
