### PR TITLE
T4812 dns site local

### DIFF
--- a/lib/libipsecconf/keywords.c
+++ b/lib/libipsecconf/keywords.c
@@ -38,6 +38,7 @@
 #include "ipsecconf/parserlast.h"
 
 #define VALUES_INITIALIZER(t)	{ t, sizeof(t)/ sizeof(t[0]) }
+#undef KEYWORD_PARSE_DEBUG 
 
 /*
  * values for keyword types  (used for debugging)
@@ -667,7 +668,7 @@ unsigned int parser_loose_enum_arg(struct keyword *k, const char *s, char **rest
 #ifdef KEYWORD_PARSE_DEBUG
     {
         char kdtypebuf[KEYWORD_NAME_BUFLEN];
-        fprintf(stderr, "loose enum for %s is %d\n", keyword_name(&kt_values_list, kd->type, kdtypebuf),
+        fprintf(stderr, "loose enum(%s) for %s is %d\n", s, keyword_name(&kt_values_list, kd->type, kdtypebuf),
                 kd->loose_enum_value);
     }
 #endif

--- a/programs/pluto/connections.c
+++ b/programs/pluto/connections.c
@@ -731,9 +731,9 @@ check_connection_end(const struct whack_end *this, const struct whack_end *that
 	 * !!! overloaded use of RC_CLASH
 	 */
 	loglog(RC_CLASH, "address family inconsistency in this connection=%s host=%s/nexthop=%s"
-	       , aftoinfo(wm->addr_family)->name
-	       , aftoinfo(addrtypeof(&this->host_addr))->name
-	       , aftoinfo(addrtypeof(&this->host_nexthop))->name);
+	       , (wm->addr_family)     ? aftoinfo(wm->addr_family)->name                 : "NULL"
+	       , (&this->host_addr)    ? aftoinfo(addrtypeof(&this->host_addr))->name    : "NULL"
+	       , (&this->host_nexthop) ? aftoinfo(addrtypeof(&this->host_nexthop))->name : "NULL");
 	return FALSE;
     }
 

--- a/tests/functional/08-sitelocalv6/.gdbinit
+++ b/tests/functional/08-sitelocalv6/.gdbinit
@@ -1,0 +1,2 @@
+file ../../../OBJ.linux.x86_64/programs/readwriteconf/readwriteconf
+set args --config moon.conf

--- a/tests/functional/08-sitelocalv6/Makefile
+++ b/tests/functional/08-sitelocalv6/Makefile
@@ -1,0 +1,30 @@
+# Makefile for the Openswan in-tree test cases
+# Copyright (C) 2014 Michael Richardson <mcr@xelerance.com>
+#
+# This program is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License as published by the
+# Free Software Foundation; either version 2 of the License, or (at your
+# option) any later version.  See <http://www.fsf.org/copyleft/gpl.txt>.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+# or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+
+OPENSWANSRCDIR?=$(shell cd ../../..; pwd)
+srcdir?=${OPENSWANSRCDIR}/tests/functional/01-confread
+
+include ${OPENSWANSRCDIR}/Makefile.inc
+
+READWRITE=${OBJDIRTOP}/programs/readwriteconf/readwriteconf
+
+check:
+	mkdir -p ../OUTPUTS
+	${READWRITE} --debug --config moon.conf | tee ../OUTPUTS/moon.conf.raw | diff - moon.conf.out
+
+update:
+	cp ../OUTPUTS/moon.conf.raw     moon.conf.out
+
+
+
+

--- a/tests/functional/08-sitelocalv6/description.txt
+++ b/tests/functional/08-sitelocalv6/description.txt
@@ -1,0 +1,3 @@
+This test validates that left=v6-site-local address is parsed properly by pluto.
+
+

--- a/tests/functional/08-sitelocalv6/moon.conf
+++ b/tests/functional/08-sitelocalv6/moon.conf
@@ -1,0 +1,12 @@
+# /etc/ipsec.conf - strongSwan IPsec configuration file
+
+version 2
+
+conn host-host
+	left=fec0::1
+	leftcert=moonCert.pem
+	leftid=@moon.strongswan.org
+	right=fec0::2
+	rightid=@sun.strongswan.org
+	auto=add
+

--- a/tests/functional/08-sitelocalv6/moon.conf.out
+++ b/tests/functional/08-sitelocalv6/moon.conf.out
@@ -1,0 +1,57 @@
+opening file: moon.conf
+#conn net-net loaded
+#conn host-host loaded
+
+version 2.0
+
+config setup
+	nat_traversal=yes
+	virtual_private=%v4:10.0.0.0/8,%v4:192.168.0.0/16,%v4:172.16.0.0/12,%v4:25.0.0.0/8,%v6:fd00::/8,%v6:fe80::/10
+
+
+# begin conn net-net
+conn net-net
+	left=fec0::1
+	right=fec0::2
+	#also = host-host
+	leftid="@moon.strongswan.org"
+	leftsubnet=fec1::/16
+	leftcert=moonCert.pem
+	rightid="@sun.strongswan.org"
+	rightsubnet=fec2::/16
+	salifetime=1200
+	rekeymargin=180
+	keyingtries=1
+	ikelifetime=3600
+	auto=add
+	type=tunnel
+	compress=no
+	pfs=yes
+	rekey=yes
+	overlapip=no
+	authby=rsasig
+	phase2=esp
+# end conn net-net
+
+# begin conn host-host
+conn host-host
+	left=fec0::1
+	right=fec0::2
+	leftid="@moon.strongswan.org"
+	leftcert=moonCert.pem
+	rightid="@sun.strongswan.org"
+	salifetime=1200
+	rekeymargin=180
+	keyingtries=1
+	ikelifetime=3600
+	auto=add
+	type=tunnel
+	compress=no
+	pfs=yes
+	rekey=yes
+	overlapip=no
+	authby=rsasig
+	phase2=esp
+# end conn host-host
+
+# end of config

--- a/tests/functional/08-sitelocalv6/moon.conf.out
+++ b/tests/functional/08-sitelocalv6/moon.conf.out
@@ -1,49 +1,18 @@
 opening file: moon.conf
-#conn net-net loaded
 #conn host-host loaded
 
 version 2.0
 
 config setup
-	nat_traversal=yes
-	virtual_private=%v4:10.0.0.0/8,%v4:192.168.0.0/16,%v4:172.16.0.0/12,%v4:25.0.0.0/8,%v6:fd00::/8,%v6:fe80::/10
 
-
-# begin conn net-net
-conn net-net
-	left=fec0::1
-	right=fec0::2
-	#also = host-host
-	leftid="@moon.strongswan.org"
-	leftsubnet=fec1::/16
-	leftcert=moonCert.pem
-	rightid="@sun.strongswan.org"
-	rightsubnet=fec2::/16
-	salifetime=1200
-	rekeymargin=180
-	keyingtries=1
-	ikelifetime=3600
-	auto=add
-	type=tunnel
-	compress=no
-	pfs=yes
-	rekey=yes
-	overlapip=no
-	authby=rsasig
-	phase2=esp
-# end conn net-net
 
 # begin conn host-host
 conn host-host
 	left=fec0::1
-	right=fec0::2
 	leftid="@moon.strongswan.org"
 	leftcert=moonCert.pem
+	right=fec0::2
 	rightid="@sun.strongswan.org"
-	salifetime=1200
-	rekeymargin=180
-	keyingtries=1
-	ikelifetime=3600
 	auto=add
 	type=tunnel
 	compress=no


### PR DESCRIPTION
This fixes the configuration parse so that it tries parsing both v4 and v6 addresses found in left/right= before assuming that they are DNS names.
A functional test case validates that it works.