### PR TITLE
convince compiler that j is never too big

### DIFF
--- a/programs/pluto/kernel_netlink.c
+++ b/programs/pluto/kernel_netlink.c
@@ -1897,6 +1897,8 @@ retry:
     return rsp.u.sa.id.spi;
 }
 
+#define PROTO_COUNT 4
+
 /* install or remove eroute for SA Group */
 /* (identical to KLIPS version, but refactoring isn't waranteed yet */
 static bool
@@ -1906,7 +1908,7 @@ netlink_sag_eroute(struct state *st, struct spd_route *sr
     unsigned int inner_proto;
     enum eroute_type inner_esatype;
     ipsec_spi_t inner_spi;
-    struct pfkey_proto_info proto_info[4];
+    struct pfkey_proto_info proto_info[PROTO_COUNT];
     int i;
     bool tunnel;
 
@@ -1973,7 +1975,7 @@ netlink_sag_eroute(struct state *st, struct spd_route *sr
         inner_esatype = ET_IPIP;
 
         proto_info[i].encapsulation = ENCAPSULATION_MODE_TUNNEL;
-        for (j = i + 1; proto_info[j].proto; j++)
+        for (j = i + 1; j < PROTO_COUNT && proto_info[j].proto; j++)
         {
             proto_info[j].encapsulation = ENCAPSULATION_MODE_TRANSPORT;
         }

--- a/programs/pluto/kernel_pfkey.c
+++ b/programs/pluto/kernel_pfkey.c
@@ -1342,6 +1342,8 @@ pfkey_shunt_eroute(struct connection *c
     }
 }
 
+#define PROTO_COUNT 4
+
 /* install or remove eroute for SA Group */
 bool
 pfkey_sag_eroute(struct state *st, struct spd_route *sr
@@ -1350,7 +1352,7 @@ pfkey_sag_eroute(struct state *st, struct spd_route *sr
     unsigned int inner_proto;
     enum eroute_type inner_esatype;
     ipsec_spi_t inner_spi;
-    struct pfkey_proto_info proto_info[4];
+    struct pfkey_proto_info proto_info[PROTO_COUNT];
     int i;
     bool tunnel;
 
@@ -1419,7 +1421,7 @@ pfkey_sag_eroute(struct state *st, struct spd_route *sr
         inner_esatype = ET_IPIP;
 
         proto_info[i].encapsulation = ENCAPSULATION_MODE_TUNNEL;
-        for (j = i + 1; proto_info[j].proto; j++)
+        for (j = i + 1; j < PROTO_COUNT && proto_info[j].proto; j++)
         {
             proto_info[j].encapsulation = ENCAPSULATION_MODE_TRANSPORT;
         }


### PR DESCRIPTION
This fixes gcc 4.9 (x64) having -Werror=array-bounds on.
