### PR TITLE
T5149 delete reuses msgid

### DIFF
--- a/programs/pluto/ikev2.c
+++ b/programs/pluto/ikev2.c
@@ -1260,8 +1260,7 @@ void complete_v2_state_transition(struct msg_digest **mdp
 
     case STF_INLINE:         /* mcr: this is second time through complete
 			      * state transition, so the MD has already
-			      * been freed.
-			      0				  */
+			      * been freed.                              */
 			      *mdp = NULL;
 			      /* fall through to STF_OK */
 

--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -1124,6 +1124,10 @@ ikev2child_outC1_tail(struct pluto_crypto_req_cont *pcrc
     zero(reply_buffer);
     init_pbs(&reply_stream, reply_buffer, sizeof(reply_buffer), "reply packet");
 
+    openswan_log("starting rekey of CHILD SA for state=#%lu (expired) using PARENT SA #%lu"
+                 , st->st_replaced
+                 , st->st_clonedfrom);
+
     /* HDR out */
     {
         struct isakmp_hdr r_hdr = md->hdr;

--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -1018,13 +1018,6 @@ stf_status ikev2child_outC1(int whack_sock UNUSED
 
     insert_state(st);
 
-    /* create a new parent event to rekey again */
-    delete_event(parentst);
-    event_schedule(EVENT_SA_REPLACE, c->sa_ike_life_seconds, parentst);
-
-    /* XXX -- this needs a new child state value */
-    //change_state(st, STATE_PARENT_I2);
-
     // record which state we are aiming to replace.
     st->st_replaced = replacing;
 
@@ -1629,9 +1622,6 @@ static stf_status ikev2child_inCR1_decrypt(struct msg_digest *md)
 {
     struct state *st = md->st;
     v2_notification_t rn;
-
-    /* create a new parent event to rekey again */
-    event_schedule(EVENT_SO_DISCARD, 0, st);
 
     /* now decrypt payload and extract values */
     {

--- a/programs/pluto/ikev2_parent.c
+++ b/programs/pluto/ikev2_parent.c
@@ -2446,7 +2446,7 @@ stf_status process_informational_ikev2(struct msg_digest *md)
         stf_status ret;
         struct state *const st = md->st;
 
-        /* Only send response if it is request*/
+        /* Only send response if it is request (we are responder!) */
         if (!(md->hdr.isa_flags & ISAKMP_FLAGS_R)) {
             unsigned char *authstart;
             pb_stream      e_pbs, e_pbs_cipher;
@@ -2588,7 +2588,7 @@ stf_status process_informational_ikev2(struct msg_digest *md)
                             return STF_IGNORE;
                         }
                         else {
-                            DBG(DBG_CONTROLMORE, DBG_log("No. of SPIs to be sent %d", j);
+                            DBG(DBG_CONTROLMORE, DBG_log("Number of SPIs to be sent %d", j);
                                 DBG_dump(" Emit SPIs", spi_buf, j*v2del->isad_spisize));
                         }
 
@@ -2805,7 +2805,7 @@ stf_status process_informational_ikev2(struct msg_digest *md)
             }
     }
 
-    return STF_OK;
+    return STF_IGNORE;
 }
 
 /*

--- a/programs/pluto/timer.c
+++ b/programs/pluto/timer.c
@@ -700,11 +700,12 @@ next_event(void)
 	    DBG_log("next event %s in %ld seconds"
 		, enum_show(&timer_event_names, evlist->ev_type)
 		, (long)evlist->ev_time - (long)tm);
-	else
-	    DBG_log("next event %s in %ld seconds for #%lu"
+	else {
+	    DBG_log("next event %s in %ld seconds for #%lu (%s)"
 		, enum_show(&timer_event_names, evlist->ev_type)
 		, (long)evlist->ev_time - (long)tm
-		, evlist->ev_state->st_serialno));
+                    , evlist->ev_state->st_serialno, oswtimestr()));
+        }
 
     if (evlist->ev_time - tm <= 0)
 	return 0;

--- a/tests/unit/libpluto/lp13-parentI3/output1.txt
+++ b/tests/unit/libpluto/lp13-parentI3/output1.txt
@@ -599,7 +599,7 @@ sending 76 bytes for ikev2_delete_out through eth0:500 to 132.213.238.7:500 (usi
 |    ISAKMP version: IKEv2 version 2.0 (rfc4306/rfc5996)
 |    exchange type: ISAKMP_v2_INFORMATIONAL
 |    flags: ISAKMP_FLAG_INIT
-|    message ID:  00 00 00 02
+|    message ID:  00 00 00 03
 | ***emit IKEv2 Encryption Payload:
 |    next payload type: ISAKMP_NEXT_v2D
 |    critical bit: none
@@ -621,17 +621,17 @@ sending 76 bytes for ikev2_delete_out through eth0:500 to 132.213.238.7:500 (usi
 | data after encryption:
 |   23 56 8c 9a  7c 01 7c 8e  c1 2a 91 9a  c4 da 80 c2
 | data being hmac:  80 01 02 03  04 05 06 07  de bc 58 3a  8f 40 d0 cf
-|   2e 20 25 08  00 00 00 02  00 00 00 4c  2a 00 00 30
+|   2e 20 25 08  00 00 00 03  00 00 00 4c  2a 00 00 30
 |   80 01 02 03  04 05 06 07  08 09 0a 0b  0c 0d 0e 0f
 |   23 56 8c 9a  7c 01 7c 8e  c1 2a 91 9a  c4 da 80 c2
 | out calculated auth:
-|   16 a3 d4 62  eb 10 ce 81  c3 c9 f3 30
+|   39 4b 66 f8  5e 19 f9 eb  15 95 53 79
 sending 76 bytes for ikev2_delete_out through eth0:500 to 132.213.238.7:500 (using #1)
 |   80 01 02 03  04 05 06 07  de bc 58 3a  8f 40 d0 cf
-|   2e 20 25 08  00 00 00 02  00 00 00 4c  2a 00 00 30
+|   2e 20 25 08  00 00 00 03  00 00 00 4c  2a 00 00 30
 |   80 01 02 03  04 05 06 07  08 09 0a 0b  0c 0d 0e 0f
 |   23 56 8c 9a  7c 01 7c 8e  c1 2a 91 9a  c4 da 80 c2
-|   16 a3 d4 62  eb 10 ce 81  c3 c9 f3 30
+|   39 4b 66 f8  5e 19 f9 eb  15 95 53 79
 ./parentI3 leak: skeyseed_t1, item size: X
 ./parentI3 leak: responder keys, item size: X
 ./parentI3 leak: initiator keys, item size: X

--- a/tests/unit/libpluto/lp46-rekeyikev2-I1/output1.txt
+++ b/tests/unit/libpluto/lp46-rekeyikev2-I1/output1.txt
@@ -538,6 +538,7 @@ sending 556 bytes for STATE_PARENT_I1 through eth0:500 to 132.213.238.7:500 (usi
 now pretend that the keylife timer is up, and rekey the connection
 RC=0 #2: "parker1--jj2":500 IKEv2.0 STATE_CHILD_C1_KEYED (CHILD SA established); none in -1s; newest IPSEC; nodpd; msgid=1; idle; import:admin initiate
 RC=0 #1: "parker1--jj2":500 IKEv2.0 STATE_PARENT_I3 (PARENT SA established); none in -1s; newest ISAKMP; nodpd; retranscnt=0,outorder=0,last=1,next=2,recv=0; msgid=0; idle; import:admin initiate
+./rekeyikev2-I1 starting rekey of CHILD SA for state=#2 (expired) using PARENT SA #1
 | **emit ISAKMP Message:
 |    initiator cookie:
 |   80 01 02 03  04 05 06 07
@@ -900,7 +901,7 @@ sending 76 bytes for ikev2_delete_out through eth0:500 to 132.213.238.7:500 (usi
 |    ISAKMP version: IKEv2 version 2.0 (rfc4306/rfc5996)
 |    exchange type: ISAKMP_v2_INFORMATIONAL
 |    flags: ISAKMP_FLAG_INIT
-|    message ID:  00 00 00 03
+|    message ID:  00 00 00 04
 | ***emit IKEv2 Encryption Payload:
 |    next payload type: ISAKMP_NEXT_v2D
 |    critical bit: none
@@ -923,10 +924,10 @@ sending 76 bytes for ikev2_delete_out through eth0:500 to 132.213.238.7:500 (usi
 |   23 56 8c 9a  7c 01 7c 8e  c1 2a 91 9a  c4 da 80 c2
 sending 76 bytes for ikev2_delete_out through eth0:500 to 132.213.238.7:500 (using #1)
 |   80 01 02 03  04 05 06 07  de bc 58 3a  8f 40 d0 cf
-|   2e 20 25 08  00 00 00 03  00 00 00 4c  2a 00 00 30
+|   2e 20 25 08  00 00 00 04  00 00 00 4c  2a 00 00 30
 |   80 01 02 03  04 05 06 07  08 09 0a 0b  0c 0d 0e 0f
 |   23 56 8c 9a  7c 01 7c 8e  c1 2a 91 9a  c4 da 80 c2
-|   39 4b 66 f8  5e 19 f9 eb  15 95 53 79
+|   4a 21 e4 b4  7a ae c5 28  b6 ea e0 30
 ./rekeyikev2-I1 leak: reply packet for ikev2_out_C1_tail, item size: X
 ./rekeyikev2-I1 leak: db_v2_trans, item size: X
 ./rekeyikev2-I1 leak: db_v2_prop_conj, item size: X

--- a/tests/unit/libpluto/lp48-rekeyikev2-inCR1/output1.txt
+++ b/tests/unit/libpluto/lp48-rekeyikev2-inCR1/output1.txt
@@ -537,6 +537,7 @@ sending 556 bytes for STATE_PARENT_I1 through eth0:500 to 132.213.238.7:500 (usi
 now pretend that the keylife timer is up, and rekey the connection
 RC=0 #2: "parker1--jj2":500 IKEv2.0 STATE_CHILD_C1_KEYED (CHILD SA established); none in -1s; newest IPSEC; nodpd; msgid=1; idle; import:admin initiate
 RC=0 #1: "parker1--jj2":500 IKEv2.0 STATE_PARENT_I3 (PARENT SA established); none in -1s; newest ISAKMP; nodpd; retranscnt=0,outorder=0,last=1,next=2,recv=0; msgid=0; idle; import:admin initiate
+./rekeyikev2-inCR1 starting rekey of CHILD SA for state=#2 (expired) using PARENT SA #1
 | **emit ISAKMP Message:
 |    initiator cookie:
 |   80 01 02 03  04 05 06 07
@@ -1003,7 +1004,7 @@ sending 76 bytes for ikev2_delete_out through eth0:500 to 132.213.238.7:500 (usi
 |    ISAKMP version: IKEv2 version 2.0 (rfc4306/rfc5996)
 |    exchange type: ISAKMP_v2_INFORMATIONAL
 |    flags: ISAKMP_FLAG_INIT
-|    message ID:  00 00 00 03
+|    message ID:  00 00 00 04
 | ***emit IKEv2 Encryption Payload:
 |    next payload type: ISAKMP_NEXT_v2D
 |    critical bit: none
@@ -1028,10 +1029,10 @@ sending 76 bytes for ikev2_delete_out through eth0:500 to 132.213.238.7:500 (usi
 |   b5 fc a4 92  84 aa c2 c2  26 45 c4 84  4b 67 04 77
 sending 76 bytes for ikev2_delete_out through eth0:500 to 132.213.238.7:500 (using #1)
 |   80 01 02 03  04 05 06 07  de bc 58 3a  8f 40 d0 cf
-|   2e 20 25 08  00 00 00 03  00 00 00 4c  2a 00 00 30
+|   2e 20 25 08  00 00 00 04  00 00 00 4c  2a 00 00 30
 |   80 01 02 03  04 05 06 07  08 09 0a 0b  0c 0d 0e 0f
 |   b5 fc a4 92  84 aa c2 c2  26 45 c4 84  4b 67 04 77
-|   13 95 e9 47  e3 35 79 4b  7f e1 27 93
+|   d8 28 80 26  76 d3 5c b5  ac de 1a 26
 | pass 1: considering PARENT SAs to delete
 ./rekeyikev2-inCR1 deleting state #1 (STATE_PARENT_I3)
 | considering request to delete IKE parent state
@@ -1045,7 +1046,7 @@ sending 76 bytes for ikev2_delete_out through eth0:500 to 132.213.238.7:500 (usi
 |    ISAKMP version: IKEv2 version 2.0 (rfc4306/rfc5996)
 |    exchange type: ISAKMP_v2_INFORMATIONAL
 |    flags: ISAKMP_FLAG_INIT
-|    message ID:  00 00 00 03
+|    message ID:  00 00 00 05
 | ***emit IKEv2 Encryption Payload:
 |    next payload type: ISAKMP_NEXT_v2D
 |    critical bit: none
@@ -1068,10 +1069,10 @@ sending 76 bytes for ikev2_delete_out through eth0:500 to 132.213.238.7:500 (usi
 |   23 56 8c 9a  7c 01 7c 8e  c1 2a 91 9a  c4 da 80 c2
 sending 76 bytes for ikev2_delete_out through eth0:500 to 132.213.238.7:500 (using #1)
 |   80 01 02 03  04 05 06 07  de bc 58 3a  8f 40 d0 cf
-|   2e 20 25 08  00 00 00 03  00 00 00 4c  2a 00 00 30
+|   2e 20 25 08  00 00 00 05  00 00 00 4c  2a 00 00 30
 |   80 01 02 03  04 05 06 07  08 09 0a 0b  0c 0d 0e 0f
 |   23 56 8c 9a  7c 01 7c 8e  c1 2a 91 9a  c4 da 80 c2
-|   39 4b 66 f8  5e 19 f9 eb  15 95 53 79
+|   df 06 d4 89  4c 60 85 1d  b7 60 27 8e
 ./rekeyikev2-inCR1 leak: skeyseed_t1, item size: X
 ./rekeyikev2-inCR1 leak: responder keys, item size: X
 ./rekeyikev2-inCR1 leak: initiator keys, item size: X


### PR DESCRIPTION
This is the result of the log file analysis of the beta of 2.6.48rc1: the conclusion was that the delete messages which eventually get sent out when an SA is rekeyed did not allocate their msgid properly, so they screwed up subsequent rekeys (which appear to be re-transmissions).
