### PR TITLE
STF_INLINE was falling through into STF_OK code, but really all of th…

### DIFF
--- a/programs/pluto/ikev2.c
+++ b/programs/pluto/ikev2.c
@@ -1258,11 +1258,13 @@ void complete_v2_state_transition(struct msg_digest **mdp
 	*mdp = NULL;
 	break;
 
-    case STF_INLINE:         /* mcr: this is second time through complete
-			      * state transition, so the MD has already
-			      * been freed.                              */
-			      *mdp = NULL;
-			      /* fall through to STF_OK */
+    case STF_INLINE:
+        /* mcr: this is second time through complete
+         * state transition: the MD was processed by the
+         * appropriate _tail() function, and released.
+         */
+        *mdp = NULL;
+        break;
 
     case STF_OK:
 	/* advance the state */


### PR DESCRIPTION
…e STF_OK code has already been run: that is the point of the STF_INLINE reply.

Just anul mdp (it was already freed) and finish