### PR TITLE
IKEv1 fixes, from IKEv2 changes to MD

### DIFF
--- a/programs/pluto/ikev1.c
+++ b/programs/pluto/ikev1.c
@@ -1953,7 +1953,7 @@ complete_v1_state_transition(struct msg_digest **mdp, stf_status result)
     passert(result == STF_INLINE || result == STF_IGNORE || result == STF_SUSPEND
             || st == NULL || (st && st->st_calculating==FALSE));
 
-    if(md->transition_state != NULL) {
+    if(md->transition_state == NULL) {
         md->transition_state = st;
     }
 

--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -1004,7 +1004,7 @@ ikev2child_outC1_tail(struct pluto_crypto_req_cont *pcrc
                             , struct pluto_crypto_req *r);
 
 
-stf_status ikev2child_outC1(int whack_sock UNUSED
+stf_status ikev2child_outC1(int whack_sock
                             , struct state *parentst
                             , struct connection *c
                             , lset_t policy
@@ -1018,6 +1018,7 @@ stf_status ikev2child_outC1(int whack_sock UNUSED
 
     /* okay, got a transmit slot, make a child state to send this. */
     st = duplicate_state(parentst);
+    st->st_whack_sock = whack_sock;
     ret = allocate_msgid_from_parent(parentst, &st->st_msgid);
 
     if(ret != STF_OK) return ret;


### PR DESCRIPTION
IKEv2 code needs a transition_state to indicate which state (parent or child) should undergo the state transition, and this is provided for with the md->transition_state member.  
IKEv1 has simpler requirements (so far: there is actually the same mess buried), but if transition_state is not set, it should go with the previous behaviour.  This patch fixes the logic, which was inverted, which causes a core dump.
