### PR TITLE
uClibc-ng is compatible to glibc

### DIFF
--- a/linux/include/openswan.h
+++ b/linux/include/openswan.h
@@ -27,18 +27,6 @@
 #endif
 
 /*
- * When using uclibc, malloc(0) returns NULL instead of success. This is
- * to make it use the inbuilt work-around.
- * See: http://osdir.com/ml/network.freeswan.devel/2003-11/msg00009.html
- */
-#ifdef __UCLIBC__
-# if !defined(__MALLOC_GLIBC_COMPAT__) && !defined(MALLOC_GLIBC_COMPAT)
-#  warning Please compile uclibc with GLIBC_COMPATIBILITY defined
-# endif
-#endif
-
-
-/*
  * We've just got to have some datatypes defined...  And annoyingly, just
  * where we get them depends on whether we're in userland or not.
  */


### PR DESCRIPTION
Hi,

uClibc-ng is compatible to glibc malloc(0).
This extra check is breaking openswan compilation in Buildroot.
Any existing user of old uClibc 0.9.33.2 will still be able to use OpenSwan, just the extra
check wouldn't be done. But existing user base will have it enabled to compile Openswan.
So I vote for just removing the check.
thanks in advance
 Waldemar