### PR TITLE
Issue237 cert type 12

### DIFF
--- a/Makefile.top
+++ b/Makefile.top
@@ -31,6 +31,7 @@ SUBDIRS?=lib programs
 
 clean::
 	-(cd ${OPENSWANSRCDIR} && $(MAKE) modclean && $(MAKE) mod26clean)
+	-${MAKE} -C tests clean
 
 distclean:	clean
 	rm -f out.kpatch

--- a/lib/libpluto/packet.c
+++ b/lib/libpluto/packet.c
@@ -827,7 +827,8 @@ static field_desc ikev2_cert_fields[] = {
   { ft_enum, 8/BITS_PER_BYTE, "next payload type", &payload_names },
   { ft_set, 8/BITS_PER_BYTE, "critical bit", critical_names},
   { ft_len, 16/BITS_PER_BYTE, "length", NULL },
-  { ft_enum, 8/BITS_PER_BYTE, "ikev2 cert encoding", &ikev2_cert_type_names },
+  { ft_loose_enum,
+             8/BITS_PER_BYTE, "ikev2 cert encoding", &ikev2_cert_type_names },
   { ft_end,  0, NULL, NULL }
 };
 
@@ -852,9 +853,10 @@ struct_desc ikev2_certificate_desc = { "IKEv2 Certificate Payload", ikev2_cert_f
 
 static field_desc ikev2_cert_req_fields[] = {
   { ft_enum, 8/BITS_PER_BYTE, "next payload type", &payload_names },
-  { ft_set, 8/BITS_PER_BYTE, "critical bit", critical_names},
+  { ft_set,  8/BITS_PER_BYTE, "critical bit", critical_names},
   { ft_len, 16/BITS_PER_BYTE, "length", NULL },
-  { ft_enum, 8/BITS_PER_BYTE, "ikev2 cert encoding", &ikev2_cert_type_names },
+  { ft_loose_enum,
+             8/BITS_PER_BYTE, "ikev2 cert encoding", &ikev2_cert_type_names },
   { ft_end,  0, NULL, NULL }
 };
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,3 +21,16 @@ check:
 	@${MAKE} -C unit       check
 	@${MAKE} -C build      check
 
+clean:
+	@${MAKE} -C functional clean
+	@${MAKE} -C unit       clean
+	@${MAKE} -C build      clean
+
+programs:
+	@true
+
+install:
+	@true
+
+
+

--- a/tests/unit/Makefile
+++ b/tests/unit/Makefile
@@ -16,9 +16,9 @@ srcdir?=${OPENSWANSRCDIR}/tests/unit
 
 include ${OPENSWANSRCDIR}/Makefile.inc
 
-check:
-	@${MAKE} -C libopenswan check
-	@${MAKE} -C libpluto    check
-	@${MAKE} -C ikev2crypto check
-	@${MAKE} -C liboswkeys  check
+clean check:
+	@${MAKE} -C libopenswan $@
+	@${MAKE} -C libpluto    $@
+	@${MAKE} -C ikev2crypto $@
+	@${MAKE} -C liboswkeys  $@
 


### PR DESCRIPTION
This marks the cert and cert request payloads to have a cert type field which is a "loose" enum, which means, that new/unknown values are acceptable (just ignored).
