### PR TITLE
T6589 improve error messages

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -106,6 +106,7 @@ typedef unsigned long long lset_t;
 typedef const struct enum_names enum_names;
 
 extern const char *enum_name(enum_names *ed, unsigned long val);
+extern const char *enum_name_default(enum_names *ed, unsigned long val, const char *def);
 extern const char *enum_show(enum_names *ed, unsigned long val);
 extern int enum_search(enum_names *ed, const char *string);
 

--- a/include/ietf_constants.h
+++ b/include/ietf_constants.h
@@ -972,6 +972,7 @@ enum ike_trans_type_dh {
 
 /*
  * IKEv1 RFC2408 http://www.iana.org/assignments/ipsec-registry
+ * https://www.iana.org/assignments/ikev2-parameters/ikev2-parameters.xhtml
  * extern enum_names notification_names;
  * extern enum_names ipsec_notification_names;
  */
@@ -1008,7 +1009,22 @@ typedef enum {
     CERTIFICATE_UNAVAILABLE =   28,
     UNSUPPORTED_EXCHANGE_TYPE = 29,
     UNEQUAL_PAYLOAD_LENGTHS =   30,
-    /* 31-8191 RESERVED (Future Use) */
+
+    SINGLE_PAIR_REQUIRED =	34,	/* [RFC7296] */
+    NO_ADDITIONAL_SAS =		35,	/* [RFC7296] */
+    INTERNAL_ADDRESS_FAILURE =	36,	/* [RFC7296] */
+    FAILED_CP_REQUIRED =	37,	/* [RFC7296] */
+    TS_UNACCEPTABLE =		38,	/* [RFC7296] */
+    INVALID_SELECTORS =		39,	/* [RFC7296] */
+    UNACCEPTABLE_ADDRESSES =	40,	/* [RFC4555] */
+    UNEXPECTED_NAT_DETECTED =	41,	/* [RFC4555] */
+    USE_ASSIGNED_HoA =		42,	/* [RFC5026] */
+    TEMPORARY_FAILURE =		43,	/* [RFC7296] */
+    CHILD_SA_NOT_FOUND =	44,	/* [RFC7296] */
+    INVALID_GROUP_ID =		45,	/* [draft-yeung-g-ikev2] */
+    AUTHORIZATION_FAILED =	46,	/* [draft-yeung-g-ikev2] */
+
+    /* 47-8191 RESERVED (Future Use) */
 
     /*
      * Sub-Registry: Notify Messages - Status Types (16384-24575)

--- a/include/names_constant.h
+++ b/include/names_constant.h
@@ -78,6 +78,10 @@ extern enum_names ikev2_cert_type_names;
 extern enum_names ikev2_notify_names;
 extern enum_names ikev2_ts_type_names;
 
+/* lookup macros */
+
+extern const char *stf_status_name(stf_status code);
+
 #ifdef HAVE_LABELED_IPSEC
 extern u_int16_t secctx_attr_value;
 #endif

--- a/lib/libopenswan/constants.c
+++ b/lib/libopenswan/constants.c
@@ -969,6 +969,22 @@ static const char *const notification_name[] = {
 	"CERTIFICATE_UNAVAILABLE",
 	"UNSUPPORTED_EXCHANGE_TYPE",
 	"UNEQUAL_PAYLOAD_LENGTHS",
+	"__reserved_31__",
+	"__reserved_32__",
+	"__reserved_33__",
+	"SINGLE_PAIR_REQUIRED",
+	"NO_ADDITIONAL_SAS",
+	"INTERNAL_ADDRESS_FAILURE",
+	"FAILED_CP_REQUIRED",
+	"TS_UNACCEPTABLE",
+	"INVALID_SELECTORS",
+	"UNACCEPTABLE_ADDRESSES",
+	"UNEXPECTED_NAT_DETECTED",
+	"USE_ASSIGNED_HoA",
+	"TEMPORARY_FAILURE",
+	"CHILD_SA_NOT_FOUND",
+	"INVALID_GROUP_ID",
+	"AUTHORIZATION_FAILED",
     };
 
 static const char *const notification_status_name[] = {
@@ -1029,7 +1045,7 @@ enum_names notification_dpd_names =
       notification_dpd_name, &notification_cisco_chatter_names };
 
 enum_names notification_names =
-    { INVALID_PAYLOAD_TYPE, UNEQUAL_PAYLOAD_LENGTHS,
+    { INVALID_PAYLOAD_TYPE, AUTHORIZATION_FAILED,
         notification_name, &notification_dpd_names };
 
 enum_names notification_status_names =

--- a/lib/libopenswan/constants.c
+++ b/lib/libopenswan/constants.c
@@ -1481,14 +1481,19 @@ struct keyword_enum_values kw_host_list=
 /* look up enum names in an enum_names */
 
 const char *
-enum_name(enum_names *ed, unsigned long val)
+enum_name_default(enum_names *ed, unsigned long val, const char *def)
 {
     enum_names	*p;
 
     for (p = ed; p != NULL; p = p->en_next_range)
 	if (p->en_first <= val && val <= p->en_last)
 	    return p->en_names[val - p->en_first];
-    return NULL;
+    return def;
+}
+const char *
+enum_name(enum_names *ed, unsigned long val)
+{
+	return enum_name_default(ed, val, NULL);
 }
 
 /* look up an enum in a starter friendly way */

--- a/lib/libpluto/pluto_constants.c
+++ b/lib/libpluto/pluto_constants.c
@@ -281,6 +281,20 @@ static const char *const stfstatus_names[] = {
 enum_names stfstatus_name =
   {STF_IGNORE, STF_FAIL, stfstatus_names, NULL};
 
+/* stf_status_name() generates a string in a temporary buffer
+ * for errors past STF_FAIL */
+#define STF_STATUS_BUFFER_MAX 128
+static char stf_status_buffer[STF_STATUS_BUFFER_MAX];
+const char *stf_status_name(stf_status code)
+{
+	const char *ret = enum_name(&stfstatus_name, code);
+	if (ret) return ret;
+	/* decode errors past STF_FAIL */
+	snprintf(stf_status_buffer, sizeof(stf_status_buffer),
+		 "STF_FAIL%+d", code);
+	return stf_status_buffer;
+}
+
 /* Timer events */
 static const char *const dns_auth_level_name[] = {
     "unsigned",

--- a/programs/pluto/ikev1.c
+++ b/programs/pluto/ikev1.c
@@ -1944,7 +1944,7 @@ complete_v1_state_transition(struct msg_digest **mdp, stf_status result)
     /* advance the state */
     DBG(DBG_CONTROL
 	, DBG_log("complete state transition with %s"
-		  , enum_name(&stfstatus_name, result)));
+		  , stf_status_name(result)));
 
     /*
      * we can only be in calculating state if state is ignore,

--- a/programs/pluto/ikev1_main.c
+++ b/programs/pluto/ikev1_main.c
@@ -1386,11 +1386,11 @@ main_inI2_outR2_tail(struct pluto_crypto_req_cont *pcrc
 
 	DBG(DBG_CONTROLMORE,
 	    DBG_log("started dh_secretiv, returned: stf=%s\n"
-		    , enum_name(&stfstatus_name, e)));
+		    , stf_status_name(e)));
 
 	if(e == STF_FAIL) {
 	    loglog(RC_LOG_SERIOUS, "failed to start async DH calculation, stf=%s\n"
-		   , enum_name(&stfstatus_name, e));
+		   , stf_status_name(e));
 	    return e;
 	}
 

--- a/programs/pluto/ikev2.c
+++ b/programs/pluto/ikev2.c
@@ -846,7 +846,8 @@ process_v2_packet(struct msg_digest **mdp)
 
     ret = (svm->processor)(md);
 
-    DBG(DBG_CONTROLMORE, DBG_log("processor '%s' returned %d", svm->svm_name, ret));
+    DBG(DBG_CONTROLMORE, DBG_log("processor '%s' returned %s (%d)",
+				 svm->svm_name, stf_status_name(ret), ret));
 
     complete_v2_state_transition(mdp, ret);
 }
@@ -1344,7 +1345,7 @@ void complete_v2_state_transition(struct msg_digest **mdp
     DBG(DBG_CONTROL
 	, DBG_log("#%lu complete v2 state transition with %s"
                   , st ? st->st_serialno : 0
-		  , enum_name(&stfstatus_name, (result > STF_FAIL) ? STF_FAIL : result)));
+		  , stf_status_name(result)));
 
     switch(result) {
     case STF_IGNORE:

--- a/programs/pluto/ikev2.c
+++ b/programs/pluto/ikev2.c
@@ -1010,7 +1010,8 @@ send_v2_notification_from_state(struct state *st, enum state_kind state,
     if (state == STATE_UNDEFINED)
 	state = st->st_state;
 
-    send_v2_notification(st, type, NULL, st->st_icookie, st->st_rcookie, data);
+    send_v2_notification(st, ISAKMP_v2_SA_INIT, type, NULL,
+			 st->st_icookie, st->st_rcookie, data);
 }
 
 void
@@ -1041,7 +1042,7 @@ send_v2_notification_from_md(struct msg_digest *md UNUSED, u_int16_t type
     cnx.interface = md->iface;
     st.st_interface = md->iface;
 
-    send_v2_notification(&st, type, NULL,
+    send_v2_notification(&st, ISAKMP_v2_SA_INIT, type, NULL,
 			 md->hdr.isa_icookie, md->hdr.isa_rcookie, data);
 }
 

--- a/programs/pluto/ikev2.h
+++ b/programs/pluto/ikev2.h
@@ -231,10 +231,14 @@ extern void ikev2_print_ts(struct traffic_selector *ts);
 extern void send_v2_notification(struct state *p1st
 				   , enum isakmp_xchg_types xchg_type
 				   , notification_t ntf_type
-				   , struct state *encst
 				   , u_char *icookie
 				   , u_char *rcookie
 				   , chunk_t *n_data);
+
+extern int send_v2_notification_enc(struct msg_digest *md
+				    , enum isakmp_xchg_types xchg_type
+				    , notification_t ntf_type
+				    , chunk_t *notify_data);
 
 extern void calculate_nat_hash(const unsigned char cookie_i[COOKIE_SIZE]
                                , const unsigned char cookie_r[COOKIE_SIZE]

--- a/programs/pluto/ikev2.h
+++ b/programs/pluto/ikev2.h
@@ -228,11 +228,13 @@ extern void ikev2_update_counters(struct msg_digest *md);
 extern void ikev2_print_ts(struct traffic_selector *ts);
 
 
-extern void send_v2_notification(struct state *p1st, u_int16_t type
-				 , struct state *encst
-				 , u_char *icookie
-				 , u_char *rcookie
-				 , chunk_t *data);
+extern void send_v2_notification(struct state *p1st
+				   , enum isakmp_xchg_types xchg_type
+				   , notification_t ntf_type
+				   , struct state *encst
+				   , u_char *icookie
+				   , u_char *rcookie
+				   , chunk_t *n_data);
 
 extern void calculate_nat_hash(const unsigned char cookie_i[COOKIE_SIZE]
                                , const unsigned char cookie_r[COOKIE_SIZE]

--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -1656,7 +1656,7 @@ ikev2child_inCI1_tail(struct msg_digest *md, struct state *st, bool dopfs)
                 v2_notify_num = ret - STF_FAIL;
                 DBG(DBG_CONTROL,DBG_log("ikev2_child_sa_respond returned STF_FAIL with %s", enum_name(&ikev2_notify_names, v2_notify_num)))
             } else if(ret != STF_OK) {
-                DBG_log("ikev2_child_sa_respond returned %s", enum_name(&stfstatus_name, ret));
+                DBG_log("ikev2_child_sa_respond returned %s", stf_status_name(ret));
             }
         }
 

--- a/programs/pluto/ikev2_notify.c
+++ b/programs/pluto/ikev2_notify.c
@@ -242,7 +242,7 @@ bool ship_v2N(unsigned int np, u_int8_t  critical,
             return FALSE;
         }
     }
-    if(n_data != NULL) {
+    if(n_data && n_data->len) {
         if (!out_raw(n_data->ptr, n_data->len, &n_pbs, "Notify data")) {
             openswan_log("error writing notify payload for notify message");
             return FALSE;

--- a/programs/pluto/ikev2_parent.c
+++ b/programs/pluto/ikev2_parent.c
@@ -560,7 +560,6 @@ send_v2_notification(struct state *p1st
 		       , u_char *rcookie
 		       , chunk_t *notify_data)
 {
-    u_char buffer[1024];
     pb_stream reply;
     pb_stream rbody;
     chunk_t child_spi;
@@ -582,7 +581,7 @@ send_v2_notification(struct state *p1st
                  , p1st->st_remoteport);
 
     memset(buffer, 0, sizeof(buffer));
-    init_pbs(&reply, buffer, sizeof(buffer), "notification msg");
+    init_pbs(&reply, reply_buffer, sizeof(reply_buffer), "notification msg");
 
     /* HDR out */
     {

--- a/programs/pluto/ikev2_parent_I1.c
+++ b/programs/pluto/ikev2_parent_I1.c
@@ -331,11 +331,8 @@ ikev2_parent_outI1_common(struct msg_digest *md
         chunk_t child_spi;
         memset(&child_spi, 0, sizeof(child_spi));
 
-        ship_v2N(0, DBGP(IMPAIR_SEND_BOGUS_ISAKMP_FLAG) ?
-                 (ISAKMP_PAYLOAD_NONCRITICAL | ISAKMP_PAYLOAD_OPENSWAN_BOGUS) :
-                 ISAKMP_PAYLOAD_NONCRITICAL, PROTO_ISAKMP,
-                 &child_spi,
-                 v2N_COOKIE, &st->st_dcookie, &md->rbody);
+        ship_v2N(ISAKMP_NEXT_NONE, ISAKMP_PAYLOAD_NONCRITICAL, PROTO_ISAKMP,
+                 &child_spi, v2N_COOKIE, &st->st_dcookie, &md->rbody);
     }
 
     /* SA out */

--- a/programs/pluto/ikev2_parent_R2.c
+++ b/programs/pluto/ikev2_parent_R2.c
@@ -123,7 +123,7 @@ ikev2_parent_inI2outR2_continue(struct pluto_crypto_req_cont *pcrc
         int v2_notify_num = e - STF_FAIL;
         DBG_log("ikev2_parent_inI2outR2_tail returned STF_FAIL with %s", enum_name(&ikev2_notify_names, v2_notify_num));
     } else if( e != STF_OK) {
-        DBG_log("ikev2_parent_inI2outR2_tail returned %s", enum_name(&stfstatus_name, e));
+        DBG_log("ikev2_parent_inI2outR2_tail returned %s", stf_status_name(e));
     }
 
     if(dh->md != NULL) {
@@ -436,7 +436,7 @@ ikev2_parent_inI2outR2_tail(struct pluto_crypto_req_cont *pcrc
                 DBG(DBG_CONTROL,DBG_log("ikev2_child_sa_respond returned STF_FAIL with %s", enum_name(&ikev2_notify_names, v2_notify_num)))
                 np = ISAKMP_NEXT_NONE;
             } else if(ret != STF_OK) {
-                DBG_log("ikev2_child_sa_respond returned %s", enum_name(&stfstatus_name, ret));
+                DBG_log("ikev2_child_sa_respond returned %s", stf_status_name(ret));
                 np = ISAKMP_NEXT_NONE;
             }
         }

--- a/tests/unit/libpluto/lp06-parentR1notchosen/output.txt
+++ b/tests/unit/libpluto/lp06-parentR1notchosen/output.txt
@@ -195,9 +195,9 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | processing payload: ISAKMP_NEXT_v2V (len=16)
 | now proceed with state specific processing using state #3 responder-V2_init
 | no connection with matching policy found
-| #0 complete v2 state transition with STF_FAIL
+| #0 complete v2 state transition with STF_FAIL+32
 ./parentI1R1 no-state: AUTHENTICATION_FAILED
-./parentI1R1 sending  notification v2N_AUTHENTICATION_FAILED to 10.10.5.4:500
+./parentI1R1 sending notification ISAKMP_v2_SA_INIT/v2N_AUTHENTICATION_FAILED to 10.10.5.4:500
 sending 36 bytes for send_v2_notification through eth0:500 [192.168.1.1:500] to 10.10.5.4:500 (using #0)
 |   56 11 47 13  4b 1d 6d 52  00 00 00 00  00 00 00 00
 |   29 20 22 20  00 00 00 00  00 00 00 24  00 00 00 08

--- a/tests/unit/libpluto/lp08-parentR1/output1.txt
+++ b/tests/unit/libpluto/lp08-parentR1/output1.txt
@@ -192,7 +192,7 @@ RC=0 "parker1--jj2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SA
 | emitting length of IKEv2 Proposal Substructure Payload: 44
 | emitting length of IKEv2 Security Association Payload: 48
 ./parentR1 KE has 192 byte DH public value; 256 required
-./parentR1 sending  notification v2N_INVALID_KE_PAYLOAD to 192.168.1.1:500
+./parentR1 sending notification ISAKMP_v2_SA_INIT/v2N_INVALID_KE_PAYLOAD to 192.168.1.1:500
 | **emit ISAKMP Message:
 |    initiator cookie:
 |   00 01 02 03  04 05 06 07
@@ -223,9 +223,9 @@ sending 40 bytes for send_v2_notification through eth0:500 [132.213.238.7:500] t
 | ICOOKIE:  00 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28
-| #1 complete v2 state transition with STF_FAIL
+| #1 complete v2 state transition with STF_FAIL+25
 ./parentR1 STATE_CHILDSA_DEL: INVALID_KEY_INFORMATION
-./parentR1 sending  notification v2N_INVALID_KE_PAYLOAD to 192.168.1.1:500
+./parentR1 sending notification ISAKMP_v2_SA_INIT/v2N_INVALID_KE_PAYLOAD to 192.168.1.1:500
 | **emit ISAKMP Message:
 |    initiator cookie:
 |   00 01 02 03  04 05 06 07

--- a/tests/unit/libpluto/lp13-parentI3/output1.txt
+++ b/tests/unit/libpluto/lp13-parentI3/output1.txt
@@ -533,7 +533,7 @@ sending 556 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132.
 |   ip low: fd68:c9f9:4157::
 |   ip high: fd68:c9f9:4157:0:ffff:ffff:ffff:ffff
 | empty esp_info, returning defaults
-| processor 'initiator-auth-process' returned 3
+| processor 'initiator-auth-process' returned STF_OK (3)
 | #2 complete v2 state transition with STF_OK
 ./parentI3 transition from state STATE_CHILD_C0_KEYING to state STATE_CHILD_C1_KEYED
 | v2_state_transition: st is #2; pst is #0; transition_st is #0

--- a/tests/unit/libpluto/lp25-wrongcacert/output1.txt
+++ b/tests/unit/libpluto/lp25-wrongcacert/output1.txt
@@ -840,7 +840,7 @@ RC=0 Nov 23 22:12:14 UTC 2015, 2048 RSA localf key AwEAAeOoT/75B9 7996 96CB FFE9
 RC=0        ID_DER_ASN1_DN 'C=CA, ST=Canada, L=Ottawa, O=Xelerance Corporation, OU=Doctor Taylor Plumage, CN=moon.testing.openswan.org, E=mcr@xelerance.com'
 RC=0        Issuer 'C=CA, ST=Ontario, L=Ottawa, O=Xelerance Corporation, OU=Doctor Taylor Plumage, CN=testing.xelerance.com, E=mcr@xelerance.com'
 ./wrongcacert RSA authentication failed
-./wrongcacert sending  notification v2N_AUTHENTICATION_FAILED to 93.184.216.34:500
+./wrongcacert sending notification ISAKMP_v2_SA_INIT/v2N_AUTHENTICATION_FAILED to 93.184.216.34:500
 | **emit ISAKMP Message:
 |    initiator cookie:
 |   80 01 02 03  04 05 06 07

--- a/tests/unit/libpluto/lp45-h2hR1-noikev2/output1.txt
+++ b/tests/unit/libpluto/lp45-h2hR1-noikev2/output1.txt
@@ -123,10 +123,10 @@ RC=0 "mytunnel-no-ikev2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2Init+S
 | searching for connection with policy = IKEv2ALLOW/-
 | find_host_connection2 returns empty (ike=mytunnel-no-ikev2/none)
 ./h2hR1-noikev2 connection refused, IKEv2 not authorized
-| processor 'responder-V2_init' returned 32
-| #0 complete v2 state transition with STF_FAIL
+| processor 'responder-V2_init' returned STF_FAIL+32 (32)
+| #0 complete v2 state transition with STF_FAIL+32
 ./h2hR1-noikev2 no-state: AUTHENTICATION_FAILED
-./h2hR1-noikev2 sending  notification v2N_AUTHENTICATION_FAILED to 192.168.1.1:500
+./h2hR1-noikev2 sending notification ISAKMP_v2_SA_INIT/v2N_AUTHENTICATION_FAILED to 192.168.1.1:500
 | **emit ISAKMP Message:
 |    initiator cookie:
 |   80 01 02 03  04 05 06 07

--- a/tests/unit/libpluto/lp46-rekeyikev2-I1/output1.txt
+++ b/tests/unit/libpluto/lp46-rekeyikev2-I1/output1.txt
@@ -533,7 +533,7 @@ sending 556 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132.
 |   ip low: fd68:c9f9:4157::
 |   ip high: fd68:c9f9:4157:0:ffff:ffff:ffff:ffff
 | empty esp_info, returning defaults
-| processor 'initiator-auth-process' returned 3
+| processor 'initiator-auth-process' returned STF_OK (3)
 | #2 complete v2 state transition with STF_OK
 ./rekeyikev2-I1 transition from state STATE_CHILD_C0_KEYING to state STATE_CHILD_C1_KEYED
 | v2_state_transition: st is #2; pst is #0; transition_st is #0

--- a/tests/unit/libpluto/lp48-rekeyikev2-inCR1/output1.txt
+++ b/tests/unit/libpluto/lp48-rekeyikev2-inCR1/output1.txt
@@ -532,7 +532,7 @@ sending 556 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132.
 |   ip low: fd68:c9f9:4157::
 |   ip high: fd68:c9f9:4157:0:ffff:ffff:ffff:ffff
 | empty esp_info, returning defaults
-| processor 'initiator-auth-process' returned 3
+| processor 'initiator-auth-process' returned STF_OK (3)
 | #2 complete v2 state transition with STF_OK
 ./rekeyikev2-inCR1 transition from state STATE_CHILD_C0_KEYING to state STATE_CHILD_C1_KEYED
 | v2_state_transition: st is #2; pst is #0; transition_st is #0

--- a/tests/unit/libpluto/lp50-rekey-no-reply-rekey/output1.txt
+++ b/tests/unit/libpluto/lp50-rekey-no-reply-rekey/output1.txt
@@ -533,7 +533,7 @@ sending 556 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132.
 |   ip low: fd68:c9f9:4157::
 |   ip high: fd68:c9f9:4157:0:ffff:ffff:ffff:ffff
 | empty esp_info, returning defaults
-| processor 'initiator-auth-process' returned 3
+| processor 'initiator-auth-process' returned STF_OK (3)
 | #2 complete v2 state transition with STF_OK
 ./rekey-no-reply-I1 transition from state STATE_CHILD_C0_KEYING to state STATE_CHILD_C1_KEYED
 | v2_state_transition: st is #2; pst is #0; transition_st is #0

--- a/tests/unit/libpluto/lp56-rekeyv2nopfs-I1/output1.txt
+++ b/tests/unit/libpluto/lp56-rekeyv2nopfs-I1/output1.txt
@@ -533,7 +533,7 @@ sending 556 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132.
 |   ip low: fd68:c9f9:4157::
 |   ip high: fd68:c9f9:4157:0:ffff:ffff:ffff:ffff
 | empty esp_info, returning defaults
-| processor 'initiator-auth-process' returned 3
+| processor 'initiator-auth-process' returned STF_OK (3)
 | #2 complete v2 state transition with STF_OK
 ./rekeyv2nopfs-I1 transition from state STATE_CHILD_C0_KEYING to state STATE_CHILD_C1_KEYED
 | v2_state_transition: st is #2; pst is #0; transition_st is #0

--- a/tests/unit/libpluto/lp57-rekeyv2nopfs-R1/output1.txt
+++ b/tests/unit/libpluto/lp57-rekeyv2nopfs-R1/output1.txt
@@ -1163,7 +1163,7 @@ sending 444 bytes for STATE_PARENT_R1 through eth0:500 [132.213.238.7:500] to 19
 |   8e a8 fd 6c  28 38 21 82  be 00 9e 6b  d0 db a9 0a
 | out calculated auth:
 |   82 a8 d0 53  af 95 c8 a9  a9 64 c4 71
-| processor 'rekey-child-SA-responder' returned 3
+| processor 'rekey-child-SA-responder' returned STF_OK (3)
 | #3 complete v2 state transition with STF_OK
 ./rekeyv2nopfs-R1 transition from state STATE_CHILD_C1_REKEY to state STATE_CHILD_C1_KEYED
 | v2_state_transition: st is #3; pst is #1; transition_st is #3

--- a/tests/unit/libpluto/lp58-rekeyv2nopfs-inCR1/output1.txt
+++ b/tests/unit/libpluto/lp58-rekeyv2nopfs-inCR1/output1.txt
@@ -532,7 +532,7 @@ sending 556 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132.
 |   ip low: fd68:c9f9:4157::
 |   ip high: fd68:c9f9:4157:0:ffff:ffff:ffff:ffff
 | empty esp_info, returning defaults
-| processor 'initiator-auth-process' returned 3
+| processor 'initiator-auth-process' returned STF_OK (3)
 | #2 complete v2 state transition with STF_OK
 ./rekeyv2nopfs-inCR1 transition from state STATE_CHILD_C0_KEYING to state STATE_CHILD_C1_KEYED
 | v2_state_transition: st is #2; pst is #0; transition_st is #0
@@ -852,7 +852,7 @@ sending 348 bytes for ikev2child_outC1_tail through eth0:500 [192.168.1.1:500] t
 | peer keymat  d4 e5 d8 b8  c5 be c0 f0  2c 72 22 9a  3f d1 6b 3f
 |   76 47 d0 21  1d e2 76 c7  d6 a6 95 24  45 9d 94 68
 |   e5 86 a5 7d
-| processor 'rekey-childSA-ack' returned 3
+| processor 'rekey-childSA-ack' returned STF_OK (3)
 | #3 complete v2 state transition with STF_OK
 ./rekeyv2nopfs-inCR1 transition from state STATE_CHILD_C1_REKEY to state STATE_CHILD_C1_KEYED
 | v2_state_transition: st is #3; pst is #0; transition_st is #3

--- a/tests/unit/libpluto/lp65-nattI3/output1.txt
+++ b/tests/unit/libpluto/lp65-nattI3/output1.txt
@@ -317,7 +317,7 @@ picking: eth0:4500 float outside: 55045 <=> d: 55045
 |   ip low: fd68:c9f9:4157::
 |   ip high: fd68:c9f9:4157:0:ffff:ffff:ffff:ffff
 | empty esp_info, returning defaults
-| processor 'initiator-auth-process' returned 3
+| processor 'initiator-auth-process' returned STF_OK (3)
 | #2 complete v2 state transition with STF_OK
 ./nattI3 transition from state STATE_CHILD_C0_KEYING to state STATE_CHILD_C1_KEYED
 | v2_state_transition: st is #2; pst is #0; transition_st is #0

--- a/tests/unit/libpluto/run-unit-tests.sh
+++ b/tests/unit/libpluto/run-unit-tests.sh
@@ -1,8 +1,18 @@
 #!/bin/sh
 
+# set some funky toilet options
+toilet_options=
+[ -t 0 ] && toilet_options="--metal --width $(tput cols) --font future"
+
+header() {
+    # use tilet if possible
+    toilet $toilet_options $@ \
+    || figlet -t $@
+}
+
 for f in $(make testlist)
 do
-    (cd $f; figlet -t $f
+    (cd $f ; header $f
      while ! make check;
      do
          make update && git add -p .

--- a/tests/unit/libpluto/seam_demux.c
+++ b/tests/unit/libpluto/seam_demux.c
@@ -154,7 +154,7 @@ void
 complete_state_transition(struct msg_digest **mdp, stf_status result)
 {
 	fprintf(stderr, "transitioning on result: %s\n"
-		, enum_name(&stfstatus_name, result));
+		, stf_status_name(result));
 }
 
 #ifndef INCLUDE_IKEV1_PROCESSING
@@ -162,6 +162,6 @@ void
 complete_v1_state_transition(struct msg_digest **mdp, stf_status result)
 {
 	fprintf(stderr, "v1 transitioning on result: %s\n"
-		, enum_name(&stfstatus_name, result));
+		, stf_status_name(result));
 }
 #endif


### PR DESCRIPTION
before we were able to interop with Strongswan, we would be generating a lot of N(INVAL) notification messages.  The  N(INVAL) messages were sent in response to messages from Strongswan that we did not understand.  There were several issues with the way we generated N(INVAL) and that caused confusion on the Strongswan side, at which point SS killed the connection.

This work addresses the erroneous generation of notification messages to requests with encrypted payload.

A few minor changes were also made to error code lookup, and added new/missing IKEv2 parameters and corresponding strings.