### PR TITLE
T6453 md5 for keymat generation

### DIFF
--- a/programs/pluto/ikev2.h
+++ b/programs/pluto/ikev2.h
@@ -171,7 +171,7 @@ extern stf_status ikev2_emit_ipsec_sa(struct msg_digest *md
 				      , struct connection *c
 				      , lset_t policy);
 
-extern void ikev2_derive_child_keys(struct state *st
+extern stf_status ikev2_derive_child_keys(struct state *st
 				    , enum phase1_role role);
 
 extern int ikev2_evaluate_connection_fit(struct connection *d

--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -960,7 +960,9 @@ stf_status ikev2_child_sa_respond(struct msg_digest *md
     }
 
     /* in this case, RESPONDER means the responder to this message */
-    ikev2_derive_child_keys(st1, RESPONDER);
+    ret = ikev2_derive_child_keys(st1, RESPONDER);
+    if (ret != STF_OK)
+	return ret;
 
     /* install inbound and outbound SPI info */
     if(!install_ipsec_sa(pst, st1, TRUE))
@@ -2041,7 +2043,9 @@ static stf_status ikev2child_inCR1_tail(struct msg_digest *md, struct state *st)
             return STF_FAIL + rn;
     }
 
-    ikev2_derive_child_keys(st, INITIATOR);
+    e = ikev2_derive_child_keys(st, INITIATOR);
+    if (e != STF_OK)
+	return e;
 
     c->newest_ipsec_sa = st->st_serialno;
 

--- a/programs/pluto/ikev2_derived_keys.c
+++ b/programs/pluto/ikev2_derived_keys.c
@@ -52,7 +52,7 @@
 #include "alg_info.h"
 #include "kernel_alg.h"
 
-void ikev2_derive_child_keys(struct state *st, enum phase1_role role)
+stf_status ikev2_derive_child_keys(struct state *st, enum phase1_role role)
 {
 	struct v2prf_stuff childsacalc;
 	struct state *pst;
@@ -79,9 +79,9 @@ void ikev2_derive_child_keys(struct state *st, enum phase1_role role)
 	childsacalc.prf_hasher = (struct hash_desc *)
 		ike_alg_ikev2_find(IKE_ALG_HASH, alg, 0);
 	if (!childsacalc.prf_hasher) {
-		alg = IKEv2_PRF_HMAC_SHA1;
-		childsacalc.prf_hasher = (struct hash_desc *)
-			ike_alg_ikev2_find(IKE_ALG_HASH, alg, 0);
+		DBG(DBG_CONTROL,
+		    DBG_log("unsupported prf+ algorithm %d", alg));
+		return STF_FAIL;
 	}
 
 	DBG(DBG_CRYPT,
@@ -151,6 +151,7 @@ void ikev2_derive_child_keys(struct state *st, enum phase1_role role)
 	    st->st_esp.our_keymat = rkeymat.ptr;
 	}
 
+	return STF_OK;
 }
 
 

--- a/programs/pluto/ikev2_parent_I3.c
+++ b/programs/pluto/ikev2_parent_I3.c
@@ -188,7 +188,9 @@ stf_status ikev2parent_inR2(struct msg_digest *md)
         return e;
     }
 
-    ikev2_derive_child_keys(st, INITIATOR);
+    e = ikev2_derive_child_keys(st, INITIATOR);
+    if (e != STF_OK)
+	return e;
 
     c->newest_ipsec_sa = st->st_serialno;
 

--- a/tests/unit/libpluto/lp12-parentR2/output1.txt
+++ b/tests/unit/libpluto/lp12-parentR2/output1.txt
@@ -654,6 +654,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ipv6 high  fd 68 c9 f9  41 57 00 00  ff ff ff ff  ff ff ff ff
 | emitting length of IKEv2 Traffic Selector: 40
 | emitting length of IKEv2 Traffic Selector Payload: 48
+| ikev2_derive_child_keys: using oakley_sha for prf+
 | childsacalc.ni  20 98 9d 37  a8 14 a6 4d  8f f0 7c 08  d3 20 e9 e3
 | childsacalc.nr  c6 ba 31 9f  88 5b e7 b7  a2 93 85 dc  bb c6 15 84
 | ikev2_derive_child_keys: my role is RESPONDER

--- a/tests/unit/libpluto/lp17-childselfpolicy/output2.txt
+++ b/tests/unit/libpluto/lp17-childselfpolicy/output2.txt
@@ -640,6 +640,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ipv4 high  0a 02 ff ff
 | emitting length of IKEv2 Traffic Selector: 16
 | emitting length of IKEv2 Traffic Selector Payload: 24
+| ikev2_derive_child_keys: using oakley_sha for prf+
 | childsacalc.ni  20 98 9d 37  a8 14 a6 4d  8f f0 7c 08  d3 20 e9 e3
 | childsacalc.nr  c6 ba 31 9f  88 5b e7 b7  a2 93 85 dc  bb c6 15 84
 | ikev2_derive_child_keys: my role is RESPONDER

--- a/tests/unit/libpluto/lp21-certreplyselfR2/output1.txt
+++ b/tests/unit/libpluto/lp21-certreplyselfR2/output1.txt
@@ -1146,6 +1146,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ipv4 high  0a 02 ff ff
 | emitting length of IKEv2 Traffic Selector: 16
 | emitting length of IKEv2 Traffic Selector Payload: 24
+| ikev2_derive_child_keys: using oakley_sha for prf+
 | childsacalc.ni  20 98 9d 37  a8 14 a6 4d  8f f0 7c 08  d3 20 e9 e3
 | childsacalc.nr  c6 ba 31 9f  88 5b e7 b7  a2 93 85 dc  bb c6 15 84
 | ikev2_derive_child_keys: my role is RESPONDER

--- a/tests/unit/libpluto/lp22-certreplymanyR2/output1.txt
+++ b/tests/unit/libpluto/lp22-certreplymanyR2/output1.txt
@@ -1222,6 +1222,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ipv4 high  0a 02 ff ff
 | emitting length of IKEv2 Traffic Selector: 16
 | emitting length of IKEv2 Traffic Selector Payload: 24
+| ikev2_derive_child_keys: using oakley_sha for prf+
 | childsacalc.ni  20 98 9d 37  a8 14 a6 4d  8f f0 7c 08  d3 20 e9 e3
 | childsacalc.nr  c6 ba 31 9f  88 5b e7 b7  a2 93 85 dc  bb c6 15 84
 | ikev2_derive_child_keys: my role is RESPONDER

--- a/tests/unit/libpluto/lp24-certreplydaveR2/output1.txt
+++ b/tests/unit/libpluto/lp24-certreplydaveR2/output1.txt
@@ -1221,6 +1221,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ipv4 high  0a 02 ff ff
 | emitting length of IKEv2 Traffic Selector: 16
 | emitting length of IKEv2 Traffic Selector Payload: 24
+| ikev2_derive_child_keys: using oakley_sha for prf+
 | childsacalc.ni  20 98 9d 37  a8 14 a6 4d  8f f0 7c 08  d3 20 e9 e3
 | childsacalc.nr  c6 ba 31 9f  88 5b e7 b7  a2 93 85 dc  bb c6 15 84
 | ikev2_derive_child_keys: my role is RESPONDER
@@ -2710,6 +2711,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ipv4 high  0a 02 ff ff
 | emitting length of IKEv2 Traffic Selector: 16
 | emitting length of IKEv2 Traffic Selector Payload: 24
+| ikev2_derive_child_keys: using oakley_sha for prf+
 | childsacalc.ni  20 98 9d 37  a8 14 a6 4d  8f f0 7c 08  d3 20 e9 e3
 | childsacalc.nr  c6 ba 31 9f  88 5b e7 b7  a2 93 85 dc  bb c6 15 84
 | ikev2_derive_child_keys: my role is RESPONDER

--- a/tests/unit/libpluto/lp39-h2hR2/output1.txt
+++ b/tests/unit/libpluto/lp39-h2hR2/output1.txt
@@ -645,6 +645,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ipv4 high  84 d5 ee 07
 | emitting length of IKEv2 Traffic Selector: 16
 | emitting length of IKEv2 Traffic Selector Payload: 24
+| ikev2_derive_child_keys: using oakley_sha for prf+
 | childsacalc.ni  20 98 9d 37  a8 14 a6 4d  8f f0 7c 08  d3 20 e9 e3
 | childsacalc.nr  c6 ba 31 9f  88 5b e7 b7  a2 93 85 dc  bb c6 15 84
 | ikev2_derive_child_keys: my role is RESPONDER

--- a/tests/unit/libpluto/lp47-rekeyikev2-R1/output1.txt
+++ b/tests/unit/libpluto/lp47-rekeyikev2-R1/output1.txt
@@ -653,6 +653,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ipv6 high  fd 68 c9 f9  41 57 00 00  ff ff ff ff  ff ff ff ff
 | emitting length of IKEv2 Traffic Selector: 40
 | emitting length of IKEv2 Traffic Selector Payload: 48
+| ikev2_derive_child_keys: using oakley_sha for prf+
 | childsacalc.ni  20 98 9d 37  a8 14 a6 4d  8f f0 7c 08  d3 20 e9 e3
 | childsacalc.nr  c6 ba 31 9f  88 5b e7 b7  a2 93 85 dc  bb c6 15 84
 | ikev2_derive_child_keys: my role is RESPONDER
@@ -1207,6 +1208,7 @@ sending 444 bytes for STATE_PARENT_R1 through eth0:500 [132.213.238.7:500] to 19
 | ipv6 high  fd 68 c9 f9  41 57 00 00  ff ff ff ff  ff ff ff ff
 | emitting length of IKEv2 Traffic Selector: 40
 | emitting length of IKEv2 Traffic Selector Payload: 48
+| ikev2_derive_child_keys: using oakley_sha for prf+
 | childsacalc.ni  20 98 9d 37  a8 14 a6 4d  8f f0 7c 08  d3 20 e9 e3
 | childsacalc.nr  c6 ba 31 9f  88 5b e7 b7  a2 93 85 dc  bb c6 15 84
 | ikev2_derive_child_keys: my role is RESPONDER

--- a/tests/unit/libpluto/lp48-rekeyikev2-inCR1/output1.txt
+++ b/tests/unit/libpluto/lp48-rekeyikev2-inCR1/output1.txt
@@ -921,6 +921,7 @@ sending 604 bytes for ikev2child_outC1_tail through eth0:500 [192.168.1.1:500] t
 |   ip low: fd68:c9f9:4157::
 |   ip high: fd68:c9f9:4157:0:ffff:ffff:ffff:ffff
 | empty esp_info, returning defaults
+| ikev2_derive_child_keys: using oakley_sha for prf+
 | childsacalc.ni  20 98 9d 37  a8 14 a6 4d  8f f0 7c 08  d3 20 e9 e3
 | childsacalc.nr  c6 ba 31 9f  88 5b e7 b7  a2 93 85 dc  bb c6 15 84
 | ikev2_derive_child_keys: my role is INITIATOR

--- a/tests/unit/libpluto/lp55-davecert-gatewayID-R2/output1.txt
+++ b/tests/unit/libpluto/lp55-davecert-gatewayID-R2/output1.txt
@@ -1027,6 +1027,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ipv4 high  0a 02 ff ff
 | emitting length of IKEv2 Traffic Selector: 16
 | emitting length of IKEv2 Traffic Selector Payload: 24
+| ikev2_derive_child_keys: using oakley_sha for prf+
 | childsacalc.ni  20 98 9d 37  a8 14 a6 4d  8f f0 7c 08  d3 20 e9 e3
 | childsacalc.nr  c6 ba 31 9f  88 5b e7 b7  a2 93 85 dc  bb c6 15 84
 | ikev2_derive_child_keys: my role is RESPONDER

--- a/tests/unit/libpluto/lp57-rekeyv2nopfs-R1/output1.txt
+++ b/tests/unit/libpluto/lp57-rekeyv2nopfs-R1/output1.txt
@@ -653,6 +653,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ipv6 high  fd 68 c9 f9  41 57 00 00  ff ff ff ff  ff ff ff ff
 | emitting length of IKEv2 Traffic Selector: 40
 | emitting length of IKEv2 Traffic Selector Payload: 48
+| ikev2_derive_child_keys: using oakley_sha for prf+
 | childsacalc.ni  20 98 9d 37  a8 14 a6 4d  8f f0 7c 08  d3 20 e9 e3
 | childsacalc.nr  c6 ba 31 9f  88 5b e7 b7  a2 93 85 dc  bb c6 15 84
 | ikev2_derive_child_keys: my role is RESPONDER
@@ -1099,6 +1100,7 @@ sending 444 bytes for STATE_PARENT_R1 through eth0:500 [132.213.238.7:500] to 19
 | ipv6 high  fd 68 c9 f9  41 57 00 00  ff ff ff ff  ff ff ff ff
 | emitting length of IKEv2 Traffic Selector: 40
 | emitting length of IKEv2 Traffic Selector Payload: 48
+| ikev2_derive_child_keys: using oakley_sha for prf+
 | childsacalc.ni  80 01 02 03  04 05 06 07  08 09 0a 0b  0c 0d 0e 0f
 | childsacalc.nr  80 01 02 03  04 05 06 07  08 09 0a 0b  0c 0d 0e 0f
 | ikev2_derive_child_keys: my role is RESPONDER

--- a/tests/unit/libpluto/lp58-rekeyv2nopfs-inCR1/output1.txt
+++ b/tests/unit/libpluto/lp58-rekeyv2nopfs-inCR1/output1.txt
@@ -835,6 +835,7 @@ sending 348 bytes for ikev2child_outC1_tail through eth0:500 [192.168.1.1:500] t
 |   ip low: fd68:c9f9:4157::
 |   ip high: fd68:c9f9:4157:0:ffff:ffff:ffff:ffff
 | empty esp_info, returning defaults
+| ikev2_derive_child_keys: using oakley_sha for prf+
 | childsacalc.ni  80 01 02 03  04 05 06 07  08 09 0a 0b  0c 0d 0e 0f
 | childsacalc.nr  c6 ba 31 9f  88 5b e7 b7  a2 93 85 dc  bb c6 15 84
 | ikev2_derive_child_keys: my role is INITIATOR

--- a/tests/unit/libpluto/lp64-nattR2/output1.txt
+++ b/tests/unit/libpluto/lp64-nattR2/output1.txt
@@ -690,6 +690,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ipv6 high  fd 68 c9 f9  41 57 00 00  ff ff ff ff  ff ff ff ff
 | emitting length of IKEv2 Traffic Selector: 40
 | emitting length of IKEv2 Traffic Selector Payload: 48
+| ikev2_derive_child_keys: using oakley_sha for prf+
 | childsacalc.ni  20 98 9d 37  a8 14 a6 4d  8f f0 7c 08  d3 20 e9 e3
 | childsacalc.nr  c6 ba 31 9f  88 5b e7 b7  a2 93 85 dc  bb c6 15 84
 | ikev2_derive_child_keys: my role is RESPONDER


### PR DESCRIPTION
This pull request is for allowing pluto to use MD5 for keymaterial generation of a child SA negotiation, when MD5 is negotiated for the parent SA.  It was previously hardcoded to SHA1, and now uses the parent SA's negotiated alg value.