### PR TITLE
wo#6532 - avoid leaking PSK text if it is malformed

### DIFF
--- a/lib/libopenswan/secrets.c
+++ b/lib/libopenswan/secrets.c
@@ -878,23 +878,33 @@ static err_t osw_process_psk_secret(const struct secret *secrets, chunk_t *psk)
 	clonetochunk(*psk, flp->tok+1, flp->cur - flp->tok  - 2, "PSK");
 	(void) shift();
     }
-    else
+    else if (*flp->tok == '0')
     {
 	char buf[RSA_MAX_ENCODING_BYTES];	/* limit on size of binary representation of key */
 	size_t sz;
 
 	ugh = ttodatav(flp->tok, flp->cur - flp->tok, 0, buf, sizeof(buf), &sz
 	    , diag_space, sizeof(diag_space), TTODATAV_SPACECOUNTS);
-	if (ugh != NULL)
+	if (ugh == NULL)
 	{
-	    /* ttodata didn't like PSK data */
+	    /* success */
+	    clonetochunk(*psk, buf, sz, "PSK");
+	    (void) shift();
+	}
+	else if (DBGP(DBG_PRIVATE))
+	{
+	    /* ttodata didn't like PSK data - we are allowed to leak the PSK */
 	    ugh = builddiag("PSK data malformed (%s): %s", ugh, flp->tok);
 	}
 	else
 	{
-	    clonetochunk(*psk, buf, sz, "PSK");
-	    (void) shift();
+	    /* ttodata didn't like PSK data */
+	    ugh = builddiag("PSK data malformed (%s); enable plutodebug=private to log secret text.", ugh);
 	}
+    }
+    else
+    {
+	    ugh = builddiag("PSK data malformed: PSK must start with a quote or a zero.");
     }
 
     DBG(DBG_CONTROL, DBG_log("Processing PSK at line %d: %s"


### PR DESCRIPTION
if the PSK text was not quoted, the parser would log the secret text to syslog.

the solution is to only leak the secret if the plutodebug=private is enabled,
which is already leaking the PSK later in the process.