### PR TITLE
wo#6532 - select the correct newest parent SA for EVENT_SA_REPLACE

### DIFF
--- a/programs/pluto/timer.c
+++ b/programs/pluto/timer.c
@@ -545,7 +545,7 @@ handle_next_timer_event(void)
 
 		passert(st != NULL);
 		c = st->st_connection;
-		newest = (IS_PHASE1(st->st_state) || IS_PHASE15(st->st_state ))
+		newest = IS_PARENT_SA(st)
 		    ? c->newest_isakmp_sa : c->newest_ipsec_sa;
 
 		if (newest != st->st_serialno


### PR DESCRIPTION
previously, when EVENT_SA_REPLACE triggered, the code would incorrectly select
the latest child SA for comparison.  Since the child SA was always different
than the parent SA index, it would conclude that the rekey was not required,
and the parent SA would never rekey.