### PR TITLE
T6874 parent sa rekey

### DIFF
--- a/include/pluto/connections.h
+++ b/include/pluto/connections.h
@@ -438,7 +438,7 @@ extern char *fmt_conn_instance(const struct connection *c
 
 struct pending;	/* forward declaration (opaque outside connections.c) */
 
-extern void add_pending(int whack_sock
+extern int add_pending(int whack_sock
     , struct state *isakmp_sa
     , struct connection *c
     , lset_t policy
@@ -449,7 +449,7 @@ extern void add_pending(int whack_sock
 
 extern void release_pending_whacks(struct state *st, err_t story);
 extern void unpend(struct state *st);
-extern void update_pending(struct state *os, struct state *ns);
+extern int update_pending(struct state *os, struct state *ns);
 extern void flush_pending_by_state(struct state *st);
 extern void connection_discard(struct connection *c);
 

--- a/programs/pluto/ikev1.h
+++ b/programs/pluto/ikev1.h
@@ -67,7 +67,9 @@ extern stf_status aggr_not_present(int whack_sock
                                    , so_serial_t  *newstateno
                                    , lset_t policy
                                    , unsigned long try
-                                   , enum crypto_importance importance);
+                                   , enum crypto_importance importance
+				   , struct xfrm_user_sec_ctx_ike * uctx
+				   );
 
 extern void ikev1_delete_out(struct state *st);
 

--- a/programs/pluto/ikev2_parent.c
+++ b/programs/pluto/ikev2_parent.c
@@ -630,7 +630,7 @@ send_v2_notification_enc(struct msg_digest *md
 		       , chunk_t *notify_data)
 
 {
-    struct state *st = md->st;
+    struct state *st;
     struct ikev2_generic e;
     unsigned char *encstart;
     pb_stream      e_pbs, e_pbs_cipher;
@@ -638,6 +638,14 @@ send_v2_notification_enc(struct msg_digest *md
     int            ivsize;
     stf_status     ret;
     unsigned char *authstart;
+
+    st = md->st;
+    if (!st) {
+        openswan_log("cannot send notification %s/%s, state is NULL"
+                     , enum_name(&exchange_names, xchg_type)
+                     , enum_name(&ikev2_notify_names, ntf_type));
+        return STF_INTERNAL_ERROR;
+    }
 
     zero(&e);
     zero(&e_pbs);

--- a/programs/pluto/ipsec_doi.c
+++ b/programs/pluto/ipsec_doi.c
@@ -419,6 +419,36 @@ ipsecdoi_initiate(int whack_sock
     return SOS_NOBODY;
 }
 
+/* Add features of actual old state to policy.  This ensures
+ * that rekeying doesn't downgrade security.  I admit that
+ * this doesn't capture everything. */
+lset_t
+update_policy_from_state(const struct state *st, lset_t policy)
+{
+    if (st->st_pfs_group != NULL)
+        policy |= POLICY_PFS;
+    if (st->st_ah.present)
+    {
+        policy |= POLICY_AUTHENTICATE;
+        if (st->st_ah.attrs.encapsulation == ENCAPSULATION_MODE_TUNNEL)
+            policy |= POLICY_TUNNEL;
+    }
+    if (st->st_esp.present && st->st_esp.attrs.transattrs.encrypt != ESP_NULL)
+    {
+        policy |= POLICY_ENCRYPT;
+        if (st->st_esp.attrs.encapsulation == ENCAPSULATION_MODE_TUNNEL)
+            policy |= POLICY_TUNNEL;
+    }
+    if (st->st_ipcomp.present)
+    {
+        policy |= POLICY_COMPRESS;
+        if (st->st_ipcomp.attrs.encapsulation == ENCAPSULATION_MODE_TUNNEL)
+            policy |= POLICY_TUNNEL;
+    }
+
+    return policy;
+}
+
 /* Replace SA with a fresh one that is similar
  *
  * Shares some logic with ipsecdoi_initiate, but not the same!
@@ -460,30 +490,7 @@ ipsecdoi_replace(struct state *st
     }
     else
     {
-	/* Add features of actual old state to policy.  This ensures
-	 * that rekeying doesn't downgrade security.  I admit that
-	 * this doesn't capture everything.
-	 */
-	if (st->st_pfs_group != NULL)
-	    policy |= POLICY_PFS;
-	if (st->st_ah.present)
-	{
-	    policy |= POLICY_AUTHENTICATE;
-	    if (st->st_ah.attrs.encapsulation == ENCAPSULATION_MODE_TUNNEL)
-		policy |= POLICY_TUNNEL;
-	}
-	if (st->st_esp.present && st->st_esp.attrs.transattrs.encrypt != ESP_NULL)
-	{
-	    policy |= POLICY_ENCRYPT;
-	    if (st->st_esp.attrs.encapsulation == ENCAPSULATION_MODE_TUNNEL)
-		policy |= POLICY_TUNNEL;
-	}
-	if (st->st_ipcomp.present)
-	{
-	    policy |= POLICY_COMPRESS;
-	    if (st->st_ipcomp.attrs.encapsulation == ENCAPSULATION_MODE_TUNNEL)
-		policy |= POLICY_TUNNEL;
-	}
+        policy = update_policy_from_state(st, policy);
 	passert(HAS_IPSEC_POLICY(policy));
 	ipsecdoi_initiate(whack_sock
                           , old_parent_state

--- a/programs/pluto/ipsec_doi.h
+++ b/programs/pluto/ipsec_doi.h
@@ -24,6 +24,8 @@ extern so_serial_t ipsecdoi_initiate(int whack_sock
                               , struct xfrm_user_sec_ctx_ike *
 			      );
 
+extern lset_t update_policy_from_state(const struct state *st, lset_t policy);
+
 extern void ipsecdoi_replace(struct state *st
 			     , lset_t policy_add, lset_t policy_del
 			     , unsigned long try);

--- a/programs/pluto/spdb_print.c
+++ b/programs/pluto/spdb_print.c
@@ -94,6 +94,11 @@ print_sa_trans(struct db_sa *f, struct db_trans *tr)
     unsigned int i;
     printf("      transform: %u cnt: %u\n",
 	   tr->transid, tr->attr_cnt);
+    if (!tr->attrs) {
+        if (tr->attr_cnt)
+            printf("      !!! WARNING: tr->attrs found NULL\n");
+        return;
+    }
     for(i=0; i<tr->attr_cnt; i++) {
 	if(f->parentSA) {
 	    print_sa_attr_oakley(&tr->attrs[i]);
@@ -111,6 +116,11 @@ print_sa_prop(struct db_sa *f, struct db_prop *dp)
 	   , dp->protoid
 	   , enum_name(&protocol_names, dp->protoid)
 	   , dp->trans_cnt);
+    if (!dp->trans) {
+        if (dp->trans_cnt)
+            printf("      !!! WARNING: dp->trans found NULL\n");
+        return;
+    }
     for(i=0; i<dp->trans_cnt; i++) {
 	print_sa_trans(f, &dp->trans[i]);
     }
@@ -122,6 +132,11 @@ print_sa_prop_conj(struct db_sa *f, struct db_prop_conj *pc)
     unsigned int i;
     printf("  conjunctions cnt: %u\n",
 	   pc->prop_cnt);
+    if (!pc->props) {
+        if (pc->prop_cnt)
+            printf("      !!! WARNING: pc->props found NULL\n");
+        return;
+    }
     for(i=0; i<pc->prop_cnt; i++) {
 	print_sa_prop(f, &pc->props[i]);
     }
@@ -133,6 +148,11 @@ sa_print(struct db_sa *f)
     unsigned int i;
     printf("sa disjunct cnt: %u\n",
 	   f->prop_conj_cnt);
+    if (!f->prop_conjs) {
+        if (f->prop_conj_cnt)
+            printf("      !!! WARNING: f->prop_conjs found NULL\n");
+        return;
+    }
     for(i=0; i<f->prop_conj_cnt; i++) {
 	print_sa_prop_conj(f, &f->prop_conjs[i]);
     }
@@ -168,6 +188,11 @@ print_sa_v2_trans(struct db_v2_trans *tr)
 	   , enum_name(&trans_type_names, tr->transform_type)
 	   , tr->transid, en ? enum_name(en, tr->transid) : "unknown"
 	   , tr->attr_cnt);
+    if (!tr->attrs) {
+        if (tr->attr_cnt)
+            printf("      !!! WARNING: tr->attrs found NULL\n");
+        return;
+    }
     for(i=0; i<tr->attr_cnt; i++) {
 	print_sa_v2_attr(&tr->attrs[i]);
     }
@@ -182,6 +207,11 @@ print_sa_v2_prop_conj(struct db_v2_prop_conj *dp)
 	   , dp->protoid
 	   , enum_name(&protocol_names, dp->protoid)
 	   , dp->trans_cnt);
+    if (!dp->trans) {
+        if (dp->trans_cnt)
+            printf("      !!! WARNING: dp->trans found NULL\n");
+        return;
+    }
     for(i=0; i<dp->trans_cnt; i++) {
 	print_sa_v2_trans(&dp->trans[i]);
     }
@@ -193,6 +223,11 @@ print_sa_v2_prop(struct db_v2_prop *pc)
     unsigned int i;
     printf("  conjunctions cnt: %u\n",
 	   pc->prop_cnt);
+    if (!pc->props) {
+        if (pc->prop_cnt)
+            printf("      !!! WARNING: pc->props found NULL\n");
+        return;
+    }
     for(i=0; i<pc->prop_cnt; i++) {
 	    print_sa_v2_prop_conj(&pc->props[i]);
     }
@@ -204,6 +239,11 @@ sa_v2_print(struct db_sa *f)
 	unsigned int i;
 	printf("sav2 disjoint cnt: %u\n",
 	       f->prop_disj_cnt);
+	if (!f->prop_disj) {
+		if (f->prop_disj_cnt)
+			printf("      !!! WARNING: f->prop_disj found NULL\n");
+		return;
+        }
 	for(i=0; i<f->prop_disj_cnt; i++) {
 		print_sa_v2_prop(&f->prop_disj[i]);
 	}

--- a/programs/pluto/spdb_v2_struct.c
+++ b/programs/pluto/spdb_v2_struct.c
@@ -149,17 +149,30 @@ ikev2_out_sa(pb_stream *outs
     /* now send out all the proposals */
     for(pc_cnt=0; pc_cnt < sadb->prop_disj_cnt; pc_cnt++)
     {
-	struct db_v2_prop *vp = &sadb->prop_disj[pc_cnt];
+	struct db_v2_prop *vp;
 	unsigned int pr_cnt;
+
+	if (!sadb->prop_disj) {
+            openswan_log("%s: FATAL: prop_disj_cnt=%d, but prop_disj=NULL",
+                         __func__, sadb->prop_disj_cnt);
+            return STF_INTERNAL_ERROR;
+        }
+	vp = &sadb->prop_disj[pc_cnt];
 
 	/* now send out all the transforms */
 	for(pr_cnt=0; pr_cnt < vp->prop_cnt; pr_cnt++)
 	{
 	    unsigned int ts_cnt;
-	    struct db_v2_prop_conj *vpc = &vp->props[pr_cnt];
-
+	    struct db_v2_prop_conj *vpc;
 	    struct ikev2_prop p;
 	    pb_stream t_pbs;
+
+	    if (!vp->props) {
+                openswan_log("%s: FATAL: prop_cnt=%d, but props=NULL",
+                             __func__, vp->prop_cnt);
+                return STF_INTERNAL_ERROR;
+            }
+	    vpc = &vp->props[pr_cnt];
 
 	    memset(&p, 0, sizeof(p));
 

--- a/programs/pluto/state.c
+++ b/programs/pluto/state.c
@@ -473,9 +473,10 @@ delete_state(struct state *st)
 		 * otherwise continue with deletion
 		 */
 		if(IS_CHILD_SA_ESTABLISHED(st)) {
-                    DBG(DBG_CONTROL, DBG_log("sending Child SA delete equest"));
+                    DBG(DBG_CONTROL, DBG_log("sending Child SA delete request"));
                     send_delete(st);
                     change_state(st, STATE_CHILDSA_DEL);
+                    event_schedule(EVENT_SA_DELETE, 300, st);
 
                     /* actual deletion when we receive peer response*/
                     return;

--- a/programs/pluto/state.c
+++ b/programs/pluto/state.c
@@ -320,6 +320,9 @@ unhash_state(struct state *st)
     /* unlink from forward chain */
     struct state **p;
 
+    DBG(DBG_CONTROL
+	, DBG_log("removing state object #%lu", st->st_serialno));
+
     if(st->st_hashchain_prev == NULL) {
 	p = state_hash(st->st_icookie, st->st_rcookie, NULL);
 	if(*p != st) {
@@ -438,6 +441,8 @@ void free_state(struct state *st)
 #ifdef HAVE_LABELED_IPSEC
     pfreeany(st->sec_ctx);
 #endif
+    DBG(DBG_CONTROL
+	, DBG_log("freeing state object #%lu", st->st_serialno));
     pfree(st);
 }
 

--- a/programs/pluto/stubs.c
+++ b/programs/pluto/stubs.c
@@ -79,7 +79,8 @@ stf_status aggr_not_present(int whack_sock UNUSED
                             , so_serial_t  *newstateno UNUSED
 			    , lset_t policy UNUSED
 			    , unsigned long try UNUSED
-			    , enum crypto_importance importance UNUSED)
+			    , enum crypto_importance importance UNUSED
+			    , struct xfrm_user_sec_ctx_ike * uctx UNUSED)
 {
     openswan_log("An attempt to use aggressive mode was made.");
     openswan_log("This pluto does not have aggressive mode (congradulations on your wisdom)");

--- a/tests/unit/libpluto/lp08-parentR1/output1.txt
+++ b/tests/unit/libpluto/lp08-parentR1/output1.txt
@@ -220,6 +220,7 @@ sending 40 bytes for send_v2_notification through eth0:500 [132.213.238.7:500] t
 |   01 00 00 11  00 0e 00 00
 ./parentR1 deleting state #1 (STATE_PARENT_R1)
 | considering request to delete IKE parent state
+| removing state object #1
 | ICOOKIE:  00 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28

--- a/tests/unit/libpluto/lp10-parentI2/output1.txt
+++ b/tests/unit/libpluto/lp10-parentI2/output1.txt
@@ -156,6 +156,7 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | state hash entry 4
 | v2 peer and cookies match on #1
 | v2 state object #1 (parker1--jj2) found, in STATE_PARENT_I1
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
@@ -522,6 +523,7 @@ sending 556 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132.
 | pass 0: considering CHILD SAs to delete
 ./parentI2 deleting state #2 (STATE_CHILD_C0_KEYING)
 | received request to delete child state
+| removing state object #2
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28
@@ -566,6 +568,7 @@ sending 76 bytes for ikev2_delete_out through eth0:500 [192.168.1.1:500] to 132.
 ./parentI2 deleting state #1 (STATE_IKESA_DEL)
 | considering request to delete IKE parent state
 | now deleting the IKE (or parent) state
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28

--- a/tests/unit/libpluto/lp11-parentI2dup/output1.txt
+++ b/tests/unit/libpluto/lp11-parentI2dup/output1.txt
@@ -154,6 +154,7 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | state hash entry 4
 | v2 peer and cookies match on #1
 | v2 state object #1 (parker1--jj2) found, in STATE_PARENT_I1
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
@@ -477,6 +478,7 @@ sending 556 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132.
 | pass 0: considering CHILD SAs to delete
 ./parentI2duplicate deleting state #2 (STATE_CHILD_C0_KEYING)
 | received request to delete child state
+| removing state object #2
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28
@@ -517,6 +519,7 @@ sending 76 bytes for ikev2_delete_out through eth0:500 [192.168.1.1:500] to 132.
 ./parentI2duplicate deleting state #1 (STATE_IKESA_DEL)
 | considering request to delete IKE parent state
 | now deleting the IKE (or parent) state
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28

--- a/tests/unit/libpluto/lp13-parentI3/output1.txt
+++ b/tests/unit/libpluto/lp13-parentI3/output1.txt
@@ -549,7 +549,7 @@ RC=0 #1: "parker1--jj2":500 IKEv2.0 STATE_PARENT_I3 (PARENT SA established); non
 | pass 0: considering CHILD SAs to delete
 ./parentI3 deleting state #2 (STATE_CHILD_C1_KEYED)
 | received request to delete child state
-| sending Child SA delete equest
+| sending Child SA delete request
 | **emit ISAKMP Message:
 |    initiator cookie:
 |   80 01 02 03  04 05 06 07

--- a/tests/unit/libpluto/lp13-parentI3/output1.txt
+++ b/tests/unit/libpluto/lp13-parentI3/output1.txt
@@ -149,6 +149,7 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | state hash entry 4
 | v2 peer and cookies match on #1
 | v2 state object #1 (parker1--jj2) found, in STATE_PARENT_I1
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4

--- a/tests/unit/libpluto/lp16-initiateselfI2/output1.txt
+++ b/tests/unit/libpluto/lp16-initiateselfI2/output1.txt
@@ -166,6 +166,7 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [93.184.216.34:
 | state hash entry 4
 | v2 peer and cookies match on #1
 | v2 state object #1 (gateway--any) found, in STATE_PARENT_I1
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
@@ -488,6 +489,7 @@ sending 492 bytes for STATE_PARENT_I1 through eth0:500 [93.184.216.34:500] to 13
 | pass 0: considering CHILD SAs to delete
 ./initiateselfI2 deleting state #2 (STATE_CHILD_C0_KEYING)
 | received request to delete child state
+| removing state object #2
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5
@@ -532,6 +534,7 @@ sending 76 bytes for ikev2_delete_out through eth0:500 [93.184.216.34:500] to 13
 ./initiateselfI2 deleting state #1 (STATE_IKESA_DEL)
 | considering request to delete IKE parent state
 | now deleting the IKE (or parent) state
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5

--- a/tests/unit/libpluto/lp20-certificateselfI2/output1.txt
+++ b/tests/unit/libpluto/lp20-certificateselfI2/output1.txt
@@ -161,6 +161,7 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [93.184.216.34:
 | state hash entry 4
 | v2 peer and cookies match on #1
 | v2 state object #1 (home) found, in STATE_PARENT_I1
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
@@ -831,6 +832,7 @@ sending 1676 bytes for STATE_PARENT_I1 through eth0:500 [93.184.216.34:500] to 1
 | pass 0: considering CHILD SAs to delete
 ./certificateselfI2 deleting state #2 (STATE_CHILD_C0_KEYING)
 | received request to delete child state
+| removing state object #2
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5
@@ -875,6 +877,7 @@ sending 76 bytes for ikev2_delete_out through eth0:500 [93.184.216.34:500] to 13
 ./certificateselfI2 deleting state #1 (STATE_IKESA_DEL)
 | considering request to delete IKE parent state
 | now deleting the IKE (or parent) state
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5

--- a/tests/unit/libpluto/lp26-davecertI2/output1.txt
+++ b/tests/unit/libpluto/lp26-davecertI2/output1.txt
@@ -160,6 +160,7 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [93.184.216.35:
 | state hash entry 4
 | v2 peer and cookies match on #1
 | v2 state object #1 (home) found, in STATE_PARENT_I1
+| removing state object #1
 | ICOOKIE:  8d 0e 0f 10  11 12 13 14
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
@@ -786,6 +787,7 @@ sending 1628 bytes for STATE_PARENT_I1 through eth0:500 [93.184.216.35:500] to 1
 | pass 0: considering CHILD SAs to delete
 ./davecertI2 deleting state #2 (STATE_CHILD_C0_KEYING)
 | received request to delete child state
+| removing state object #2
 | ICOOKIE:  8d 0e 0f 10  11 12 13 14
 | RCOOKIE:  5d 73 ce 75  3d b1 db 6d
 | state hash entry 15
@@ -830,6 +832,7 @@ sending 76 bytes for ikev2_delete_out through eth0:500 [93.184.216.35:500] to 13
 ./davecertI2 deleting state #1 (STATE_IKESA_DEL)
 | considering request to delete IKE parent state
 | now deleting the IKE (or parent) state
+| removing state object #1
 | ICOOKIE:  8d 0e 0f 10  11 12 13 14
 | RCOOKIE:  5d 73 ce 75  3d b1 db 6d
 | state hash entry 15

--- a/tests/unit/libpluto/lp33-dnsload2/output.txt
+++ b/tests/unit/libpluto/lp33-dnsload2/output.txt
@@ -50,9 +50,9 @@ RC=0 "cpenohint":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Ini
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
 | inserting state object #1 bucket: 4
-| Queuing pending Quick Mode with 93.184.216.34 "cpenohint"
 ./dnscpeI1 initiating v2 parent SA
 ./dnscpeI1 STATE_PARENT_I1: initiate
+| Queuing pending Quick Mode with 93.184.216.34 "cpenohint"
 | ikev2 parent outI1: calculated ke+nonce, sending I1
 | **emit ISAKMP Message:
 |    initiator cookie:

--- a/tests/unit/libpluto/lp38-h2hI2/output1.txt
+++ b/tests/unit/libpluto/lp38-h2hI2/output1.txt
@@ -156,6 +156,7 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | state hash entry 4
 | v2 peer and cookies match on #1
 | v2 state object #1 (mytunnel) found, in STATE_PARENT_I1
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
@@ -508,6 +509,7 @@ sending 492 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132.
 | pass 0: considering CHILD SAs to delete
 ./h2hI2 deleting state #2 (STATE_CHILD_C0_KEYING)
 | received request to delete child state
+| removing state object #2
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28
@@ -552,6 +554,7 @@ sending 76 bytes for ikev2_delete_out through eth0:500 [192.168.1.1:500] to 132.
 ./h2hI2 deleting state #1 (STATE_IKESA_DEL)
 | considering request to delete IKE parent state
 | now deleting the IKE (or parent) state
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28

--- a/tests/unit/libpluto/lp43-parentM1/output.txt
+++ b/tests/unit/libpluto/lp43-parentM1/output.txt
@@ -451,9 +451,11 @@ sending 492 bytes for main_outI1 through eth0:500 [192.168.1.1:500] to 132.213.2
 |   68 a1 f1 c9  6b 86 96 fc  77 57 01 00
 RC=105 STATE_MAIN_I1: initiate
 ./parentM1 deleting state #1 (STATE_MAIN_I1)
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
+| freeing state object #1
 ./parentM1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete

--- a/tests/unit/libpluto/lp46-rekeyikev2-I1/output1.txt
+++ b/tests/unit/libpluto/lp46-rekeyikev2-I1/output1.txt
@@ -149,6 +149,7 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | state hash entry 4
 | v2 peer and cookies match on #1
 | v2 state object #1 (parker1--jj2) found, in STATE_PARENT_I1
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
@@ -836,6 +837,7 @@ RC=0 #1: "parker1--jj2":500 IKEv2.0 STATE_PARENT_I3 (PARENT SA established); non
 | pass 0: considering CHILD SAs to delete
 ./rekeyikev2-I1 deleting state #3 (STATE_CHILD_C1_REKEY)
 | received request to delete child state
+| removing state object #3
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28

--- a/tests/unit/libpluto/lp46-rekeyikev2-I1/output1.txt
+++ b/tests/unit/libpluto/lp46-rekeyikev2-I1/output1.txt
@@ -843,7 +843,7 @@ RC=0 #1: "parker1--jj2":500 IKEv2.0 STATE_PARENT_I3 (PARENT SA established); non
 | state hash entry 28
 ./rekeyikev2-I1 deleting state #2 (STATE_CHILD_C1_KEYED)
 | received request to delete child state
-| sending Child SA delete equest
+| sending Child SA delete request
 | **emit ISAKMP Message:
 |    initiator cookie:
 |   80 01 02 03  04 05 06 07

--- a/tests/unit/libpluto/lp48-rekeyikev2-inCR1/output1.txt
+++ b/tests/unit/libpluto/lp48-rekeyikev2-inCR1/output1.txt
@@ -955,7 +955,7 @@ RC=0 #1: "parker1--jj2":500 IKEv2.0 STATE_PARENT_I3 (PARENT SA established); non
 | pass 0: considering CHILD SAs to delete
 ./rekeyikev2-inCR1 deleting state #3 (STATE_CHILD_C1_KEYED)
 | received request to delete child state
-| sending Child SA delete equest
+| sending Child SA delete request
 | **emit ISAKMP Message:
 |    initiator cookie:
 |   80 01 02 03  04 05 06 07
@@ -994,7 +994,7 @@ sending 76 bytes for ikev2_delete_out through eth0:500 [192.168.1.1:500] to 132.
 |   bc 97 31 52  72 72 67 dd  48 83 e2 02
 ./rekeyikev2-inCR1 deleting state #2 (STATE_CHILD_C1_KEYED)
 | received request to delete child state
-| sending Child SA delete equest
+| sending Child SA delete request
 | **emit ISAKMP Message:
 |    initiator cookie:
 |   80 01 02 03  04 05 06 07

--- a/tests/unit/libpluto/lp48-rekeyikev2-inCR1/output1.txt
+++ b/tests/unit/libpluto/lp48-rekeyikev2-inCR1/output1.txt
@@ -149,6 +149,7 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | state hash entry 4
 | v2 peer and cookies match on #1
 | v2 state object #1 (parker1--jj2) found, in STATE_PARENT_I1
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4

--- a/tests/unit/libpluto/lp50-rekey-no-reply-rekey/output1.txt
+++ b/tests/unit/libpluto/lp50-rekey-no-reply-rekey/output1.txt
@@ -149,6 +149,7 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | state hash entry 4
 | v2 peer and cookies match on #1
 | v2 state object #1 (parker1--jj2) found, in STATE_PARENT_I1
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
@@ -1133,11 +1134,13 @@ RC=0 #1: "parker1--jj2":500 IKEv2.0 STATE_PARENT_I3 (PARENT SA established); non
 | pass 0: considering CHILD SAs to delete
 ./rekey-no-reply-I1 deleting state #4 (STATE_CHILD_C1_REKEY)
 | received request to delete child state
+| removing state object #4
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28
 ./rekey-no-reply-I1 deleting state #3 (STATE_CHILD_C1_REKEY)
 | received request to delete child state
+| removing state object #3
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28

--- a/tests/unit/libpluto/lp50-rekey-no-reply-rekey/output1.txt
+++ b/tests/unit/libpluto/lp50-rekey-no-reply-rekey/output1.txt
@@ -1146,7 +1146,7 @@ RC=0 #1: "parker1--jj2":500 IKEv2.0 STATE_PARENT_I3 (PARENT SA established); non
 | state hash entry 28
 ./rekey-no-reply-I1 deleting state #2 (STATE_CHILD_C1_KEYED)
 | received request to delete child state
-| sending Child SA delete equest
+| sending Child SA delete request
 | **emit ISAKMP Message:
 |    initiator cookie:
 |   80 01 02 03  04 05 06 07

--- a/tests/unit/libpluto/lp54-davecert-gatewayID-I2/output1.txt
+++ b/tests/unit/libpluto/lp54-davecert-gatewayID-I2/output1.txt
@@ -162,6 +162,7 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [93.184.216.35:
 | state hash entry 4
 | v2 peer and cookies match on #1
 | v2 state object #1 (home) found, in STATE_PARENT_I1
+| removing state object #1
 | ICOOKIE:  8d 0e 0f 10  11 12 13 14
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
@@ -799,6 +800,7 @@ sending 1580 bytes for STATE_PARENT_I1 through eth0:500 [93.184.216.35:500] to 1
 | pass 0: considering CHILD SAs to delete
 ./davecertI2-id deleting state #2 (STATE_CHILD_C0_KEYING)
 | received request to delete child state
+| removing state object #2
 | ICOOKIE:  8d 0e 0f 10  11 12 13 14
 | RCOOKIE:  75 bb 19 c5  f3 60 73 6d
 | state hash entry 13
@@ -843,6 +845,7 @@ sending 76 bytes for ikev2_delete_out through eth0:500 [93.184.216.35:500] to 13
 ./davecertI2-id deleting state #1 (STATE_IKESA_DEL)
 | considering request to delete IKE parent state
 | now deleting the IKE (or parent) state
+| removing state object #1
 | ICOOKIE:  8d 0e 0f 10  11 12 13 14
 | RCOOKIE:  75 bb 19 c5  f3 60 73 6d
 | state hash entry 13

--- a/tests/unit/libpluto/lp56-rekeyv2nopfs-I1/output1.txt
+++ b/tests/unit/libpluto/lp56-rekeyv2nopfs-I1/output1.txt
@@ -149,6 +149,7 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | state hash entry 4
 | v2 peer and cookies match on #1
 | v2 state object #1 (parker1--jj2--nopfs) found, in STATE_PARENT_I1
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
@@ -767,6 +768,7 @@ RC=0 #1: "parker1--jj2--nopfs":500 IKEv2.0 STATE_PARENT_I3 (PARENT SA establishe
 ./rekeyv2nopfs-I1 deleting state #3 (STATE_CHILD_C1_REKEY)
 | received request to delete child state
 | disconnecting state #3 from md
+| removing state object #3
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28
@@ -847,6 +849,7 @@ sending 76 bytes for ikev2_delete_out through eth0:500 [192.168.1.1:500] to 132.
 |   80 01 02 03  04 05 06 07  08 09 0a 0b  0c 0d 0e 0f
 |   23 56 8c 9a  7c 01 7c 8e  c1 2a 91 9a  c4 da 80 c2
 |   4a 21 e4 b4  7a ae c5 28  b6 ea e0 30
+| freeing state object #1
 ./rekeyv2nopfs-I1 leak: reply packet for ikev2_out_C1_tail, item size: X
 ./rekeyv2nopfs-I1 leak: db_v2_trans, item size: X
 ./rekeyv2nopfs-I1 leak: db_v2_prop_conj, item size: X

--- a/tests/unit/libpluto/lp56-rekeyv2nopfs-I1/output1.txt
+++ b/tests/unit/libpluto/lp56-rekeyv2nopfs-I1/output1.txt
@@ -774,7 +774,7 @@ RC=0 #1: "parker1--jj2--nopfs":500 IKEv2.0 STATE_PARENT_I3 (PARENT SA establishe
 | state hash entry 28
 ./rekeyv2nopfs-I1 deleting state #2 (STATE_CHILD_C1_KEYED)
 | received request to delete child state
-| sending Child SA delete equest
+| sending Child SA delete request
 | **emit ISAKMP Message:
 |    initiator cookie:
 |   80 01 02 03  04 05 06 07

--- a/tests/unit/libpluto/lp58-rekeyv2nopfs-inCR1/output1.txt
+++ b/tests/unit/libpluto/lp58-rekeyv2nopfs-inCR1/output1.txt
@@ -870,7 +870,7 @@ RC=0 #1: "parker1--jj2--nopfs":500 IKEv2.0 STATE_PARENT_I3 (PARENT SA establishe
 | pass 0: considering CHILD SAs to delete
 ./rekeyv2nopfs-inCR1 deleting state #3 (STATE_CHILD_C1_KEYED)
 | received request to delete child state
-| sending Child SA delete equest
+| sending Child SA delete request
 | **emit ISAKMP Message:
 |    initiator cookie:
 |   80 01 02 03  04 05 06 07
@@ -909,7 +909,7 @@ sending 76 bytes for ikev2_delete_out through eth0:500 [192.168.1.1:500] to 132.
 |   bc 97 31 52  72 72 67 dd  48 83 e2 02
 ./rekeyv2nopfs-inCR1 deleting state #2 (STATE_CHILD_C1_KEYED)
 | received request to delete child state
-| sending Child SA delete equest
+| sending Child SA delete request
 | **emit ISAKMP Message:
 |    initiator cookie:
 |   80 01 02 03  04 05 06 07

--- a/tests/unit/libpluto/lp58-rekeyv2nopfs-inCR1/output1.txt
+++ b/tests/unit/libpluto/lp58-rekeyv2nopfs-inCR1/output1.txt
@@ -149,6 +149,7 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | state hash entry 4
 | v2 peer and cookies match on #1
 | v2 state object #1 (parker1--jj2--nopfs) found, in STATE_PARENT_I1
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4

--- a/tests/unit/libpluto/lp63-nattI2/output1.txt
+++ b/tests/unit/libpluto/lp63-nattI2/output1.txt
@@ -157,6 +157,7 @@ picking: eth0:500  outside: 55044 <=> d: 55044
 | state hash entry 4
 | v2 peer and cookies match on #1
 | v2 state object #1 (parker1--jj2) found, in STATE_PARENT_I1
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
@@ -529,6 +530,7 @@ sending 556 bytes for STATE_PARENT_I1 through eth0:4500 [93.184.216.34:55045] to
 | pass 0: considering CHILD SAs to delete
 ./nattI2 deleting state #2 (STATE_CHILD_C0_KEYING)
 | received request to delete child state
+| removing state object #2
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5
@@ -573,6 +575,7 @@ sending 76 bytes for ikev2_delete_out through eth0:4500 [93.184.216.34:55045] to
 ./nattI2 deleting state #1 (STATE_IKESA_DEL)
 | considering request to delete IKE parent state
 | now deleting the IKE (or parent) state
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5

--- a/tests/unit/libpluto/lp65-nattI3/output1.txt
+++ b/tests/unit/libpluto/lp65-nattI3/output1.txt
@@ -150,6 +150,7 @@ picking: eth0:500  outside: 55044 <=> d: 55044
 | state hash entry 4
 | v2 peer and cookies match on #1
 | v2 state object #1 (parker1--jj2) found, in STATE_PARENT_I1
+| removing state object #1
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4

--- a/tests/unit/libpluto/lp65-nattI3/output1.txt
+++ b/tests/unit/libpluto/lp65-nattI3/output1.txt
@@ -336,7 +336,7 @@ RC=0 #1: "parker1--jj2":4500 IKEv2.0 STATE_PARENT_I3 (PARENT SA established); no
 | pass 0: considering CHILD SAs to delete
 ./nattI3 deleting state #2 (STATE_CHILD_C1_KEYED)
 | received request to delete child state
-| sending Child SA delete equest
+| sending Child SA delete request
 sending 76 bytes for ikev2_delete_out through eth0:4500 [93.184.216.34:55045] to 132.213.238.7:4500 (using #1)
 |   80 01 02 03  04 05 06 07  64 0a 06 43  5c 7c 4b 31
 |   2e 20 25 08  00 00 00 02  00 00 00 4c  2a 00 00 30

--- a/tests/unit/libpluto/seam_pending.c
+++ b/tests/unit/libpluto/seam_pending.c
@@ -9,7 +9,7 @@ static struct connection *pending_c;
 static int pending_whack_sock;
 static lset_t pending_policy;
 
-void
+int
 add_pending(int whack_sock
 	    , struct state *isakmp_sa
 	    , struct connection *c
@@ -22,12 +22,14 @@ add_pending(int whack_sock
 	pending_c = c;
 	pending_policy = policy;
 	pending_whack_sock = whack_sock;
+
+	return 0;
 }
 
-void
+int
 update_pending(struct state *os, struct state *ns)
 {
-	/* nothing */
+	return 0;
 }
 
 struct connection *first_pending(struct state *st, lset_t *policy, int *p_whack_sock)


### PR DESCRIPTION
This pull requests fixes a bunch of little things that prevented a successful IKEv2 SA rekey (the parent SA), if the INITIATOR/RESPONDER roles became reversed.  That is if the original parent SA responder now initiated the parent SA rekey.  It would previously fail on the first such attempt, it's been observed to successfully reverse the INITIATOR/RESPONDER roles (with specially crafted code to induce this) 10+ times back-to-back without issues.