### PR TITLE
T7003 deleting too many SAs

### DIFF
--- a/programs/pluto/ikev2_parent.c
+++ b/programs/pluto/ikev2_parent.c
@@ -767,12 +767,16 @@ stf_status process_informational_ikev2(struct msg_digest *md)
 	stf_status ret;
         if(IKEv2_ORIGINAL_INITIATOR(md->hdr.isa_flags)) {
            DBG(DBG_CONTROLMORE
-              , DBG_log("received informational exchange request from INITIATOR"));
+              , DBG_log("received informational exchange %s from INITIATOR"
+                        , IKEv2_MSG_FROM_INITIATOR(md->hdr.isa_flags)
+                            ? "request" : "response"));
            ret = ikev2_decrypt_msg(md, RESPONDER);
         }
         else {
            DBG(DBG_CONTROLMORE
-              , DBG_log("received informational exchange request from RESPONDER"));
+              , DBG_log("received informational exchange %s from RESPONDER"
+                        , IKEv2_MSG_FROM_INITIATOR(md->hdr.isa_flags)
+                            ? "request" : "response"));
            ret = ikev2_decrypt_msg(md, INITIATOR);
         }
 

--- a/programs/pluto/state.h
+++ b/programs/pluto/state.h
@@ -442,6 +442,7 @@ struct connection;	/* forward declaration of tag */
 extern void delete_states_by_connection(struct connection *c, bool relations);
 extern void delete_p2states_by_connection(struct connection *c);
 extern void rekey_p2states_by_connection(struct connection *c);
+extern void delete_state_family(struct state *pst, bool v2_responder_state);
 
 extern struct state
     *duplicate_state(struct state *st),


### PR DESCRIPTION
When receiving a IKE/parent SA delete request (or acknowledgement) pluto would be susceptible to a hash collision bug, where it would delete more SAs than was intended.  Part of the fix comes from Libreswan where this was already addressed.  Specifically the function delete_state_family() function added in commit f1cde81 is based on delete_my_family() which comes from Libreswan.