### PR TITLE
T5532 non pfs rekey abort

### DIFF
--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -1379,7 +1379,8 @@ static stf_status ikev2child_inCI1_nopfs(struct msg_digest *md)
     /* process nonce coming in */
     rn = accept_v2_nonce(md, &st->st_ni, "Ni");
     if(rn != v2N_NOTHING_WRONG) {
-	send_v2_notification_from_state(st, st->st_state, rn, NULL);
+        enum isakmp_xchg_types xchg = md->hdr.isa_xchg;
+        send_v2_notification_from_state(st, xchg, rn, NULL);
         loglog(RC_LOG_SERIOUS, "no valid Nonce payload found");
 	return STF_INTERNAL_ERROR;
     }
@@ -1495,7 +1496,8 @@ static void ikev2child_inCI1_continue1(struct pluto_crypto_req_cont *pcrc
     /* Ni in */
     rn = accept_v2_nonce(md, &st->st_ni, "Ni");
     if(rn != v2N_NOTHING_WRONG) {
-	send_v2_notification_from_state(st, st->st_state, rn, NULL);
+        enum isakmp_xchg_types xchg = md->hdr.isa_xchg;
+        send_v2_notification_from_state(st, xchg, rn, NULL);
         loglog(RC_LOG_SERIOUS, "no valid Nonce payload found");
         goto returnerr;
     }
@@ -1739,7 +1741,8 @@ static stf_status ikev2child_inCR1_decrypt(struct msg_digest *md)
     /* Nr in */
     rn = accept_v2_nonce(md, &st->st_nr, "Nr");
     if(rn != v2N_NOTHING_WRONG) {
-	send_v2_notification_from_state(st, st->st_state, rn, NULL);
+        enum isakmp_xchg_types xchg = md->hdr.isa_xchg;
+        send_v2_notification_from_state(st, xchg, rn, NULL);
         loglog(RC_LOG_SERIOUS, "no valid Nonce payload found");
         return STF_FAIL;
     }

--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -1063,7 +1063,6 @@ stf_status ikev2child_outC1(int whack_sock
                 loglog(RC_CRYPTOFAILED, "system too busy");
                 delete_state(st);
             }
-            reset_globals();
 
         } else {
             /* this case is that st_sec already is initialized, not doing PFS,
@@ -1075,6 +1074,7 @@ stf_status ikev2child_outC1(int whack_sock
             complete_v2_state_transition(&ke->md, e);
             pfree(ke);
         }
+        reset_globals();
 
         return e;
     }

--- a/programs/pluto/ikev2_parent.c
+++ b/programs/pluto/ikev2_parent.c
@@ -553,6 +553,42 @@ static bool ikev2_get_dcookie(u_char *dcookie,  chunk_t st_ni
 #include "ikev2_parent_R2.c"
 #include "ikev2_parent_I3.c"
 
+static inline bool isakmp_xchg_type_is_valid(enum isakmp_xchg_types xchg)
+{
+    switch (xchg) {
+    default:
+        return FALSE;
+
+    case ISAKMP_XCHG_NONE:
+    case ISAKMP_XCHG_BASE:
+    case ISAKMP_XCHG_IDPROT:
+    case ISAKMP_XCHG_AO:
+    case ISAKMP_XCHG_AGGR:
+    case ISAKMP_XCHG_INFO:
+    case ISAKMP_XCHG_MODE_CFG:
+
+    /* Private exchanges to pluto -- tried to write an RFC */
+    case ISAKMP_XCHG_ECHOREQUEST:
+    case ISAKMP_XCHG_ECHOREPLY:
+
+    /* Extra exchange types, defined by Oakley
+     * RFC2409 "The Internet Key Exchange (IKE)", near end of Appendix A
+     */
+    case ISAKMP_XCHG_QUICK:
+    case ISAKMP_XCHG_NGRP:
+
+    /* IKEv2 things */
+    case ISAKMP_v2_SA_INIT:
+    case ISAKMP_v2_AUTH:
+    case ISAKMP_v2_CHILD_SA:
+    case ISAKMP_v2_INFORMATIONAL:
+
+    case ISAKMP_XCHG_ECHOREQUEST_PRIVATE:
+    case ISAKMP_XCHG_ECHOREPLY_PRIVATE:
+        return TRUE;
+    }
+}
+
 /*
  *
  ***************************************************************
@@ -585,6 +621,8 @@ send_v2_notification(struct state *p1st
                  , enum_name(&ikev2_notify_names, ntf_type)
                  , p1st ? ip_str(&p1st->st_remoteaddr) : "-"
                  , p1st ? p1st->st_remoteport : 0);
+
+    passert(isakmp_xchg_type_is_valid(xchg_type));
 
     zero(reply_buffer);
     init_pbs(&reply, reply_buffer, sizeof(reply_buffer), "notification msg");


### PR DESCRIPTION
This pull request does not fully address the issues in 7304/5532.

The following changes are submitted:
(1) if peer sends us a KE, but policy negotiated was non-PFS, ignore the KE
(2) avoid crash in ikev2child_outC1() when canceling out of an incomplete child rekey
(3) always use incoming exchange type, when generating notifications in R2
(4) self validation of inputs into send_v2_notification()