### PR TITLE
wo#7417 . prevent ikev2_validate_key_lengths() from accessing NULL pointers

### DIFF
--- a/programs/pluto/ipsec_doi.c
+++ b/programs/pluto/ipsec_doi.c
@@ -958,47 +958,55 @@ void fmt_isakmp_sa_established(struct state *st, char *sadetails, int sad_len)
 
 void __ikev2_validate_key_lengths(struct state *st, const char *fn, int ln)
 {
-    size_t expected_enc_key_len, expected_integ_key_len;
+    const char *enc_name, *integ_name;
+    size_t expected_enc_key_bytes, expected_integ_key_bytes;
 
-    expected_enc_key_len = st->st_oakley.enckeylen / 8;
+    if (!st)
+	return;
 
-    if (expected_enc_key_len != st->st_skey_ei.len)
+    /* test the encryption key length */
+    enc_name = st->st_oakley.encrypter
+	? st->st_oakley.encrypter->common.officname : "?",
+    expected_enc_key_bytes = st->st_oakley.enckeylen / 8;
+
+    if (expected_enc_key_bytes != st->st_skey_ei.len) {
         DBG_log("WARNING: %s:%u: encryptor '%s' expects keylen %ld/%d, SA #%ld INITIATOR keylen is %ld",
-                fn, ln,
-                st->st_oakley.encrypter->common.officname,
-                expected_enc_key_len,
+                fn, ln, enc_name, expected_enc_key_bytes,
                 st->st_oakley.enckeylen,
                 st->st_serialno,
                 st->st_skey_ei.len);
+    }
 
-    if (expected_enc_key_len != st->st_skey_er.len)
+    if (expected_enc_key_bytes != st->st_skey_er.len) {
         DBG_log("WARNING: %s:%u: encryptor '%s' expects keylen %ld/%d, SA #%ld RESPONDER keylen is %ld",
-                fn, ln,
-                st->st_oakley.encrypter->common.officname,
-                expected_enc_key_len,
+                fn, ln, enc_name, expected_enc_key_bytes,
                 st->st_oakley.enckeylen,
                 st->st_serialno,
                 st->st_skey_er.len);
+    }
 
-    expected_integ_key_len = st->st_oakley.integ_hasher->hash_key_size;
+    if (!st->st_oakley.integ_hasher)
+	return;
 
-    if (expected_integ_key_len != st->st_skey_ai.len)
+    /* we have the integ_hasher, test the integrity key length */
+    integ_name = st->st_oakley.integ_hasher->common.officname;
+    expected_integ_key_bytes = st->st_oakley.integ_hasher->hash_key_size;
+
+    if (expected_integ_key_bytes != st->st_skey_ai.len) {
         DBG_log("WARNING: %s:%u: hasher '%s' expects keylen %ld/%ld, SA #%ld INITIATOR keylen is %ld",
-                fn, ln,
-                st->st_oakley.integ_hasher->common.officname,
-                expected_integ_key_len,
+                fn, ln, integ_name, expected_integ_key_bytes,
                 st->st_oakley.integ_hasher->hash_key_size,
                 st->st_serialno,
                 st->st_skey_ai.len);
+    }
 
-    if (expected_integ_key_len != st->st_skey_ar.len)
+    if (expected_integ_key_bytes != st->st_skey_ar.len) {
         DBG_log("WARNING: %s:%u: hasher '%s' expects keylen %ld/%ld, SA #%ld RESPONDER keylen is %ld",
-                fn, ln,
-                st->st_oakley.integ_hasher->common.officname,
-                expected_integ_key_len,
+                fn, ln, integ_name, expected_integ_key_bytes,
                 st->st_oakley.integ_hasher->hash_key_size,
                 st->st_serialno,
                 st->st_skey_ar.len);
+    }
 }
 
 


### PR DESCRIPTION
This fixes a regression added in commit 7dfffce, related to issue 7092.