### PR TITLE
wo#7456 . cleanup the documentation of unit tests lp{80..86}

### DIFF
--- a/tests/unit/libpluto/lp80-h2h-rekeyikev2-R2-msgid0/description.txt
+++ b/tests/unit/libpluto/lp80-h2h-rekeyikev2-R2-msgid0/description.txt
@@ -14,25 +14,23 @@ Initiator                                                             Responder
 
                               --- 08:39:04 ---
 
-INIT, I, id 0
-[ SA KE No N(NATD_S_IP) N(NATD_D_IP) V ] ----->
+INIT, I, id 0                                                                     <- lp36
+[ SA KE No N(NATD_S_IP) N(NATD_D_IP) V ] ----->                                   <- send INIT req
 
-                            INIT, R, id 0
-                     <----- [ SA KE No N(NATD_S_IP) N(NATD_D_IP) N(MULT_AUTH) ]
+                            INIT, R, id 0                                         <- lp37
+                     <----- [ SA KE No N(NATD_S_IP) N(NATD_D_IP) N(MULT_AUTH) ]   <- accept INIT req, send INIT resp
 
-AUTH, I, id 1
-[ IDi AUTH SA TSi TSr ] ----->
+AUTH, I, id 1                                                                     <- lp38
+[ IDi AUTH SA TSi TSr ] ----->                                                    <- accept INIT resp, send AUTH req
 
-                                            AUTH, R, id 1
-                                     <----- [ IDr AUTH SA TSi TSr N(AUTH_LFT) ]
+                                            AUTH, R, id 1                         <- lp39
+                                     <----- [ IDr AUTH SA TSi TSr N(AUTH_LFT) ]   <- accept AUTH req, send AUTH resp
 
                               --- 08:42:06 ---
 
-CREATE_CHILD_SA, I, id 2
-[ KE No SA TSi TSr ] ----->
-
-                                                       CREATE_CHILD_SA, R, id 2
-                                                <----- [ SA No TSi TSr ]
+# NOTE: in the wild, there may have been many successful CREATE CHILD SA exchanges
+# initiated by the original Initiator.  This test case emulates a rare condition
+# where the original Responder requests a CHILD rekey.
 
                               --- 08:43:03 ---
                                                                                   <- 

--- a/tests/unit/libpluto/lp81-h2h-rekeyikev2-I3-msgid0/description.txt
+++ b/tests/unit/libpluto/lp81-h2h-rekeyikev2-I3-msgid0/description.txt
@@ -16,25 +16,23 @@ Initiator                                                             Responder
 
                               --- 08:39:04 ---
 
-INIT, I, id 0
-[ SA KE No N(NATD_S_IP) N(NATD_D_IP) V ] ----->
+INIT, I, id 0                                                                     <- lp36
+[ SA KE No N(NATD_S_IP) N(NATD_D_IP) V ] ----->                                   <- send INIT req
 
-                            INIT, R, id 0
-                     <----- [ SA KE No N(NATD_S_IP) N(NATD_D_IP) N(MULT_AUTH) ]
+                            INIT, R, id 0                                         <- lp37
+                     <----- [ SA KE No N(NATD_S_IP) N(NATD_D_IP) N(MULT_AUTH) ]   <- accept INIT req, send INIT resp
 
-AUTH, I, id 1
-[ IDi AUTH SA TSi TSr ] ----->
+AUTH, I, id 1                                                                     <- lp38
+[ IDi AUTH SA TSi TSr ] ----->                                                    <- accept INIT resp, send AUTH req
 
-                                            AUTH, R, id 1
-                                     <----- [ IDr AUTH SA TSi TSr N(AUTH_LFT) ]
+                                            AUTH, R, id 1                         <- lp39
+                                     <----- [ IDr AUTH SA TSi TSr N(AUTH_LFT) ]   <- accept AUTH req, send AUTH resp
 
                               --- 08:42:06 ---
 
-CREATE_CHILD_SA, I, id 2
-[ KE No SA TSi TSr ] ----->
-
-                                                       CREATE_CHILD_SA, R, id 2
-                                                <----- [ SA No TSi TSr ]
+# NOTE: in the wild, there may have been many successful CREATE CHILD SA exchanges
+# initiated by the original Initiator.  This test case emulates a rare condition
+# where the original Responder requests a CHILD rekey.
 
                               --- 08:43:03 ---
                                                                                   <- 

--- a/tests/unit/libpluto/lp82-h2h-deleteSA-R2/description.txt
+++ b/tests/unit/libpluto/lp82-h2h-deleteSA-R2/description.txt
@@ -1,12 +1,11 @@
-This test case is an IKEv2 responder for the first SA, which then decides to
-delete the child SA (before the other end).  To simulate behaviour of 
-Strongswan, this end is made to send out a CREATE_CHILD_SA message with 
-msgid of 0.
+This test case is an IKEv2 Responder for the first SA, which then decides to
+delete the child SA (before the other end).  To simulate behaviour of
+Strongswan, this end is made to send out an INFO/D message with msgid of 0.
 
 This uses the I1/R1/I2/R2/I3 pcap files from lp36 thru lp39.
 
-The output packet of this test will be sent to the next test lp83.  Together
-the interaction is intended to look like this:
+The output packet of this test, the INFO/D message, will be sent to the next
+test lp83.  Together the interaction is intended to look like this:
 
 
 Initiator                                                             Responder
@@ -14,25 +13,24 @@ Initiator                                                             Responder
 
                               --- 08:39:04 ---
 
-INIT, I, id 0
-[ SA KE No N(NATD_S_IP) N(NATD_D_IP) V ] ----->
+INIT, I, id 0                                                                     <- lp36
+[ SA KE No N(NATD_S_IP) N(NATD_D_IP) V ] ----->                                   <- send INIT req
 
-                            INIT, R, id 0
-                     <----- [ SA KE No N(NATD_S_IP) N(NATD_D_IP) N(MULT_AUTH) ]
+                            INIT, R, id 0                                         <- lp37
+                     <----- [ SA KE No N(NATD_S_IP) N(NATD_D_IP) N(MULT_AUTH) ]   <- accept INIT req, send INIT resp
 
-AUTH, I, id 1
-[ IDi AUTH SA TSi TSr ] ----->
+AUTH, I, id 1                                                                     <- lp38
+[ IDi AUTH SA TSi TSr ] ----->                                                    <- accept INIT resp, send AUTH req
 
-                                            AUTH, R, id 1
-                                     <----- [ IDr AUTH SA TSi TSr N(AUTH_LFT) ]
+                                            AUTH, R, id 1                         <- lp39
+                                     <----- [ IDr AUTH SA TSi TSr N(AUTH_LFT) ]   <- accept AUTH req, send AUTH resp
 
                               --- 08:42:06 ---
 
-CREATE_CHILD_SA, I, id 2
-[ KE No SA TSi TSr ] ----->
-
-                                                       CREATE_CHILD_SA, R, id 2
-                                                <----- [ SA No TSi TSr ]
+# NOTE: in the real exchange, the Initiator would first send out a
+# CREATE_CHILD_SA, which is already tested for in other test cases.  Here, we
+# skip negotiating CHILD SA #3, and skip directly to the Responder initiating
+# the deletion of #2, which is what's being tested.
 
                               --- 08:43:03 ---
                                                                                   <- 

--- a/tests/unit/libpluto/lp83-h2h-deleteSA-I3/description.txt
+++ b/tests/unit/libpluto/lp83-h2h-deleteSA-I3/description.txt
@@ -1,9 +1,9 @@
-This test case continues lp80, where the IKEv2 original responder will delete
+This test case continues lp82, where the IKEv2 original Responder will delete
 a child SA (before the original initiator).  In this test case, we are the
-initiator and we will receive the request to delete the child SA for the first
+Initiator and we will receive the request to delete the child SA for the first
 time.
 
-NOTE: To simulate behaviour of Strongswan, the other end (lp80) sent us
+NOTE: To simulate behaviour of Strongswan, the other end (lp82) sent us
 a CREATE_CHILD_SA message with msgid of 0.
 
 This uses the I1/R1/I2/R2/I3 pcap files from lp36 thru lp39.  Some packets
@@ -15,25 +15,24 @@ Initiator                                                             Responder
 
                               --- 08:39:04 ---
 
-INIT, I, id 0
-[ SA KE No N(NATD_S_IP) N(NATD_D_IP) V ] ----->
+INIT, I, id 0                                                                     <- lp36
+[ SA KE No N(NATD_S_IP) N(NATD_D_IP) V ] ----->                                   <- send INIT req
 
-                            INIT, R, id 0
-                     <----- [ SA KE No N(NATD_S_IP) N(NATD_D_IP) N(MULT_AUTH) ]
+                            INIT, R, id 0                                         <- lp37
+                     <----- [ SA KE No N(NATD_S_IP) N(NATD_D_IP) N(MULT_AUTH) ]   <- accept INIT req, send INIT resp
 
-AUTH, I, id 1
-[ IDi AUTH SA TSi TSr ] ----->
+AUTH, I, id 1                                                                     <- lp38
+[ IDi AUTH SA TSi TSr ] ----->                                                    <- accept INIT resp, send AUTH req
 
-                                            AUTH, R, id 1
-                                     <----- [ IDr AUTH SA TSi TSr N(AUTH_LFT) ]
+                                            AUTH, R, id 1                         <- lp39
+                                     <----- [ IDr AUTH SA TSi TSr N(AUTH_LFT) ]   <- accept AUTH req, send AUTH resp
 
                               --- 08:42:06 ---
 
-CREATE_CHILD_SA, I, id 2
-[ KE No SA TSi TSr ] ----->
-
-                                                       CREATE_CHILD_SA, R, id 2
-                                                <----- [ SA No TSi TSr ]
+# NOTE: in the real exchange, the Initiator would first send out a
+# CREATE_CHILD_SA, which is already tested for in other test cases.  Here, we
+# skip negotiating CHILD SA #3, and skip directly to the Responder initiating
+# the deletion of #2, which is what's being tested.
 
                               --- 08:43:03 ---
                                                                                   <- 

--- a/tests/unit/libpluto/lp85-h2h-invalid-deleteSA-I3/description.txt
+++ b/tests/unit/libpluto/lp85-h2h-invalid-deleteSA-I3/description.txt
@@ -1,14 +1,14 @@
-This test case continues lp80, where the IKEv2 original responder will delete
-a child SA (before the original initiator).  In this test case, we are the
-initiator and we will receive the request to delete the child SA for the first
-time.
+This test case continues lp82, where the IKEv2 original Responder will delete a
+child SA (before the original Initiator).  In this test case, we are the
+Initiator and we will receive the request (from lp82) to delete the child SA
+for the first time.
 
 This test case bulds on lp82/lp83/lp84 where this transaction was successful.
-Instead, lp85/lp86 simulate an encrypted request that cannot be handled, and
-a failed notification is sent out.
+Instead, lp85 simulates an encrypted request that cannot be handled, and a
+failed notification is sent out to lp86.
 
-This uses the I1/R1/I2/R2/I3 pcap files from lp36 thru lp39.  Some packets
-come from lp82.
+This uses the I1/R1/I2/R2/I3 pcap files from lp36 thru lp39.  Some packets come
+from lp82.
 
 
 Initiator                                                             Responder
@@ -16,25 +16,24 @@ Initiator                                                             Responder
 
                               --- 08:39:04 ---
 
-INIT, I, id 0
-[ SA KE No N(NATD_S_IP) N(NATD_D_IP) V ] ----->
+INIT, I, id 0                                                                     <- lp36
+[ SA KE No N(NATD_S_IP) N(NATD_D_IP) V ] ----->                                   <- send INIT req
 
-                            INIT, R, id 0
-                     <----- [ SA KE No N(NATD_S_IP) N(NATD_D_IP) N(MULT_AUTH) ]
+                            INIT, R, id 0                                         <- lp37
+                     <----- [ SA KE No N(NATD_S_IP) N(NATD_D_IP) N(MULT_AUTH) ]   <- accept INIT req, send INIT resp
 
-AUTH, I, id 1
-[ IDi AUTH SA TSi TSr ] ----->
+AUTH, I, id 1                                                                     <- lp38
+[ IDi AUTH SA TSi TSr ] ----->                                                    <- accept INIT resp, send AUTH req
 
-                                            AUTH, R, id 1
-                                     <----- [ IDr AUTH SA TSi TSr N(AUTH_LFT) ]
+                                            AUTH, R, id 1                         <- lp39
+                                     <----- [ IDr AUTH SA TSi TSr N(AUTH_LFT) ]   <- accept AUTH req, send AUTH resp
 
                               --- 08:42:06 ---
 
-CREATE_CHILD_SA, I, id 2
-[ KE No SA TSi TSr ] ----->
-
-                                                       CREATE_CHILD_SA, R, id 2
-                                                <----- [ SA No TSi TSr ]
+# NOTE: in the real exchange, the Initiator would first send out a
+# CREATE_CHILD_SA, which is already tested for in other test cases.  Here, we
+# skip negotiating CHILD SA #3, and skip directly to the Responder initiating
+# the deletion of #2, which is what's being tested.
 
                               --- 08:43:03 ---
                                                                                   <- 
@@ -42,8 +41,13 @@ CREATE_CHILD_SA, I, id 2
                                              <----- [ D ]                         <- state: R2 
                                                                                   <-
 
+# NOTE: this test case corrupts the microcode state table, to prevent the
+# processing of INFORMATIONAL messages.  The intent of lp85 test case is for
+# the Intiator to send an encrypted NOTIFICATION back to the Responder's
+# request.
+
                                                                                   <-
-INFORMATIONAL, IR, id 0                                                           <- lp85
+INFORMATIONAL, IR, id 0                                                           <- lp85/lp86
 [ N ] ----->                                                                      <- state: I3
                                                                                   <-
 

--- a/tests/unit/libpluto/lp86-h2h-invalid-deleteSA-R2-R/description.txt
+++ b/tests/unit/libpluto/lp86-h2h-invalid-deleteSA-R2-R/description.txt
@@ -12,3 +12,44 @@ our SA.
 This uses the I1/R1/I2/R2/I3 pcap files from lp36 thru lp39.  From lp85 we take
 the request response, which will finish the delete exchange.
 
+
+
+Initiator                                                             Responder
+-------------------------------------------------------------------------------
+
+                              --- 08:39:04 ---
+
+INIT, I, id 0                                                                     <- lp36
+[ SA KE No N(NATD_S_IP) N(NATD_D_IP) V ] ----->                                   <- send INIT req
+
+                            INIT, R, id 0                                         <- lp37
+                     <----- [ SA KE No N(NATD_S_IP) N(NATD_D_IP) N(MULT_AUTH) ]   <- accept INIT req, send INIT resp
+
+AUTH, I, id 1                                                                     <- lp38
+[ IDi AUTH SA TSi TSr ] ----->                                                    <- accept INIT resp, send AUTH req
+
+                                            AUTH, R, id 1                         <- lp39
+                                     <----- [ IDr AUTH SA TSi TSr N(AUTH_LFT) ]   <- accept AUTH req, send AUTH resp
+
+                              --- 08:42:06 ---
+
+# NOTE: in the real exchange, the Initiator would first send out a
+# CREATE_CHILD_SA, which is already tested for in other test cases.  Here, we
+# skip negotiating CHILD SA #3, and skip directly to the Responder initiating
+# the deletion of #2, which is what's being tested.
+
+                              --- 08:43:03 ---
+                                                                                  <- 
+                                                    INFORMATIONAL, id 0           <- lp82
+                                             <----- [ D ]                         <- state: R2 
+                                                                                  <-
+
+# NOTE: in lp85 we prevented pluto from handling the INFO/D message from lp82.
+# In this test case, lp86, we will process the notification, and confirm that
+# the (failed) DELETE did not occur.
+
+                                                                                  <-
+INFORMATIONAL, IR, id 0                                                           <- lp85/lp86
+[ N ] ----->                                                                      <- state: I3
+                                                                                  <-
+


### PR DESCRIPTION
Michael noticed some inconsistencies between the documentation and actual test cases.

This commit addresses the documentations errors.