### PR TITLE
T7572 double nat crash

### DIFF
--- a/lib/libopenswan/sameaddr.c
+++ b/lib/libopenswan/sameaddr.c
@@ -38,6 +38,9 @@ const ip_address *b;
 	size_t n = (as < bs) ? as : bs;		/* min(as, bs) */
 	int c = memcmp(ap, bp, n);
 
+	if (!at && !bt)
+	  return 0;
+
         if (at == 0)            /* do not compare further */
           return -1;
 

--- a/programs/pluto/initiate.c
+++ b/programs/pluto/initiate.c
@@ -1527,7 +1527,9 @@ ISAKMP_SA_established(struct connection *c, so_serial_t serial)
 	{
 	    struct connection *next = d->ac_next;	/* might move underneath us */
 
-	    if ( ((d->kind == CK_PERMANENT) || (d->kind == CK_INSTANCE) || (d->kind == CK_GOING_AWAY))
+	    if ( c != d
+	    && ((d->kind == CK_PERMANENT) || (d->kind == CK_INSTANCE)
+		|| (d->kind == CK_GOING_AWAY))
 	    && same_id(&c->spd.this.id, &d->spd.this.id)
 	    && same_id(&c->spd.that.id, &d->spd.that.id)
 	    && (!sameaddr(&c->spd.that.host_addr, &d->spd.that.host_addr)


### PR DESCRIPTION
This PR is for crashes observed when running DTP test cases "ikev1/double-nat" and "ikev1/double-nat-net".  The core problem was in addrcmp() not returning equality for two undefined addresses.