### PR TITLE
wo#7597 . move errant LIBNSS setup to private_key_setup

### DIFF
--- a/lib/libopenswan/secrets.c
+++ b/lib/libopenswan/secrets.c
@@ -692,6 +692,9 @@ void private_key_setup(struct private_key_stuff *pks)
         pks->pub->alg = PUBKEY_ALG_RSA;
         reference_key(pks->pub);
     }
+#ifdef HAVE_LIBNSS
+    pks->pub->nssCert = NULL;
+#endif
 }
 
 
@@ -1320,9 +1323,6 @@ osw_process_secret_records(struct secret **psecrets, int verbose,
                 s->secretlineno=flp->lino;
                 s->next = NULL;
 
-#ifdef HAVE_LIBNSS
-                s->pks.pub->nssCert = NULL;
-#endif
                 private_key_setup(&s->pks);
 
 


### PR DESCRIPTION
This fixes a crash upon init when LIBNSS=true.