### PR TITLE
T7742 sha2 fix

### DIFF
--- a/lib/libopenswan/secrets.c
+++ b/lib/libopenswan/secrets.c
@@ -692,6 +692,9 @@ void private_key_setup(struct private_key_stuff *pks)
         pks->pub->alg = PUBKEY_ALG_RSA;
         reference_key(pks->pub);
     }
+#ifdef HAVE_LIBNSS
+    pks->pub->nssCert = NULL;
+#endif
 }
 
 
@@ -1320,9 +1323,6 @@ osw_process_secret_records(struct secret **psecrets, int verbose,
                 s->secretlineno=flp->lino;
                 s->next = NULL;
 
-#ifdef HAVE_LIBNSS
-                s->pks.pub->nssCert = NULL;
-#endif
                 private_key_setup(&s->pks);
 
 

--- a/programs/addconn/addconn.c
+++ b/programs/addconn/addconn.c
@@ -226,6 +226,14 @@ main(int argc, char *argv[])
 	yydebug=1;
     }
 
+#ifdef HAVE_LIBNSS
+    SECStatus success = NSS_NoDB_Init(NULL);
+    if(success != SECSuccess) {
+        fprintf(stderr, "failed to initialize NSS, unable to proceed\n");
+        exit(2);
+    }
+#endif
+
     /* find config file */
     confdir = getenv(IPSEC_CONFDIR_VAR);
     if(confdir == NULL)

--- a/programs/pluto/plutomain.c
+++ b/programs/pluto/plutomain.c
@@ -993,9 +993,6 @@ main(int argc, char **argv)
 	     */
 	    openswan_log("@(#) built on "__DATE__":" __TIME__ " by " BUILDER);
 	}
-#if defined(USE_1DES)
-	openswan_log("WARNING: 1DES is enabled");
-#endif
     }
 
     if(coredir) {

--- a/programs/pluto/plutomain.c
+++ b/programs/pluto/plutomain.c
@@ -904,7 +904,7 @@ main(int argc, char **argv)
 
 #ifdef HAVE_LIBNSS
 	char buf[100];
-	snprintf(buf, sizeof(buf), "%s",oco->confddir);
+	snprintf(buf, sizeof(buf), "sql:%s",oco->confddir);
 	loglog(RC_LOG_SERIOUS,"nss directory plutomain: %s",buf);
 	SECStatus nss_init_status= NSS_InitReadWrite(buf);
 	if (nss_init_status != SECSuccess) {

--- a/programs/readwriteconf/readwriteconf.c
+++ b/programs/readwriteconf/readwriteconf.c
@@ -180,6 +180,14 @@ main(int argc, char *argv[])
 	}
     }
 
+#ifdef HAVE_LIBNSS
+    SECStatus success = NSS_NoDB_Init(NULL);
+    if(success != SECSuccess) {
+        fprintf(stderr, "failed to initialize NSS, unable to proceed\n");
+        exit(2);
+    }
+#endif
+
     /* find config file */
     confdir = getenv(IPSEC_CONFDIR_VAR);
     if(confdir == NULL)

--- a/tests/functional/03-plutostart/pluto.nhelper5.out
+++ b/tests/functional/03-plutostart/pluto.nhelper5.out
@@ -4,7 +4,6 @@ LEAK_DETECTIVE support [disabled]
 OCF support for IKE [disabled]
 SAref support [disabled]: Protocol not available
 SAbind support [disabled]: Protocol not available
-NSS support [disabled]
 HAVE_STATSD notification support not compiled in
 Setting NAT-Traversal port-4500 floating to off
    port floating activation criteria nat_t=0/port_float=1
@@ -14,8 +13,3 @@ ike_alg_register_hash(): Activating OAKLEY_SHA2_512: Ok (ret=0)
 ike_alg_register_hash(): Activating OAKLEY_SHA2_256: Ok (ret=0)
 starting up X cryptographic helpers
 Using 'no_kernel' interface code on
-pluto_crypto_helper: helper [nonnss] (X) is exiting normally 
-pluto_crypto_helper: helper [nonnss] (X) is exiting normally 
-pluto_crypto_helper: helper [nonnss] (X) is exiting normally 
-pluto_crypto_helper: helper [nonnss] (X) is exiting normally 
-pluto_crypto_helper: helper [nonnss] (X) is exiting normally 

--- a/tests/functional/03-plutostart/pluto.nhelpers.out
+++ b/tests/functional/03-plutostart/pluto.nhelpers.out
@@ -4,7 +4,6 @@ LEAK_DETECTIVE support [disabled]
 OCF support for IKE [disabled]
 SAref support [disabled]: Protocol not available
 SAbind support [disabled]: Protocol not available
-NSS support [disabled]
 HAVE_STATSD notification support not compiled in
 Setting NAT-Traversal port-4500 floating to off
    port floating activation criteria nat_t=0/port_float=1
@@ -14,4 +13,3 @@ ike_alg_register_hash(): Activating OAKLEY_SHA2_512: Ok (ret=0)
 ike_alg_register_hash(): Activating OAKLEY_SHA2_256: Ok (ret=0)
 starting up X cryptographic helpers
 Using 'no_kernel' interface code on
-pluto_crypto_helper: helper [nonnss] (X) is exiting normally 

--- a/tests/functional/03-plutostart/pluto.secctx.out
+++ b/tests/functional/03-plutostart/pluto.secctx.out
@@ -5,7 +5,6 @@ LEAK_DETECTIVE support [disabled]
 OCF support for IKE [disabled]
 SAref support [disabled]: Protocol not available
 SAbind support [disabled]: Protocol not available
-NSS support [disabled]
 HAVE_STATSD notification support not compiled in
 Setting NAT-Traversal port-4500 floating to off
    port floating activation criteria nat_t=0/port_float=1
@@ -15,4 +14,3 @@ ike_alg_register_hash(): Activating OAKLEY_SHA2_512: Ok (ret=0)
 ike_alg_register_hash(): Activating OAKLEY_SHA2_256: Ok (ret=0)
 starting up X cryptographic helpers
 Using 'no_kernel' interface code on
-pluto_crypto_helper: helper [nonnss] (X) is exiting normally 

--- a/tests/functional/03-plutostart/pluto.start.out
+++ b/tests/functional/03-plutostart/pluto.start.out
@@ -4,7 +4,6 @@ LEAK_DETECTIVE support [disabled]
 OCF support for IKE [disabled]
 SAref support [disabled]: Protocol not available
 SAbind support [disabled]: Protocol not available
-NSS support [disabled]
 HAVE_STATSD notification support not compiled in
 Setting NAT-Traversal port-4500 floating to off
    port floating activation criteria nat_t=0/port_float=1
@@ -14,4 +13,3 @@ ike_alg_register_hash(): Activating OAKLEY_SHA2_512: Ok (ret=0)
 ike_alg_register_hash(): Activating OAKLEY_SHA2_256: Ok (ret=0)
 starting up X cryptographic helpers
 Using 'no_kernel' interface code on
-pluto_crypto_helper: helper [nonnss] (X) is exiting normally 

--- a/tests/functional/05-addconn/pluto.addconn.out
+++ b/tests/functional/05-addconn/pluto.addconn.out
@@ -4,7 +4,6 @@ LEAK_DETECTIVE support [disabled]
 OCF support for IKE [disabled]
 SAref support [disabled]: Protocol not available
 SAbind support [disabled]: Protocol not available
-NSS support [disabled]
 HAVE_STATSD notification support not compiled in
 Setting NAT-Traversal port-4500 floating to off
    port floating activation criteria nat_t=0/port_float=1
@@ -26,4 +25,3 @@ use keyid: 1:A9AA 8D65 3DB6 D939 2943 917B F17C 2031 68AD BCB3 / 2:<>
 adding connection: "green"
 "green": deleting connection
 "gateway--any": deleting connection
-pluto_crypto_helper: helper [nonnss] (X) is exiting normally 

--- a/tests/functional/08-sitelocalv6/pluto.sitelocalv6.out
+++ b/tests/functional/08-sitelocalv6/pluto.sitelocalv6.out
@@ -4,7 +4,6 @@ LEAK_DETECTIVE support [disabled]
 OCF support for IKE [disabled]
 SAref support [disabled]: Protocol not available
 SAbind support [disabled]: Protocol not available
-NSS support [disabled]
 HAVE_STATSD notification support not compiled in
 Setting NAT-Traversal port-4500 floating to off
    port floating activation criteria nat_t=0/port_float=1
@@ -58,4 +57,3 @@ loading named conns: host-host
 000  
 000  
 "host-host": deleting connection
-pluto_crypto_helper: helper [nonnss] (X) is exiting normally 

--- a/tests/functional/09-v6inv4/pluto.v6inv4.out
+++ b/tests/functional/09-v6inv4/pluto.v6inv4.out
@@ -5,7 +5,6 @@ LEAK_DETECTIVE support [disabled]
 OCF support for IKE [disabled]
 SAref support [disabled]: Protocol not available
 SAbind support [disabled]: Protocol not available
-NSS support [disabled]
 HAVE_STATSD notification support not compiled in
 Setting NAT-Traversal port-4500 floating to off
    port floating activation criteria nat_t=0/port_float=1
@@ -64,4 +63,3 @@ loaded private key for keyid: PPK_RSA:AwEAAeOoT/75B9 7996 96CB FFE9 9CEA F984 D5
 000  
 forgetting secrets
 "net-net": deleting connection
-pluto_crypto_helper: helper [nonnss] (X) is exiting normally 

--- a/tests/functional/10-defaultroute/pluto.defaultroute.out
+++ b/tests/functional/10-defaultroute/pluto.defaultroute.out
@@ -5,7 +5,6 @@ LEAK_DETECTIVE support [disabled]
 OCF support for IKE [disabled]
 SAref support [disabled]: Protocol not available
 SAbind support [disabled]: Protocol not available
-NSS support [disabled]
 HAVE_STATSD notification support not compiled in
 Setting NAT-Traversal port-4500 floating to off
    port floating activation criteria nat_t=0/port_float=1
@@ -64,4 +63,3 @@ loaded private key for keyid: PPK_RSA:AwEAAbXtb/A339 C44A 54EA F8CD A71A 5BC3 31
 000  
 forgetting secrets
 "nat-t": deleting connection
-pluto_crypto_helper: helper [nonnss] (X) is exiting normally 

--- a/tests/functional/13-bigpubkey/pluto.big-key-green.out
+++ b/tests/functional/13-bigpubkey/pluto.big-key-green.out
@@ -4,7 +4,6 @@ LEAK_DETECTIVE support [disabled]
 OCF support for IKE [disabled]
 SAref support [disabled]: Protocol not available
 SAbind support [disabled]: Protocol not available
-NSS support [disabled]
 HAVE_STATSD notification support not compiled in
 Setting NAT-Traversal port-4500 floating to off
    port floating activation criteria nat_t=0/port_float=1
@@ -37,4 +36,3 @@ forgetting secrets
 "berri-vzhost-mondev-v6/2x0": deleting connection
 "berri-vzhost-mondev-v6/1x0": deleting connection
 "big-key-green": deleting connection
-pluto_crypto_helper: helper [nonnss] (X) is exiting normally 

--- a/tests/functional/Makefile
+++ b/tests/functional/Makefile
@@ -16,19 +16,25 @@ srcdir?=${OPENSWANSRCDIR}/tests/functional
 
 include ${OPENSWANSRCDIR}/Makefile.inc
 
-check:
-	@${MAKE} -C 01-confread check
-	@${MAKE} -C 03-plutostart check
-	@${MAKE} -C 04-whackwrite check
-	@${MAKE} -C 05-addconn check
-	@${MAKE} -C 06-dnsdelay check
-	@${MAKE} -C 06-alsoflip check
-	@${MAKE} -C 07-sourceipv6 check
-	@${MAKE} -C 08-sitelocalv6 check
-	@${MAKE} -C 09-v6inv4 check
-	@${MAKE} -C 10-defaultroute check
-	@${MAKE} -C 11-subnets      check
-	@${MAKE} -C 12-rwcertwrite  check
-	@${MAKE} -C 13-bigpubkey  check
+FUNCTIONALTESTS=
+FUNCTIONALTESTS+=01-confread
+FUNCTIONALTESTS+=03-plutostart
+FUNCTIONALTESTS+=04-whackwrite
+FUNCTIONALTESTS+=05-addconn
+FUNCTIONALTESTS+=06-dnsdelay
+FUNCTIONALTESTS+=06-alsoflip
+FUNCTIONALTESTS+=07-sourceipv6
+FUNCTIONALTESTS+=08-sitelocalv6
+FUNCTIONALTESTS+=09-v6inv4
+FUNCTIONALTESTS+=10-defaultroute
+FUNCTIONALTESTS+=11-subnets
+FUNCTIONALTESTS+=12-rwcertwrite
+FUNCTIONALTESTS+=13-bigpubkey
 
+# running 'make check KEEPGOING=1' will run through all tests w/o stopping
+ERROR_CHECK=$(if ${KEEPGOING},,set -e;)
+clean check pcapupdate:
+	@${ERROR_CHECK} for unittest in ${FUNCTIONALTESTS}; do ${MAKE} -C $$unittest $@; done
 
+testlist:
+	@echo ${FUNCTIONALTESTS}

--- a/tests/functional/run-unit-tests.sh
+++ b/tests/functional/run-unit-tests.sh
@@ -1,0 +1,1 @@
+../unit/libpluto/run-unit-tests.sh

--- a/tests/utils/openswanver.sed
+++ b/tests/utils/openswanver.sed
@@ -3,4 +3,9 @@ s/Openswan Version [0-9]+\.[0-9]+\.[0-9]+.*/Openswan Version VERSION/
 s/Vendor ID .* pid:.*/Vendor ID THING pid:NUMBER/
 s/started helper pid=.*$/started helper pid=PID /
 s/Using 'no_kernel' interface code on .*/Using 'no_kernel' interface code on/
+/NSS support/d
+/NSS Initialized/d
+/Non-fips mode/d
+/nss directory plutomain/d
+/helper.*exiting normally/d
 


### PR DESCRIPTION
This includes a fix to make sure that auxiliary programs (readwriteconf and addconn) initialize NSS so that they can use the sha256 routines to calculate public KEY IDs.
