### PR TITLE
T7710 need controlmore debug for ikev2

### DIFF
--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -571,36 +571,38 @@ int ikev2_evaluate_connection_fit(struct connection *d
 	er = &sr->this;
     }
 
+    if(!ei->has_client && ei->host_type == KH_ANY) {
+	/* here, fill in new end with actual client info from the state */
+	fei = *ei;
+	ei  = &fei;
+	addrtosubnet(&st->st_remoteaddr, &fei.client);
+    }
+
+    if(!er->has_client && er->host_type == KH_ANY) {
+	/* here, fill in new end with actual client info from the state */
+	fer = *er;
+	er  = &fer;
+	addrtosubnet(&st->st_remoteaddr, &fer.client);
+    }
+
     DBG(DBG_CONTROLMORE,
     {
 	char ei3[SUBNETTOT_BUF];
 	char er3[SUBNETTOT_BUF];
         if(ei->has_client) {
             subnettot(&ei->client,  0, ei3, sizeof(ei3));
+	} else if(ei->host_type == KH_ANY) {
+	    strcpy(ei3, "<self>");
         } else {
             strcpy(ei3, "<noclient>");
-
-            /* here, fill in new end with actual client info from the state */
-            if(ei->host_type == KH_ANY) {
-                fei = *ei;
-                ei  = &fei;
-                strcpy(ei3, "<self>");
-                addrtosubnet(&st->st_remoteaddr, &fei.client);
-            }
         }
 
         if(er->has_client) {
             subnettot(&er->client,  0, er3, sizeof(er3));
+	} else if(er->host_type == KH_ANY) {
+            strcpy(er3, "<self>");
         } else {
-            strcpy(er3, "<noclient");
-
-            /* here, fill in new end with actual client info from the state */
-            if(er->host_type == KH_ANY) {
-                fer = *er;
-                er  = &fer;
-                strcpy(er3, "<self>");
-                addrtosubnet(&st->st_remoteaddr, &fer.client);
-            }
+            strcpy(er3, "<noclient>");
         }
 	DBG_log("  ikev2_evaluate_connection_fit evaluating our "
 		"I=%s:%s:%d/%d R=%s:%d/%d %s to their:"

--- a/tests/unit/libpluto/lp39-h2hR2/output1.txt
+++ b/tests/unit/libpluto/lp39-h2hR2/output1.txt
@@ -580,7 +580,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | parsing 4 raw bytes of IKEv2 Traffic Selector into ipv4 ts
 | ipv4 ts  84 d5 ee 07
 | ikev2_evaluate_connection_fit, evaluating base fit for mytunnel
-|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient:0/0  to their:
+|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient>:0/0  to their:
 |     tsi[0]=192.168.1.1/192.168.1.1 proto=0 portrange 0-65535, tsr[0]=132.213.238.7/132.213.238.7 proto=0 portrange 0-65535
 | ei->port 0  tsi[tsi_ni].startport 0  tsi[tsi_ni].endport 65535
 |       has ts_range1=0 maskbits1=32 ts_range2=0 maskbits2=32 fitbits=8224 <> -1

--- a/tests/unit/libpluto/lp74-alg-h2hR2/output1.txt
+++ b/tests/unit/libpluto/lp74-alg-h2hR2/output1.txt
@@ -546,7 +546,7 @@ sending 428 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | parsing 4 raw bytes of IKEv2 Traffic Selector into ipv4 ts
 | ipv4 ts  84 d5 ee 07
 | ikev2_evaluate_connection_fit, evaluating base fit for alttunnel
-|   ikev2_evaluate_connection_fit evaluating our I=alttunnel:<noclient>:0/0 R=<noclient:0/0  to their:
+|   ikev2_evaluate_connection_fit evaluating our I=alttunnel:<noclient>:0/0 R=<noclient>:0/0  to their:
 |     tsi[0]=192.168.1.1/192.168.1.1 proto=0 portrange 0-65535, tsr[0]=132.213.238.7/132.213.238.7 proto=0 portrange 0-65535
 | ei->port 0  tsi[tsi_ni].startport 0  tsi[tsi_ni].endport 65535
 |       has ts_range1=0 maskbits1=32 ts_range2=0 maskbits2=32 fitbits=8224 <> -1

--- a/tests/unit/libpluto/lp75-alg-h2hI3/output1.txt
+++ b/tests/unit/libpluto/lp75-alg-h2hI3/output1.txt
@@ -745,7 +745,7 @@ sending 476 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132.
 | parsing 4 raw bytes of IKEv2 Traffic Selector into ipv4 ts
 | ipv4 ts  84 d5 ee 07
 | checking TSi(1)/TSr(1) selectors, looking for exact match
-|   ikev2_evaluate_connection_fit evaluating our I=alttunnel:<noclient>:0/0 R=<noclient:0/0  to their:
+|   ikev2_evaluate_connection_fit evaluating our I=alttunnel:<noclient>:0/0 R=<noclient>:0/0  to their:
 |     tsi[0]=192.168.1.1/192.168.1.1 proto=0 portrange 0-65535, tsr[0]=132.213.238.7/132.213.238.7 proto=0 portrange 0-65535
 | ei->port 0  tsi[tsi_ni].startport 0  tsi[tsi_ni].endport 65535
 |       has ts_range1=0 maskbits1=32 ts_range2=0 maskbits2=32 fitbits=8224 <> -1

--- a/tests/unit/libpluto/lp80-h2h-rekeyikev2-R2-msgid0/output1.txt
+++ b/tests/unit/libpluto/lp80-h2h-rekeyikev2-R2-msgid0/output1.txt
@@ -595,7 +595,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | parsing 4 raw bytes of IKEv2 Traffic Selector into ipv4 ts
 | ipv4 ts  84 d5 ee 07
 | ikev2_evaluate_connection_fit, evaluating base fit for mytunnel
-|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient:0/0  to their:
+|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient>:0/0  to their:
 |     tsi[0]=192.168.1.1/192.168.1.1 proto=0 portrange 0-65535, tsr[0]=132.213.238.7/132.213.238.7 proto=0 portrange 0-65535
 | ei->port 0  tsi[tsi_ni].startport 0  tsi[tsi_ni].endport 65535
 |       has ts_range1=0 maskbits1=32 ts_range2=0 maskbits2=32 fitbits=8224 <> -1

--- a/tests/unit/libpluto/lp81-h2h-rekeyikev2-I3-msgid0/output1.txt
+++ b/tests/unit/libpluto/lp81-h2h-rekeyikev2-I3-msgid0/output1.txt
@@ -746,7 +746,7 @@ sending 492 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132.
 | parsing 4 raw bytes of IKEv2 Traffic Selector into ipv4 ts
 | ipv4 ts  84 d5 ee 07
 | checking TSi(1)/TSr(1) selectors, looking for exact match
-|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient:0/0  to their:
+|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient>:0/0  to their:
 |     tsi[0]=192.168.1.1/192.168.1.1 proto=0 portrange 0-65535, tsr[0]=132.213.238.7/132.213.238.7 proto=0 portrange 0-65535
 | ei->port 0  tsi[tsi_ni].startport 0  tsi[tsi_ni].endport 65535
 |       has ts_range1=0 maskbits1=32 ts_range2=0 maskbits2=32 fitbits=8224 <> -1
@@ -1137,7 +1137,7 @@ sending 492 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132.
 | parsing 4 raw bytes of IKEv2 Traffic Selector into ipv4 ts
 | ipv4 ts  84 d5 ee 07
 | ikev2_evaluate_connection_fit, evaluating base fit for mytunnel
-|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient:0/0  to their:
+|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient>:0/0  to their:
 |     tsi[0]=192.168.1.1/192.168.1.1 proto=0 portrange 0-65535, tsr[0]=132.213.238.7/132.213.238.7 proto=0 portrange 0-65535
 | prefix range fit c mytunnel c->name was rejected by Traffic Selectors
 | find_ID_host_pair: looking for me=192.168.1.1 him=132.213.238.7 (wildcard)

--- a/tests/unit/libpluto/lp82-h2h-deleteSA-R2/output1.txt
+++ b/tests/unit/libpluto/lp82-h2h-deleteSA-R2/output1.txt
@@ -595,7 +595,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | parsing 4 raw bytes of IKEv2 Traffic Selector into ipv4 ts
 | ipv4 ts  84 d5 ee 07
 | ikev2_evaluate_connection_fit, evaluating base fit for mytunnel
-|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient:0/0  to their:
+|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient>:0/0  to their:
 |     tsi[0]=192.168.1.1/192.168.1.1 proto=0 portrange 0-65535, tsr[0]=132.213.238.7/132.213.238.7 proto=0 portrange 0-65535
 | ei->port 0  tsi[tsi_ni].startport 0  tsi[tsi_ni].endport 65535
 |       has ts_range1=0 maskbits1=32 ts_range2=0 maskbits2=32 fitbits=8224 <> -1

--- a/tests/unit/libpluto/lp83-h2h-deleteSA-I3/output1.txt
+++ b/tests/unit/libpluto/lp83-h2h-deleteSA-I3/output1.txt
@@ -746,7 +746,7 @@ sending 492 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132.
 | parsing 4 raw bytes of IKEv2 Traffic Selector into ipv4 ts
 | ipv4 ts  84 d5 ee 07
 | checking TSi(1)/TSr(1) selectors, looking for exact match
-|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient:0/0  to their:
+|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient>:0/0  to their:
 |     tsi[0]=192.168.1.1/192.168.1.1 proto=0 portrange 0-65535, tsr[0]=132.213.238.7/132.213.238.7 proto=0 portrange 0-65535
 | ei->port 0  tsi[tsi_ni].startport 0  tsi[tsi_ni].endport 65535
 |       has ts_range1=0 maskbits1=32 ts_range2=0 maskbits2=32 fitbits=8224 <> -1

--- a/tests/unit/libpluto/lp84-h2h-deleteSA-R2-R/output1.txt
+++ b/tests/unit/libpluto/lp84-h2h-deleteSA-R2-R/output1.txt
@@ -594,7 +594,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | parsing 4 raw bytes of IKEv2 Traffic Selector into ipv4 ts
 | ipv4 ts  84 d5 ee 07
 | ikev2_evaluate_connection_fit, evaluating base fit for mytunnel
-|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient:0/0  to their:
+|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient>:0/0  to their:
 |     tsi[0]=192.168.1.1/192.168.1.1 proto=0 portrange 0-65535, tsr[0]=132.213.238.7/132.213.238.7 proto=0 portrange 0-65535
 | ei->port 0  tsi[tsi_ni].startport 0  tsi[tsi_ni].endport 65535
 |       has ts_range1=0 maskbits1=32 ts_range2=0 maskbits2=32 fitbits=8224 <> -1

--- a/tests/unit/libpluto/lp85-h2h-invalid-deleteSA-I3/output1.txt
+++ b/tests/unit/libpluto/lp85-h2h-invalid-deleteSA-I3/output1.txt
@@ -753,7 +753,7 @@ sending 492 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132.
 | parsing 4 raw bytes of IKEv2 Traffic Selector into ipv4 ts
 | ipv4 ts  84 d5 ee 07
 | checking TSi(1)/TSr(1) selectors, looking for exact match
-|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient:0/0  to their:
+|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient>:0/0  to their:
 |     tsi[0]=192.168.1.1/192.168.1.1 proto=0 portrange 0-65535, tsr[0]=132.213.238.7/132.213.238.7 proto=0 portrange 0-65535
 | ei->port 0  tsi[tsi_ni].startport 0  tsi[tsi_ni].endport 65535
 |       has ts_range1=0 maskbits1=32 ts_range2=0 maskbits2=32 fitbits=8224 <> -1

--- a/tests/unit/libpluto/lp86-h2h-invalid-deleteSA-R2-R/output1.txt
+++ b/tests/unit/libpluto/lp86-h2h-invalid-deleteSA-R2-R/output1.txt
@@ -594,7 +594,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | parsing 4 raw bytes of IKEv2 Traffic Selector into ipv4 ts
 | ipv4 ts  84 d5 ee 07
 | ikev2_evaluate_connection_fit, evaluating base fit for mytunnel
-|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient:0/0  to their:
+|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient>:0/0  to their:
 |     tsi[0]=192.168.1.1/192.168.1.1 proto=0 portrange 0-65535, tsr[0]=132.213.238.7/132.213.238.7 proto=0 portrange 0-65535
 | ei->port 0  tsi[tsi_ni].startport 0  tsi[tsi_ni].endport 65535
 |       has ts_range1=0 maskbits1=32 ts_range2=0 maskbits2=32 fitbits=8224 <> -1

--- a/tests/unit/libpluto/lp90-h2h-sareplace-I1/output1.txt
+++ b/tests/unit/libpluto/lp90-h2h-sareplace-I1/output1.txt
@@ -595,7 +595,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | parsing 4 raw bytes of IKEv2 Traffic Selector into ipv4 ts
 | ipv4 ts  84 d5 ee 07
 | ikev2_evaluate_connection_fit, evaluating base fit for mytunnel
-|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient:0/0  to their:
+|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient>:0/0  to their:
 |     tsi[0]=192.168.1.1/192.168.1.1 proto=0 portrange 0-65535, tsr[0]=132.213.238.7/132.213.238.7 proto=0 portrange 0-65535
 | ei->port 0  tsi[tsi_ni].startport 0  tsi[tsi_ni].endport 65535
 |       has ts_range1=0 maskbits1=32 ts_range2=0 maskbits2=32 fitbits=8224 <> -1

--- a/tests/unit/libpluto/lp91-h2h-sareplace-R1/output1.txt
+++ b/tests/unit/libpluto/lp91-h2h-sareplace-R1/output1.txt
@@ -746,7 +746,7 @@ sending 492 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132.
 | parsing 4 raw bytes of IKEv2 Traffic Selector into ipv4 ts
 | ipv4 ts  84 d5 ee 07
 | checking TSi(1)/TSr(1) selectors, looking for exact match
-|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient:0/0  to their:
+|   ikev2_evaluate_connection_fit evaluating our I=mytunnel:<noclient>:0/0 R=<noclient>:0/0  to their:
 |     tsi[0]=192.168.1.1/192.168.1.1 proto=0 portrange 0-65535, tsr[0]=132.213.238.7/132.213.238.7 proto=0 portrange 0-65535
 | ei->port 0  tsi[tsi_ni].startport 0  tsi[tsi_ni].endport 65535
 |       has ts_range1=0 maskbits1=32 ts_range2=0 maskbits2=32 fitbits=8224 <> -1


### PR DESCRIPTION
fix IKEv2/rw/rsa conn eval when plutodebug=none

In DTP testing, a simple test case attempting IKEv2/rw/rsa would fail,
unless plutodebug=controlmore.

The bug was in ikev2_evaluate_connection_fit() where a large
DBG(DBG_CONTROLMORE,) block was updating ent point structures.

The fix is to move that code out of the DBG(DBG_CONTROLMORE,) block and
do it regardless.

This commit also fixed a typo in the messages logged (there was a missing close bracket)
and so the second commit fixes the unit tests affected.