### PR TITLE
T7615 ikev2 nat keepalives

### DIFF
--- a/programs/pluto/ikev2.h
+++ b/programs/pluto/ikev2.h
@@ -258,6 +258,8 @@ extern stf_status process_nat_payload(struct state *st
 
 extern stf_status ikev2_process_notifies(struct state *st, struct msg_digest *md);
 
+extern void ikev2_enable_nat_keepalives(struct state *st);
+
 
 
 

--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -1155,6 +1155,9 @@ ikev2child_outC1_tail(struct pluto_crypto_req_cont *pcrc
         unpack_nonce(&st->st_ni, r);
     }
 
+    /* enable NAT-T keepalives, if necessary */
+    ikev2_enable_nat_keepalives(st);
+
     /* beginning of data going out */
     authstart = reply_stream.cur;
 
@@ -1600,6 +1603,9 @@ ikev2child_inCI1_tail(struct msg_digest *md, struct state *st, bool dopfs)
     /* at this point, the child will be the one making the transition */
     set_cur_state(st);
     md->transition_state = st;
+
+    /* enable NAT-T keepalives, if necessary */
+    ikev2_enable_nat_keepalives(st);
 
     /* send response */
     {

--- a/programs/pluto/ikev2_notify.c
+++ b/programs/pluto/ikev2_notify.c
@@ -123,17 +123,18 @@ stf_status process_nat_payload(struct state *st
     if(same_chunk(*data, calculated_hash)) {
         DBG(DBG_PARSING|DBG_CONTROLMORE, DBG_log("nat-t payloads for %s match: no NAT", payload_name));
     } else {
-        st->hidden_variables.st_nat_traversal = NAT_T_WITH_RFC_VALUES |
-            NAT_T_DETECTED;
+	st->hidden_variables.st_nat_traversal = NAT_T_WITH_RFC_VALUES;
 
         switch(notify_type) {
         case v2N_NAT_DETECTION_DESTINATION_IP:
             loglog(RC_COMMENT, "detected that I am NATed");
+	    st->hidden_variables.st_nat_traversal |= LELEM(NAT_TRAVERSAL_NAT_BHND_ME);
             break;
         case v2N_NAT_DETECTION_SOURCE_IP:
             addrtot(addr, 0, addrbuf, ADDRTOT_BUF);
             loglog(RC_COMMENT, "detected that they are NATed at: %s:%u"
                          , addrbuf, port);
+	    st->hidden_variables.st_nat_traversal |= LELEM(NAT_TRAVERSAL_NAT_BHND_PEER);
             break;
         default:
             break;

--- a/programs/pluto/ikev2_notify.c
+++ b/programs/pluto/ikev2_notify.c
@@ -206,6 +206,12 @@ stf_status ikev2_process_notifies(struct state *st, struct msg_digest *md)
     return STF_OK;
 }
 
+void ikev2_enable_nat_keepalives(struct state *st)
+{
+    if (st->hidden_variables.st_nat_traversal & NAT_T_WITH_KA)
+	nat_traversal_new_ka_event();
+}
+
 /* add notify payload to the rbody */
 bool ship_v2N(unsigned int np, u_int8_t  critical,
               u_int8_t protoid, chunk_t *spi,

--- a/programs/pluto/ikev2_parent_I2.c
+++ b/programs/pluto/ikev2_parent_I2.c
@@ -70,6 +70,9 @@ stf_status ikev2parent_inR1outI2(struct msg_digest *md)
 
         /* switch to port 4500, if necessary */
         ikev2_update_nat_ports(st);
+
+	/* enable NAT-T keepalives, if necessary */
+	ikev2_enable_nat_keepalives(st);
     }
 
 

--- a/programs/pluto/ikev2_parent_R2.c
+++ b/programs/pluto/ikev2_parent_R2.c
@@ -294,7 +294,11 @@ ikev2_parent_inI2outR2_tail(struct pluto_crypto_req_cont *pcrc
     delete_event(st);
     event_schedule(EVENT_SA_REPLACE, c->sa_ike_life_seconds, st);
 
+    /* switch to port 4500, if necessary */
     ikev2_update_nat_ports(st);
+
+    /* enable NAT-T keepalives, if necessary */
+    ikev2_enable_nat_keepalives(st);
 
     authstart = reply_stream.cur;
     /* send response */

--- a/tests/unit/libpluto/lp63-nattI2/output1.txt
+++ b/tests/unit/libpluto/lp63-nattI2/output1.txt
@@ -224,6 +224,7 @@ picking: eth0:500  outside: 55044 <=> d: 55044
 |   considering eth0 192.168.1.1 port: 4500, family: 2, best: <none>/0 0
 |   considering eth0 2606:2800:220:1:248:1893:25c8:1946 port: 500, family: 10, best: eth0/40 0
 |   picking maching interface for family[2,2]: AF_INET resulted in: 192.168.1.1
+./nattI2 nat_traversal_ka_event_scheduled = TRUE (was FALSE)
 | ikev2 parent inR1: calculating g^{xy} in order to send I2
 | ****parse IKEv2 Proposal Substructure Payload:
 |    length: 44

--- a/tests/unit/libpluto/lp64-nattR2/output1.txt
+++ b/tests/unit/libpluto/lp64-nattR2/output1.txt
@@ -564,6 +564,7 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 |   considering eth0 132.213.238.7 port: 4500, family: 2, best: <none>/0 0
 |   considering eth0 132.213.238.7 port: 500, family: 2, best: eth0/20 0
 |   picking maching interface for family[2,0]: AF_INET resulted in: 132.213.238.7
+./nattR2 nat_traversal_ka_event_scheduled = TRUE (was FALSE)
 | **emit ISAKMP Message:
 |    initiator cookie:
 |   80 01 02 03  04 05 06 07

--- a/tests/unit/libpluto/lp65-nattI3/output1.txt
+++ b/tests/unit/libpluto/lp65-nattI3/output1.txt
@@ -176,6 +176,7 @@ picking: eth0:500  outside: 55044 <=> d: 55044
 |   considering eth0 192.168.1.1 port: 4500, family: 2, best: <none>/0 0
 |   considering eth0 2606:2800:220:1:248:1893:25c8:1946 port: 500, family: 10, best: eth0/40 0
 |   picking maching interface for family[2,2]: AF_INET resulted in: 192.168.1.1
+./nattI3 nat_traversal_ka_event_scheduled = TRUE (was FALSE)
 | ikev2 parent inR1: calculating g^{xy} in order to send I2
 | processor 'initiator-V2_init' returned STF_SUSPEND (2)
 | #1 complete v2 state transition with STF_SUSPEND

--- a/tests/unit/libpluto/seam_natt.c
+++ b/tests/unit/libpluto/seam_natt.c
@@ -5,17 +5,44 @@
 bool nat_traversal_support_non_ike = FALSE;
 bool nat_traversal_support_port_floating = FALSE;
 bool nat_traversal_enabled = FALSE;
+bool nat_traversal_ka_event_called = FALSE;
+bool nat_traversal_ka_event_scheduled = FALSE;
+
 void nat_traversal_change_port_lookup(struct msg_digest *md, struct state *st)
-{}
-void nat_traversal_ka_event (void) {}
+{
+}
+
+void nat_traversal_ka_event (void)
+{
+    openswan_log("nat_traversal_ka_event_called = TRUE (was %s)",
+		 nat_traversal_ka_event_called ? "TRUE" : "FALSE");
+    nat_traversal_ka_event_called = TRUE;
+}
 
 bool nat_traversal_add_natd(u_int8_t np, pb_stream *outs,
-                            struct msg_digest *md) { return TRUE; }
+                            struct msg_digest *md)
+{
+    return TRUE;
+}
 
-void nat_traversal_natd_lookup(struct msg_digest *md) {}
-void nat_traversal_show_result (u_int32_t nt, u_int16_t sport) {}
-u_int32_t nat_traversal_vid_to_method(unsigned short nat_t_vid) { return LELEM(NAT_TRAVERSAL_RFC); }
+void nat_traversal_natd_lookup(struct msg_digest *md)
+{
+}
 
-void nat_traversal_new_ka_event (void) {}
+void nat_traversal_show_result (u_int32_t nt, u_int16_t sport)
+{
+}
+
+u_int32_t nat_traversal_vid_to_method(unsigned short nat_t_vid)
+{
+    return LELEM(NAT_TRAVERSAL_RFC);
+}
+
+void nat_traversal_new_ka_event (void)
+{
+    openswan_log("nat_traversal_ka_event_scheduled = TRUE (was %s)",
+		 nat_traversal_ka_event_scheduled ? "TRUE" : "FALSE");
+    nat_traversal_ka_event_scheduled = TRUE;
+}
 
 #endif


### PR DESCRIPTION
Before this set of changes, we would not enable IKEv2 NAT-T keepalives, unless there was an IKEv1 conn open that also required keepalives.

Existing unit tests were modified to require calling nat_traversal_new_ka_event() to enable the keepalives.