### PR TITLE
T7613 net2net transport

### DIFF
--- a/include/pluto_constants.h
+++ b/include/pluto_constants.h
@@ -532,6 +532,11 @@ enum pluto_policy {
 
 	POLICY_SAREF_TRACK    = LELEM(32), /* Saref tracking via _updown */
 	POLICY_SAREF_TRACK_CONNTRACK    = LELEM(33), /* use conntrack optimization */
+
+/* additional misc information */
+
+	POLICY_INVALID_CONFIG = LELEM(34), /* detected invalid/incompatible 'conn' ipsec.conf, should not negotiate */
+
 };
 
 /* Any IPsec policy?  If not, a connection description
@@ -541,8 +546,15 @@ enum pluto_policy {
  */
 #define HAS_IPSEC_POLICY(p) (((p) & POLICY_IPSEC_MASK) != 0)
 
+/* We mark the connection policy as INVALID_CONFIG when incompatible options
+ * are picked at add_connection() time. */
+#define IS_INVALID_CONFIG(p) ( (p) & POLICY_INVALID_CONFIG )
+
 /* Don't allow negotiation? */
-#define NEVER_NEGOTIATE(p)  (LDISJOINT((p), POLICY_PSK | POLICY_RSASIG | POLICY_AGGRESSIVE) || (((p)&POLICY_SHUNT_MASK)!=POLICY_SHUNT_TRAP))
+#define NEVER_NEGOTIATE(p)  ( LDISJOINT((p), POLICY_PSK | POLICY_RSASIG | POLICY_AGGRESSIVE) \
+			    || IS_INVALID_CONFIG(p) \
+			    || ( ((p) & POLICY_SHUNT_MASK) != POLICY_SHUNT_TRAP ) \
+			    )
 
 
 /* Oakley transform attributes

--- a/lib/libpluto/pluto_constants.c
+++ b/lib/libpluto/pluto_constants.c
@@ -381,10 +381,11 @@ prettypolicy(lset_t policy)
 
     if (bn != pbitnamesbuf)
 	pbitnamesbuf[0] = '\0';
-    snprintf(buf, sizeof(buf), "%s%s%s%s%s%s"
+    snprintf(buf, sizeof(buf), "%s%s%s%s%s%s%s"
 	, pbitnamesbuf
 	, shunt != 0 ? "+" : "", shunt != 0 ? policy_shunt_names[shunt] : ""
 	, fail != 0 ? "+failure" : "", fail != 0 ? policy_fail_names[fail] : ""
+	, IS_INVALID_CONFIG(policy) ? "+INVALID_CONFIG" : ""
 	, NEVER_NEGOTIATE(policy) ? "+NEVER_NEGOTIATE" : "");
     return buf;
 }

--- a/linux/include/openswan.h
+++ b/linux/include/openswan.h
@@ -340,6 +340,7 @@ err_t addrtosubnet(const ip_address *addr, ip_subnet *dst);
 err_t rangetosubnet(const ip_address *from, const ip_address *to, ip_subnet *dst);
 int addrtypeof(const ip_address *src);
 int subnettypeof(const ip_subnet *src);
+int subnetsize(const ip_subnet *src);
 size_t addrlenof(const ip_address *src);
 size_t addrbytesptr(const ip_address *src, unsigned char **const dst);
 size_t addrbytesptr_write(ip_address *src, unsigned char **const dst);

--- a/programs/pluto/initiate.c
+++ b/programs/pluto/initiate.c
@@ -109,6 +109,11 @@ initiate_a_connection(struct connection *c
     {
 	loglog(RC_ORIENT, "We cannot identify ourselves with either end of this connection.");
     }
+    else if (IS_INVALID_CONFIG(c->policy))
+    {
+	loglog(RC_INITSHUNT
+	       , "cannot initiate connection due to invalid configuration");
+    }
     else if (NEVER_NEGOTIATE(c->policy))
     {
 	loglog(RC_INITSHUNT

--- a/tests/functional/01-confread/Makefile
+++ b/tests/functional/01-confread/Makefile
@@ -27,6 +27,7 @@ check: OUTPUT
 	../readwritetest ${READWRITE} cassidy   cassidy.conf cassidy.conf
 	../readwritetest ${READWRITE} dooku h2h.conf ../../unit/libpluto/samples/h2h.conf
 	../readwritetest ${READWRITE} dooku certpercent.conf berri-strongswan.conf
+	../readwritetest ${READWRITE} dooku n2n-transport.conf n2n-transport.conf
 	: ../readwritetest ${READWRITE} dooku brokenspace.conf brokenspace.conf
 	[ ! -f core ]
 

--- a/tests/functional/01-confread/n2n-transport.conf
+++ b/tests/functional/01-confread/n2n-transport.conf
@@ -1,0 +1,43 @@
+# NOTE: this is a non-sensical configuration of a transport conn, with
+#       subnets.  The parser will succeed, and we will catch the error
+#       in pluto.  See handling of this in lp03-whacksemantics
+
+config setup
+
+
+conn %default
+        ikelifetime=60m
+        keylife=20m
+        rekeymargin=3m
+        keyingtries=1
+        ikev2=insist
+        #ike=3des-md5;modp1024
+        #phase2alg=3des-md5;modp1024
+
+
+conn berri
+        left=192.168.1.1
+        # rsakey AQOpgzWya
+        leftrsasigkey=0sAQOpgzWyaBsBEOT2n1tRiQATrSn+GR9vsfXvMn+4V7xN2TjqjaFnNkTNPmvv7ICTw0T+rR2J57D91ZPjQnAlTy+URCSdfRI9Q3Eqwpqi2uD6WAus1iU7cEQeC2cTX8by2xvjrHXRu9Q1GY5OAzCzeT1HnNd+vfZv0ipy5wk5zqmfxc5BBxEf4bVsSYRE3xMyaszxXTQSQnEUHygpnbDxLaVQul5nXeSHcBYt2lDRzBSOZuHd5GbyV2K7OFkoxtp6qyQypTAR04Oyf6970qj6WfxoFUTfJm4nbJ4d4SzO03KJDx7Q+Qvs5u6+G5tvqc9lFMHMPBGLJvxCOJE+WpSp6riW9HZIdnLgiIU1G9lHLPZv8xB9
+
+conn peel
+        left=132.213.238.7
+        # rsakey AQNuCprJ/
+        leftrsasigkey=0sAQNuCprJ/ikFt6nHrpWWOc0616DHG1JuvTwKffrqQCDNJb1PtXd6CGzJ12l8m56JBuV9FoGobEBVHtAFEnmnA9j/C9+am6SH+2ZY6pKqZARlldLcOXYyu0WHex4M89xNTFGew1SzHCQQMEWXVO7Q2gSv3yDzvGMdtaoZDOEcWVyByF0ZGPSqSrbeQ4J2+aYgeVqmmuXPGTCv+YfccQ3B6SYAoqkTimHzFvA5KqAEAxLK4wKnifFDKV0Wwx3oHLHS8vuf/R04zPkiJSPmrSluRI6xDJQ0/Dc8wWi5fIhT/WoQCfimbh/QVvS0Jcz1W3JehK9cyHLO/BWx0vcBWUC1kbgOyKATK14wsHNdqMlQ2kQdmWp/
+
+conn berrinet
+        also=berri
+        leftsourceip=2620:120:9000:0081::1
+        leftsubnet=2620:120:9000:0081::/64
+
+conn peelnet
+        also=peel
+        leftsourceip=2620:120:9000:0082::1
+        leftsubnet=2620:120:9000:0082::/64
+
+conn green
+        ikev2=propose
+        also=peelnet
+        alsoflip=berrinet
+        type=transport
+        auto=add

--- a/tests/functional/01-confread/n2n-transport.conf.out
+++ b/tests/functional/01-confread/n2n-transport.conf.out
@@ -1,0 +1,132 @@
+#conn berri loaded
+#conn peel loaded
+#conn berrinet loaded
+#conn peelnet loaded
+#conn green loaded
+
+version 2.0
+
+config setup
+
+
+# begin conn berri
+conn berri
+	left=192.168.1.1
+	leftrsakey=0sAQOpgzWyaBsBEOT2n1tRiQATrSn+GR9vsfXvMn+4V7xN2TjqjaFnNkTNPmvv7ICTw0T+rR2J57D91ZPjQnAlTy+URCSdfRI9Q3Eqwpqi2uD6WAus1iU7cEQeC2cTX8by2xvjrHXRu9Q1GY5OAzCzeT1HnNd+vfZv0ipy5wk5zqmfxc5BBxEf4bVsSYRE3xMyaszxXTQSQnEUHygpnbDxLaVQul5nXeSHcBYt2lDRzBSOZuHd5GbyV2K7OFkoxtp6qyQypTAR04Oyf6970qj6WfxoFUTfJm4nbJ4d4SzO03KJDx7Q+Qvs5u6+G5tvqc9lFMHMPBGLJvxCOJE+WpSp6riW9HZIdnLgiIU1G9lHLPZv8xB9
+	#right= not set
+	salifetime=1200
+	rekeymargin=180
+	keyingtries=1
+	ikelifetime=3600
+	auto=ignore
+	type=tunnel
+	compress=no
+	pfs=yes
+	rekey=yes
+	overlapip=no
+	authby=rsasig
+	phase2=esp
+	ikev2=insist
+	endaddrfamily=ipv4
+# end conn berri
+
+# begin conn peel
+conn peel
+	left=132.213.238.7
+	leftrsakey=0sAQNuCprJ/ikFt6nHrpWWOc0616DHG1JuvTwKffrqQCDNJb1PtXd6CGzJ12l8m56JBuV9FoGobEBVHtAFEnmnA9j/C9+am6SH+2ZY6pKqZARlldLcOXYyu0WHex4M89xNTFGew1SzHCQQMEWXVO7Q2gSv3yDzvGMdtaoZDOEcWVyByF0ZGPSqSrbeQ4J2+aYgeVqmmuXPGTCv+YfccQ3B6SYAoqkTimHzFvA5KqAEAxLK4wKnifFDKV0Wwx3oHLHS8vuf/R04zPkiJSPmrSluRI6xDJQ0/Dc8wWi5fIhT/WoQCfimbh/QVvS0Jcz1W3JehK9cyHLO/BWx0vcBWUC1kbgOyKATK14wsHNdqMlQ2kQdmWp/
+	#right= not set
+	salifetime=1200
+	rekeymargin=180
+	keyingtries=1
+	ikelifetime=3600
+	auto=ignore
+	type=tunnel
+	compress=no
+	pfs=yes
+	rekey=yes
+	overlapip=no
+	authby=rsasig
+	phase2=esp
+	ikev2=insist
+	endaddrfamily=ipv4
+# end conn peel
+
+# begin conn berrinet
+conn berrinet
+	#also = berri
+	left=192.168.1.1
+	leftsubnet=2620:120:9000:81::/64
+	leftrsakey=0sAQOpgzWyaBsBEOT2n1tRiQATrSn+GR9vsfXvMn+4V7xN2TjqjaFnNkTNPmvv7ICTw0T+rR2J57D91ZPjQnAlTy+URCSdfRI9Q3Eqwpqi2uD6WAus1iU7cEQeC2cTX8by2xvjrHXRu9Q1GY5OAzCzeT1HnNd+vfZv0ipy5wk5zqmfxc5BBxEf4bVsSYRE3xMyaszxXTQSQnEUHygpnbDxLaVQul5nXeSHcBYt2lDRzBSOZuHd5GbyV2K7OFkoxtp6qyQypTAR04Oyf6970qj6WfxoFUTfJm4nbJ4d4SzO03KJDx7Q+Qvs5u6+G5tvqc9lFMHMPBGLJvxCOJE+WpSp6riW9HZIdnLgiIU1G9lHLPZv8xB9
+	leftsourceip=2620:120:9000:81::1
+	#right= not set
+	salifetime=1200
+	rekeymargin=180
+	keyingtries=1
+	ikelifetime=3600
+	auto=ignore
+	type=tunnel
+	compress=no
+	pfs=yes
+	rekey=yes
+	overlapip=no
+	authby=rsasig
+	phase2=esp
+	ikev2=insist
+	endaddrfamily=ipv4
+	tunneladdrfamily=ipv6
+# end conn berrinet
+
+# begin conn peelnet
+conn peelnet
+	#also = peel
+	left=132.213.238.7
+	leftsubnet=2620:120:9000:82::/64
+	leftrsakey=0sAQNuCprJ/ikFt6nHrpWWOc0616DHG1JuvTwKffrqQCDNJb1PtXd6CGzJ12l8m56JBuV9FoGobEBVHtAFEnmnA9j/C9+am6SH+2ZY6pKqZARlldLcOXYyu0WHex4M89xNTFGew1SzHCQQMEWXVO7Q2gSv3yDzvGMdtaoZDOEcWVyByF0ZGPSqSrbeQ4J2+aYgeVqmmuXPGTCv+YfccQ3B6SYAoqkTimHzFvA5KqAEAxLK4wKnifFDKV0Wwx3oHLHS8vuf/R04zPkiJSPmrSluRI6xDJQ0/Dc8wWi5fIhT/WoQCfimbh/QVvS0Jcz1W3JehK9cyHLO/BWx0vcBWUC1kbgOyKATK14wsHNdqMlQ2kQdmWp/
+	leftsourceip=2620:120:9000:82::1
+	#right= not set
+	salifetime=1200
+	rekeymargin=180
+	keyingtries=1
+	ikelifetime=3600
+	auto=ignore
+	type=tunnel
+	compress=no
+	pfs=yes
+	rekey=yes
+	overlapip=no
+	authby=rsasig
+	phase2=esp
+	ikev2=insist
+	endaddrfamily=ipv4
+	tunneladdrfamily=ipv6
+# end conn peelnet
+
+# begin conn green
+conn green
+	#also = peelnet peel
+	left=132.213.238.7
+	leftsubnet=2620:120:9000:82::/64
+	leftrsakey=0sAQNuCprJ/ikFt6nHrpWWOc0616DHG1JuvTwKffrqQCDNJb1PtXd6CGzJ12l8m56JBuV9FoGobEBVHtAFEnmnA9j/C9+am6SH+2ZY6pKqZARlldLcOXYyu0WHex4M89xNTFGew1SzHCQQMEWXVO7Q2gSv3yDzvGMdtaoZDOEcWVyByF0ZGPSqSrbeQ4J2+aYgeVqmmuXPGTCv+YfccQ3B6SYAoqkTimHzFvA5KqAEAxLK4wKnifFDKV0Wwx3oHLHS8vuf/R04zPkiJSPmrSluRI6xDJQ0/Dc8wWi5fIhT/WoQCfimbh/QVvS0Jcz1W3JehK9cyHLO/BWx0vcBWUC1kbgOyKATK14wsHNdqMlQ2kQdmWp/
+	leftsourceip=2620:120:9000:82::1
+	right=192.168.1.1
+	rightsubnet=2620:120:9000:81::/64
+	rightrsakey=0sAQOpgzWyaBsBEOT2n1tRiQATrSn+GR9vsfXvMn+4V7xN2TjqjaFnNkTNPmvv7ICTw0T+rR2J57D91ZPjQnAlTy+URCSdfRI9Q3Eqwpqi2uD6WAus1iU7cEQeC2cTX8by2xvjrHXRu9Q1GY5OAzCzeT1HnNd+vfZv0ipy5wk5zqmfxc5BBxEf4bVsSYRE3xMyaszxXTQSQnEUHygpnbDxLaVQul5nXeSHcBYt2lDRzBSOZuHd5GbyV2K7OFkoxtp6qyQypTAR04Oyf6970qj6WfxoFUTfJm4nbJ4d4SzO03KJDx7Q+Qvs5u6+G5tvqc9lFMHMPBGLJvxCOJE+WpSp6riW9HZIdnLgiIU1G9lHLPZv8xB9
+	rightsourceip=2620:120:9000:81::1
+	salifetime=1200
+	rekeymargin=180
+	keyingtries=1
+	ikelifetime=3600
+	auto=add
+	type=transport
+	compress=no
+	pfs=yes
+	rekey=yes
+	overlapip=no
+	authby=rsasig
+	phase2=esp
+	ikev2=insist
+	endaddrfamily=ipv4
+	tunneladdrfamily=ipv6
+# end conn green
+
+# end of config

--- a/tests/unit/libpluto/lp03-whacksemantics/.gitignore
+++ b/tests/unit/libpluto/lp03-whacksemantics/.gitignore
@@ -1,3 +1,3 @@
 OUTPUT
 whacksemantics
-.gdbinit
+.gdb*init

--- a/tests/unit/libpluto/lp03-whacksemantics/Makefile
+++ b/tests/unit/libpluto/lp03-whacksemantics/Makefile
@@ -64,26 +64,71 @@ EXTRAFLAGS+=${NSS_HDRDIRS}  ${FIPS_HDRDIRS}
 CONFBASE=${OPENSWANSRCDIR}/tests/functional/01-confread
 UNITTEST1ARGS=${CONFBASE}/dooku ${CONFBASE}/dooku.conf dooku--cassidy-net
 UNITTEST2ARGS=${CONFBASE}/cassidy ${CONFBASE}/cassidy.conf knothole--cassidy
+UNITTEST3ARGS=${CONFBASE}/dooku ${CONFBASE}/n2n-transport.conf green
 
 TESTNAME=whacksemantics
 EF_DISABLE_BANNER=1
 export EF_DISABLE_BANNER
 
-check:
+check: check1 check2 check3
+update: update1 update2 update3
+
+OUTPUT:
 	@mkdir -p OUTPUT
+
+${TESTNAME}: ${TESTNAME}.c
 	@echo CC ${TESTNAME}.c
 	@${CC} -g -O0 -o ${TESTNAME} ${EXTRAFLAGS} ${TESTNAME}.c ${EXTRALIBS}
-	@echo "file ${TESTNAME}"          >.gdbinit
-	@echo "set args "${UNITTEST1ARGS} >>.gdbinit
+
+# --- test 1 ---
+
+.gdb1init:
+	@echo "file ${TESTNAME}"          >$@
+	@echo "set args "${UNITTEST1ARGS} >>$@
+
+check1: OUTPUT ${TESTNAME} .gdb1init
+	@echo "## CHECK 1 :: ${UNITTEST1ARGS}"
 	ulimit -c unlimited && ./${TESTNAME} ${UNITTEST1ARGS} >OUTPUT/${TESTNAME}1.txt 2>&1
 	sed -f ${TESTUTILS}/leak-detective.sed -f ${TESTUTILS}/conndebug.sed OUTPUT/${TESTNAME}1.txt | diff - output1.txt
+	@echo "## 1 OK"
+
+update1:
+	sed -f ${TESTUTILS}/leak-detective.sed -f ${TESTUTILS}/conndebug.sed OUTPUT/${TESTNAME}1.txt >output1.txt
+
+# --- test 2 ---
+
+.gdb2init:
+	@echo "file ${TESTNAME}"          >$@
+	@echo "set args "${UNITTEST1ARGS} >>$@
+
+check2: OUTPUT ${TESTNAME} .gdb2init
+	@echo "## CHECK 2 :: ${UNITTEST2ARGS}"
 	ulimit -c unlimited && ./${TESTNAME} ${UNITTEST2ARGS} >OUTPUT/${TESTNAME}2.txt 2>&1
 	sed -f ${TESTUTILS}/leak-detective.sed -f ${TESTUTILS}/conndebug.sed OUTPUT/${TESTNAME}2.txt | diff - output2.txt
+	@echo "## 2 OK"
 
-update:
-	sed -f ${TESTUTILS}/leak-detective.sed -f ${TESTUTILS}/conndebug.sed OUTPUT/${TESTNAME}1.txt >output1.txt
+update2:
 	sed -f ${TESTUTILS}/leak-detective.sed -f ${TESTUTILS}/conndebug.sed OUTPUT/${TESTNAME}2.txt >output2.txt
 
+# --- test 3 ---
+
+.gdb3init:
+	@echo "file ${TESTNAME}"          >$@
+	@echo "set args "${UNITTEST1ARGS} >>$@
+
+check3: OUTPUT ${TESTNAME} .gdb3init
+	@echo "## CHECK 3 :: ${UNITTEST3ARGS}"
+	ulimit -c unlimited && ./${TESTNAME} ${UNITTEST3ARGS} >OUTPUT/${TESTNAME}3.txt 2>&1
+	sed -f ${TESTUTILS}/leak-detective.sed -f ${TESTUTILS}/conndebug.sed OUTPUT/${TESTNAME}3.txt | diff - output3.txt
+	@echo "## 3 OK"
+
+update3:
+	sed -f ${TESTUTILS}/leak-detective.sed -f ${TESTUTILS}/conndebug.sed OUTPUT/${TESTNAME}3.txt >output3.txt
+
+# ---
+
+clean:
+	rm -rf OUTPUT
 
 pcapupdate:
 	@true

--- a/tests/unit/libpluto/lp03-whacksemantics/output1.txt
+++ b/tests/unit/libpluto/lp03-whacksemantics/output1.txt
@@ -20,4 +20,9 @@ emitting conn dooku--cassidy-net with end-family: 0 and tunnel-family: 0
 ./whacksemantics leak: new_list nlist, item size: X
 ./whacksemantics leak: default base, item size: X
 ./whacksemantics leak detective found Z leaks, total size X
-processing conn: dooku--cassidy-net
+processing requested conn adds
+dooku--cassidy-net: was requested
+dooku--cassidy-net: was loaded
+dooku--cassidy-net: calling add_connection()
+dooku--cassidy-net: was added
+dooku--cassidy-net: policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+SAREFTRACK

--- a/tests/unit/libpluto/lp03-whacksemantics/output2.txt
+++ b/tests/unit/libpluto/lp03-whacksemantics/output2.txt
@@ -64,6 +64,17 @@ did not find conn: clear-or-private, loading implicit
 did not find conn: private-or-clear, loading implicit
 did not find conn: private, loading implicit
 did not find conn: block, loading implicit
+emitting conn knothole--cassidy with end-family: 2 and tunnel-family: 10
+./whacksemantics use keyid: 1:<> / 2:<>
+./whacksemantics use keyid: 1:<> / 2:<>
+./whacksemantics adding connection: "knothole--cassidy"
+./whacksemantics leak: 2 * keep id name, item size: X
+./whacksemantics leak: ID host_pair, item size: X
+./whacksemantics leak: keep id name, item size: X
+./whacksemantics leak: host ip, item size: X
+./whacksemantics leak: keep id name, item size: X
+./whacksemantics leak: connection name, item size: X
+./whacksemantics leak: struct connection, item size: X
 ./whacksemantics leak: 2 * new_list item, item size: X
 ./whacksemantics leak: new_list nlist, item size: X
 ./whacksemantics leak: 2 * new_list item, item size: X
@@ -98,4 +109,9 @@ did not find conn: block, loading implicit
 ./whacksemantics leak: new_list nlist, item size: X
 ./whacksemantics leak: default base, item size: X
 ./whacksemantics leak detective found Z leaks, total size X
-processing conn: knothole--cassidy
+processing requested conn adds
+knothole--cassidy: was requested
+knothole--cassidy: was loaded
+knothole--cassidy: calling add_connection()
+knothole--cassidy: was added
+knothole--cassidy: policy RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+SAREFTRACK

--- a/tests/unit/libpluto/lp03-whacksemantics/output3.txt
+++ b/tests/unit/libpluto/lp03-whacksemantics/output3.txt
@@ -1,0 +1,42 @@
+debugging mode enabled
+Loading default conn
+Loading conn berri
+Loading conn peel
+Loading conn berrinet
+	while loading conn 'berrinet' also including 'berri'
+Loading conn peelnet
+	while loading conn 'peelnet' also including 'peel'
+Loading conn green
+	while loading conn 'green' also including 'peelnet'
+	while processing section 'peelnet' added also=peel
+	while loading conn 'green' also including 'peel'
+	while loading conn 'green' also including 'berrinet'
+	while processing section 'berrinet' added also=berri
+	while loading conn 'green' also including 'berri'
+emitting conn green with end-family: 2 and tunnel-family: 10
+./whacksemantics WARNING: cannot handle TRANSPORT mode with subnets
+./whacksemantics WARNING: connection green marked as INVALID_CONFIG
+./whacksemantics use keyid: 1:<> / 2:<>
+./whacksemantics use keyid: 1:<> / 2:<>
+./whacksemantics adding connection: "green"
+./whacksemantics leak: ID host_pair, item size: X
+./whacksemantics leak: 2 * host ip, item size: X
+./whacksemantics leak: connection name, item size: X
+./whacksemantics leak: struct connection, item size: X
+./whacksemantics leak: alsos, item size: X
+./whacksemantics leak: conn->alsos, item size: X
+./whacksemantics leak: new_list item, item size: X
+./whacksemantics leak: alsos, item size: X
+./whacksemantics leak: conn->alsos, item size: X
+./whacksemantics leak: 2 * new_list item, item size: X
+./whacksemantics leak: new_list nlist, item size: X
+./whacksemantics leak: new_list item, item size: X
+./whacksemantics leak: new_list nlist, item size: X
+./whacksemantics leak: default base, item size: X
+./whacksemantics leak detective found Z leaks, total size X
+processing requested conn adds
+green: was requested
+green: was loaded
+green: calling add_connection()
+green: was added
+green: policy RSASIG+ENCRYPT+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init+SAREFTRACK+0x40000000+INVALID_CONFIG+NEVER_NEGOTIATE

--- a/tests/unit/libpluto/lp03-whacksemantics/whacksemantics.c
+++ b/tests/unit/libpluto/lp03-whacksemantics/whacksemantics.c
@@ -61,6 +61,7 @@ int main(int argc, char *argv[])
     int  lineno=0;
     struct starter_config *cfg = NULL;
     struct starter_conn *conn = NULL;
+    struct connection *c;
 
 #ifdef HAVE_EFENCE
     EF_PROTECT_FREE=1;
@@ -86,21 +87,44 @@ int main(int argc, char *argv[])
     argv+=3;
     argc-=3;
 
+    printf("processing requested conn adds\n");
+
     /* load all conns marked as auto=add or better */
-    for(conn = cfg->conns.tqh_first;
-	conn != NULL;
-	conn = conn->link.tqe_next)
-    {
-        for(; argc>0; argc--, argv++) {
-            conn_name = *argv;
-            printf("processing conn: %s\n", conn_name);
-            if(strcasecmp(conn->name, conn_name)==0) {
-                struct whack_message msg1;
-                if(starter_whack_build_basic_conn(cfg, &msg1, conn)==0) {
-                    add_connection(&msg1);
-                }
-            }
-        }
+    for(; argc>0; argc--, argv++) {
+	struct whack_message msg1;
+
+	conn_name = *argv;
+	printf("%s: was requested\n", conn_name);
+
+	for(conn = cfg->conns.tqh_first;
+	    conn != NULL;
+	    conn = conn->link.tqe_next)
+	{
+            if(!strcasecmp(conn->name, conn_name))
+		break;
+	}
+
+	if (!conn) {
+	    printf("%s: was not loaded\n", conn_name);
+	    continue;
+	}
+	printf("%s: was loaded\n", conn_name);
+
+	if(starter_whack_build_basic_conn(cfg, &msg1, conn)==0) {
+	    printf("%s: calling add_connection()\n", conn_name);
+	    add_connection(&msg1);
+	}
+
+	c = con_by_name(conn_name, 0);
+
+	if (!conn) {
+	    printf("%s: was not added\n", conn_name);
+	    continue;
+	}
+	printf("%s: was added\n", conn_name);
+
+	printf("%s: policy %s\n", c->name , prettypolicy(c->policy));
+
     }
 
     confread_free(cfg);


### PR DESCRIPTION
Through testing 2.6.51, I discovered that pluto would negotiate a net2net conn in transport mode.

First, we will refuse to create a conn like this in ikev2_evaluate_connection_fit().  This prevents a peer from tricking us into accepting this config.

Second, we mark such configuration as INVALID and NEVER_NEGOTIATE.  This prevents us from negotiating this ourselves.

There is a DTP test case, and unit test cases associated with the bug.