### PR TITLE
wo#8115 - skip transport w/ subnet protection for shunt connections

### DIFF
--- a/programs/pluto/connections.c
+++ b/programs/pluto/connections.c
@@ -905,6 +905,7 @@ static bool connection_has_valid_config(const struct whack_message *wm)
 	bool valid = TRUE;
 
 	if (!(wm->policy & POLICY_TUNNEL)
+			&& !(wm->policy & POLICY_SHUNT_MASK)
 			&& (subnetsize(&wm->left.client) > 0
 			    || subnetsize(&wm->right.client) > 0)) {
 		loglog(RC_LOG, "WARNING: cannot handle TRANSPORT mode with subnets");


### PR DESCRIPTION
Earlier changes for issue 7613, caused a regression in shunt policies being marked as INVALID.

This has been corrected.

There is a new DTP test case to validate this.