### PR TITLE
wo#8102 - retain connection policy when calling ipsecdoi_replace() on parent SA

### DIFF
--- a/programs/pluto/ipsec_doi.c
+++ b/programs/pluto/ipsec_doi.c
@@ -481,7 +481,6 @@ ipsecdoi_replace(struct state *st
 	policy = policy | policy_add;
 
 	initiator = pick_initiator(c, policy);
-	passert(!HAS_IPSEC_POLICY(policy));
 	if(initiator) {
 	    (void) initiator(whack_sock, st->st_connection, st, &newstateno, policy
 			     , try, st->st_import

--- a/programs/pluto/replace.c
+++ b/programs/pluto/replace.c
@@ -123,11 +123,18 @@ sa_replace(struct state *st, int type)
 #endif
     else
     {
+	lset_t policy_add = LEMPTY;
 	DBG(DBG_LIFECYCLE
 	    , openswan_log("replacing stale %s %s SA"
 		, (IS_PHASE1(st->st_state)||IS_PHASE15(st->st_state)) ? "ISAKMP" : "IPsec"
 		, (IS_PARENT_SA(st)) ? "PARENT" : "CHILD"));
-	ipsecdoi_replace(st, LEMPTY, LEMPTY, 1);
+	if (IS_PARENT_SA(st)) {
+		DBG(DBG_LIFECYCLE, openswan_log("parent SA, "
+						"adding connection policy: %s",
+						prettypolicy(c->policy)));
+		policy_add = c->policy;
+	}
+	ipsecdoi_replace(st, policy_add, LEMPTY, 1);
 	if (IS_PARENT_SA(st)) {
 		/* a parent SA will not be expired immediately, but after
 		 * it's replaced */

--- a/tests/unit/libpluto/lp66-natt-replaceI/output1.txt
+++ b/tests/unit/libpluto/lp66-natt-replaceI/output1.txt
@@ -884,6 +884,7 @@ RC=0 #1: "parker1--jj2":4500 IKEv2.0 STATE_PARENT_I3 (PARENT SA established); no
 | recv_pcap_packet2() call 1: start IKE SA replace
 ./rekeyParentSA SA REPLACE: #1 parent=Y orig_init=Y nat_bhnd_{me=Y peer=N} (40000010)
 ./rekeyParentSA replacing stale IPsec PARENT SA
+./rekeyParentSA parent SA, adding connection policy: RSASIG+ENCRYPT+TUNNEL+PFS+IKEv2ALLOW+IKEv2Init+SAREFTRACK
 | creating state object #3 at Z
 | orient parker1--jj2 checking against if: eth0 (AF_INET:192.168.1.1:500)
 |     orient matched on IP


### PR DESCRIPTION
When replacing a parent SA, we were losing the policy settings.  It was impossible for IKEv1 to rekey the parent SA.  The fix was to pass the connection policy down to ipsecdoi_replace().  We now pass DTP ikev1/rw-psk-nat-rekey test case.