### PR TITLE
wo#7614 - remove the claim that left=%interface is supported from the man page

### DIFF
--- a/programs/_confread/d.ipsec.conf/left.xml
+++ b/programs/_confread/d.ipsec.conf/left.xml
@@ -40,9 +40,6 @@ and
 are to be filled in (by automatic keying) from DNS data for
 <emphasis remap='B'>left</emphasis>'s
 client.
-The value can also contain the interface name, which will then later be
-used to obtain the IP address from to fill in. For example
-<emphasis remap='B'>%ppp0</emphasis>
 
 The values
 <emphasis remap='B'>%group</emphasis>

--- a/programs/_confread/ipsec.conf.5
+++ b/programs/_confread/ipsec.conf.5
@@ -255,8 +255,7 @@ signifies that both
 and
 \fBleftnexthop\fR
 are to be filled in (by automatic keying) from DNS data for
-\fBleft\fR\*(Aqs client\&. The value can also contain the interface name, which will then later be used to obtain the IP address from to fill in\&. For example
-\fB%ppp0\fR
+\fBleft\fR\*(Aqs client\&.
 The values
 \fB%group\fR
 and


### PR DESCRIPTION
We don't support left=%eth0 anymore, so remove it from the man page.