### PR TITLE
T8179 show leak

### DIFF
--- a/Makefile.inc
+++ b/Makefile.inc
@@ -442,6 +442,7 @@ USE_TAPROOM?=false
 # Whether to use LEAK_DETECTIVE to find memory leaks.
 # disabled for now as it causes some pfree()s due to bad code
 USE_LEAK_DETECTIVE?=false
+USE_ONGOING_LEAK_DETECTIVE?=false
 
 # Use dmalloc. Requires USE_LEAK_DETECTIVE
 USE_DMALLOC?=false

--- a/programs/pluto/Makefile
+++ b/programs/pluto/Makefile
@@ -248,6 +248,9 @@ mostlyclean: clean
 
 realclean: clean
 
+options:
+	echo ${USERCOMPILE} ${PORTINCLUDE} ${COPTS} ${ALLFLAGS}
+
 check:
 	echo no checks in lib right now.
 

--- a/programs/pluto/Makefile.options
+++ b/programs/pluto/Makefile.options
@@ -253,6 +253,10 @@ endif
 
 ifeq ($(USE_LEAK_DETECTIVE),true)
 LEAK_CONF=-DLEAK_DETECTIVE
+
+ifeq ($(USE_ONGOING_LEAK_DETECTIVE),true)
+LEAK_CONF+=-DONGOING_LEAK_DETECTIVE
+endif
 endif
 
 ifeq ($(USE_TAPROOM),true)

--- a/programs/pluto/log.c
+++ b/programs/pluto/log.c
@@ -855,6 +855,11 @@ show_status(void)
     whack_log(RC_COMMENT, BLANK_FORMAT);	/* spacer */
     show_shunt_status();
 #endif
+
+#if defined(ONGOING_LEAK_DETECTIVE) && defined(LEAK_DETECTIVE)
+    report_leaks();
+#endif
+
 }
 
 /*

--- a/programs/pluto/server.c
+++ b/programs/pluto/server.c
@@ -590,6 +590,9 @@ call_server(void)
 	    long next_time = next_event();   /* time to any pending timer event */
 	    int maxfd = ctl_fd;
 
+            /* free up any states not yet freed */
+            do_state_frees();
+
 	    if (sigtermflag)
 		exit_pluto(0);
 

--- a/programs/pluto/state.c
+++ b/programs/pluto/state.c
@@ -565,10 +565,10 @@ delete_state(struct state *st)
     connection_discard(c);
 
     change_state(st, STATE_UNDEFINED);
-
     release_whack(st);
 
-    change_state(st, STATE_CHILDSA_DEL);
+    /* now actually delete the object */
+    free_state(st);
 }
 
 /*

--- a/programs/pluto/state.h
+++ b/programs/pluto/state.h
@@ -448,6 +448,7 @@ extern void state_eroute_usage(ip_subnet *ours, ip_subnet *his
     , unsigned long count, time_t nw);
 extern void free_state(struct state *st);
 extern void delete_state(struct state *st);
+extern void do_state_frees(void);
 struct connection;	/* forward declaration of tag */
 extern void delete_states_by_connection(struct connection *c, bool relations);
 extern void delete_p2states_by_connection(struct connection *c);

--- a/tests/unit/libpluto/lp02-parentI1/output.txt
+++ b/tests/unit/libpluto/lp02-parentI1/output.txt
@@ -477,10 +477,46 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
-| freeing state object #1
 ./parentI1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./parentI1 leak: saved first packet, item size: X
+./parentI1 leak: reply packet for ikev2_parent_outI1_tail, item size: X
+./parentI1 leak: sa in main_outI1, item size: X
+./parentI1 leak: db_attrs, item size: X
+./parentI1 leak: db_v2_trans, item size: X
+./parentI1 leak: db_v2_prop_conj, item size: X
+./parentI1 leak: db_v2_prop, item size: X
+./parentI1 leak: db_attrs, item size: X
+./parentI1 leak: db_v2_trans, item size: X
+./parentI1 leak: db_v2_prop_conj, item size: X
+./parentI1 leak: db_v2_trans, item size: X
+./parentI1 leak: db_v2_prop_conj, item size: X
+./parentI1 leak: db_v2_trans, item size: X
+./parentI1 leak: db_v2_prop_conj, item size: X
+./parentI1 leak: db_v2_trans, item size: X
+./parentI1 leak: db_v2_prop_conj, item size: X
+./parentI1 leak: db_v2_trans, item size: X
+./parentI1 leak: db_v2_prop_conj, item size: X
+./parentI1 leak: db_attrs, item size: X
+./parentI1 leak: db_v2_trans, item size: X
+./parentI1 leak: db_v2_prop_conj, item size: X
+./parentI1 leak: db_attrs, item size: X
+./parentI1 leak: db_v2_trans, item size: X
+./parentI1 leak: db_v2_prop_conj, item size: X
+./parentI1 leak: db_v2_trans, item size: X
+./parentI1 leak: db_v2_prop_conj, item size: X
+./parentI1 leak: db_v2_trans, item size: X
+./parentI1 leak: db_v2_prop_conj, item size: X
+./parentI1 leak: db_attrs, item size: X
+./parentI1 leak: db_v2_trans, item size: X
+./parentI1 leak: db_v2_prop_conj, item size: X
+./parentI1 leak: db_attrs, item size: X
+./parentI1 leak: db_v2_trans, item size: X
+./parentI1 leak: db_v2_prop_conj, item size: X
+./parentI1 leak: initiator nonce, item size: X
+./parentI1 leak: long term secret, item size: X
+./parentI1 leak: saved gi value, item size: X
 ./parentI1 leak: msg_digest, item size: X
 ./parentI1 leak: ikev2_outI1 KE, item size: X
 ./parentI1 leak: db_attrs, item size: X
@@ -514,6 +550,12 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 ./parentI1 leak: db_attrs, item size: X
 ./parentI1 leak: db_v2_trans, item size: X
 ./parentI1 leak: db_v2_prop_conj, item size: X
+./parentI1 leak: 12 * sa copy attrs array, item size: X
+./parentI1 leak: sa copy trans array, item size: X
+./parentI1 leak: sa copy prop array, item size: X
+./parentI1 leak: sa copy prop conj array, item size: X
+./parentI1 leak: sa copy prop_conj, item size: X
+./parentI1 leak: struct state in new_state(), item size: X
 ./parentI1 leak: policies path, item size: X
 ./parentI1 leak: ocspcerts path, item size: X
 ./parentI1 leak: aacerts path, item size: X

--- a/tests/unit/libpluto/lp02-parentI1/parentI1_main.c
+++ b/tests/unit/libpluto/lp02-parentI1/parentI1_main.c
@@ -65,7 +65,6 @@ int main(int argc, char *argv[])
     st = state_with_serialno(1);
     if(st!=NULL) {
         delete_state(st);
-        free_state(st);
     }
 #endif
 

--- a/tests/unit/libpluto/lp06-parentR1notchosen/output.txt
+++ b/tests/unit/libpluto/lp06-parentR1notchosen/output.txt
@@ -206,6 +206,43 @@ sending 36 bytes for send_v2_notification through eth0:500 [192.168.1.1:500] to 
 | state transition function for no-state failed: AUTHENTICATION_FAILED
 ./parentI1R1 deleting state #1 (STATE_PARENT_I1)
 ./parentI1R1 leak: notification packet, item size: X
+./parentI1R1 leak: saved first packet, item size: X
+./parentI1R1 leak: reply packet for ikev2_parent_outI1_tail, item size: X
+./parentI1R1 leak: sa in main_outI1, item size: X
+./parentI1R1 leak: db_attrs, item size: X
+./parentI1R1 leak: db_v2_trans, item size: X
+./parentI1R1 leak: db_v2_prop_conj, item size: X
+./parentI1R1 leak: db_v2_prop, item size: X
+./parentI1R1 leak: db_attrs, item size: X
+./parentI1R1 leak: db_v2_trans, item size: X
+./parentI1R1 leak: db_v2_prop_conj, item size: X
+./parentI1R1 leak: db_v2_trans, item size: X
+./parentI1R1 leak: db_v2_prop_conj, item size: X
+./parentI1R1 leak: db_v2_trans, item size: X
+./parentI1R1 leak: db_v2_prop_conj, item size: X
+./parentI1R1 leak: db_v2_trans, item size: X
+./parentI1R1 leak: db_v2_prop_conj, item size: X
+./parentI1R1 leak: db_v2_trans, item size: X
+./parentI1R1 leak: db_v2_prop_conj, item size: X
+./parentI1R1 leak: db_attrs, item size: X
+./parentI1R1 leak: db_v2_trans, item size: X
+./parentI1R1 leak: db_v2_prop_conj, item size: X
+./parentI1R1 leak: db_attrs, item size: X
+./parentI1R1 leak: db_v2_trans, item size: X
+./parentI1R1 leak: db_v2_prop_conj, item size: X
+./parentI1R1 leak: db_v2_trans, item size: X
+./parentI1R1 leak: db_v2_prop_conj, item size: X
+./parentI1R1 leak: db_v2_trans, item size: X
+./parentI1R1 leak: db_v2_prop_conj, item size: X
+./parentI1R1 leak: db_attrs, item size: X
+./parentI1R1 leak: db_v2_trans, item size: X
+./parentI1R1 leak: db_v2_prop_conj, item size: X
+./parentI1R1 leak: db_attrs, item size: X
+./parentI1R1 leak: db_v2_trans, item size: X
+./parentI1R1 leak: db_v2_prop_conj, item size: X
+./parentI1R1 leak: initiator nonce, item size: X
+./parentI1R1 leak: long term secret, item size: X
+./parentI1R1 leak: saved gi value, item size: X
 ./parentI1R1 leak: msg_digest, item size: X
 ./parentI1R1 leak: ikev2_outI1 KE, item size: X
 ./parentI1R1 leak: db_attrs, item size: X
@@ -239,6 +276,12 @@ sending 36 bytes for send_v2_notification through eth0:500 [192.168.1.1:500] to 
 ./parentI1R1 leak: db_attrs, item size: X
 ./parentI1R1 leak: db_v2_trans, item size: X
 ./parentI1R1 leak: db_v2_prop_conj, item size: X
+./parentI1R1 leak: 12 * sa copy attrs array, item size: X
+./parentI1R1 leak: sa copy trans array, item size: X
+./parentI1R1 leak: sa copy prop array, item size: X
+./parentI1R1 leak: sa copy prop conj array, item size: X
+./parentI1R1 leak: sa copy prop_conj, item size: X
+./parentI1R1 leak: struct state in new_state(), item size: X
 ./parentI1R1 leak: 2 * keep id name, item size: X
 ./parentI1R1 leak: ID host_pair, item size: X
 ./parentI1R1 leak: host_pair, item size: X

--- a/tests/unit/libpluto/lp06-parentR1notchosen/parentI1R1.c
+++ b/tests/unit/libpluto/lp06-parentR1notchosen/parentI1R1.c
@@ -128,7 +128,6 @@ int main(int argc, char *argv[])
     st = state_with_serialno(1);
     if(st!=NULL) {
         delete_state(st);
-        free_state(st);
     }
 
     report_leaks();

--- a/tests/unit/libpluto/lp08-parentR1/output1.txt
+++ b/tests/unit/libpluto/lp08-parentR1/output1.txt
@@ -230,7 +230,7 @@ sending 40 bytes for send_v2_notification through eth0:500 [132.213.238.7:500] t
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28
 | #1 complete v2 state transition with STF_FAIL+25
-./parentR1 STATE_CHILDSA_DEL: INVALID_KEY_INFORMATION
+./parentR1 STATE_UNDEFINED: INVALID_KEY_INFORMATION
 ./parentR1 sending notification ISAKMP_v2_SA_INIT/v2N_INVALID_KE_PAYLOAD to 192.168.1.1:500
 | **emit ISAKMP Message:
 |    initiator cookie:
@@ -254,7 +254,7 @@ sending 36 bytes for send_v2_notification through eth0:500 [132.213.238.7:500] t
 |   00 01 02 03  04 05 06 07  de bc 58 3a  8f 40 d0 cf
 |   29 20 22 20  00 00 00 00  00 00 00 24  00 00 00 08
 |   01 00 00 11
-| state transition function for STATE_CHILDSA_DEL failed: INVALID_KEY_INFORMATION
+| state transition function for STATE_UNDEFINED failed: INVALID_KEY_INFORMATION
 ./parentR1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete

--- a/tests/unit/libpluto/lp08-parentR1/output2.txt
+++ b/tests/unit/libpluto/lp08-parentR1/output2.txt
@@ -336,11 +336,55 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28
-| freeing state object #1
 ./parentR1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./parentR1 leak: reply packet, item size: X
+./parentR1 leak: saved first packet, item size: X
+./parentR1 leak: initiator nonce, item size: X
+./parentR1 leak: long term secret, item size: X
+./parentR1 leak: saved gi value, item size: X
+./parentR1 leak: nonce, item size: X
+./parentR1 leak: Gi, item size: X
+./parentR1 leak: db_attrs, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_v2_prop, item size: X
+./parentR1 leak: db_attrs, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_attrs, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_attrs, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_attrs, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_attrs, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: 12 * sa copy attrs array, item size: X
+./parentR1 leak: sa copy trans array, item size: X
+./parentR1 leak: sa copy prop array, item size: X
+./parentR1 leak: sa copy prop conj array, item size: X
+./parentR1 leak: sa copy prop_conj, item size: X
+./parentR1 leak: saved first received packet, item size: X
 ./parentR1 leak: ikev2_inI1outR1 KE, item size: X
+./parentR1 leak: struct state in new_state(), item size: X
 ./parentR1 leak: msg_digest, item size: X
 ./parentR1 leak: policies path, item size: X
 ./parentR1 leak: ocspcerts path, item size: X

--- a/tests/unit/libpluto/lp08-parentR1/output3.txt
+++ b/tests/unit/libpluto/lp08-parentR1/output3.txt
@@ -329,11 +329,55 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28
-| freeing state object #1
 ./parentR1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./parentR1 leak: reply packet, item size: X
+./parentR1 leak: saved first packet, item size: X
+./parentR1 leak: initiator nonce, item size: X
+./parentR1 leak: long term secret, item size: X
+./parentR1 leak: saved gi value, item size: X
+./parentR1 leak: nonce, item size: X
+./parentR1 leak: Gi, item size: X
+./parentR1 leak: db_attrs, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_v2_prop, item size: X
+./parentR1 leak: db_attrs, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_attrs, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_attrs, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_attrs, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: db_attrs, item size: X
+./parentR1 leak: db_v2_trans, item size: X
+./parentR1 leak: db_v2_prop_conj, item size: X
+./parentR1 leak: 12 * sa copy attrs array, item size: X
+./parentR1 leak: sa copy trans array, item size: X
+./parentR1 leak: sa copy prop array, item size: X
+./parentR1 leak: sa copy prop conj array, item size: X
+./parentR1 leak: sa copy prop_conj, item size: X
+./parentR1 leak: saved first received packet, item size: X
 ./parentR1 leak: ikev2_inI1outR1 KE, item size: X
+./parentR1 leak: struct state in new_state(), item size: X
 ./parentR1 leak: msg_digest, item size: X
 ./parentR1 leak: policies path, item size: X
 ./parentR1 leak: ocspcerts path, item size: X

--- a/tests/unit/libpluto/lp08-parentR1/parentR1_main.c
+++ b/tests/unit/libpluto/lp08-parentR1/parentR1_main.c
@@ -116,7 +116,6 @@ int main(int argc, char *argv[])
     st = state_with_serialno(1);
     if(st!=NULL) {
         delete_state(st);
-        free_state(st);
     }
 
     delete_connection(c1, TRUE);

--- a/tests/unit/libpluto/lp14-initiateself/output.txt
+++ b/tests/unit/libpluto/lp14-initiateself/output.txt
@@ -490,10 +490,46 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [93.184.216.34:
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
-| freeing state object #1
 ./initiateselfI1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./initiateselfI1 leak: saved first packet, item size: X
+./initiateselfI1 leak: reply packet for ikev2_parent_outI1_tail, item size: X
+./initiateselfI1 leak: sa in main_outI1, item size: X
+./initiateselfI1 leak: db_attrs, item size: X
+./initiateselfI1 leak: db_v2_trans, item size: X
+./initiateselfI1 leak: db_v2_prop_conj, item size: X
+./initiateselfI1 leak: db_v2_prop, item size: X
+./initiateselfI1 leak: db_attrs, item size: X
+./initiateselfI1 leak: db_v2_trans, item size: X
+./initiateselfI1 leak: db_v2_prop_conj, item size: X
+./initiateselfI1 leak: db_v2_trans, item size: X
+./initiateselfI1 leak: db_v2_prop_conj, item size: X
+./initiateselfI1 leak: db_v2_trans, item size: X
+./initiateselfI1 leak: db_v2_prop_conj, item size: X
+./initiateselfI1 leak: db_v2_trans, item size: X
+./initiateselfI1 leak: db_v2_prop_conj, item size: X
+./initiateselfI1 leak: db_v2_trans, item size: X
+./initiateselfI1 leak: db_v2_prop_conj, item size: X
+./initiateselfI1 leak: db_attrs, item size: X
+./initiateselfI1 leak: db_v2_trans, item size: X
+./initiateselfI1 leak: db_v2_prop_conj, item size: X
+./initiateselfI1 leak: db_attrs, item size: X
+./initiateselfI1 leak: db_v2_trans, item size: X
+./initiateselfI1 leak: db_v2_prop_conj, item size: X
+./initiateselfI1 leak: db_v2_trans, item size: X
+./initiateselfI1 leak: db_v2_prop_conj, item size: X
+./initiateselfI1 leak: db_v2_trans, item size: X
+./initiateselfI1 leak: db_v2_prop_conj, item size: X
+./initiateselfI1 leak: db_attrs, item size: X
+./initiateselfI1 leak: db_v2_trans, item size: X
+./initiateselfI1 leak: db_v2_prop_conj, item size: X
+./initiateselfI1 leak: db_attrs, item size: X
+./initiateselfI1 leak: db_v2_trans, item size: X
+./initiateselfI1 leak: db_v2_prop_conj, item size: X
+./initiateselfI1 leak: initiator nonce, item size: X
+./initiateselfI1 leak: long term secret, item size: X
+./initiateselfI1 leak: saved gi value, item size: X
 ./initiateselfI1 leak: msg_digest, item size: X
 ./initiateselfI1 leak: ikev2_outI1 KE, item size: X
 ./initiateselfI1 leak: db_attrs, item size: X
@@ -527,6 +563,12 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [93.184.216.34:
 ./initiateselfI1 leak: db_attrs, item size: X
 ./initiateselfI1 leak: db_v2_trans, item size: X
 ./initiateselfI1 leak: db_v2_prop_conj, item size: X
+./initiateselfI1 leak: 12 * sa copy attrs array, item size: X
+./initiateselfI1 leak: sa copy trans array, item size: X
+./initiateselfI1 leak: sa copy prop array, item size: X
+./initiateselfI1 leak: sa copy prop conj array, item size: X
+./initiateselfI1 leak: sa copy prop_conj, item size: X
+./initiateselfI1 leak: struct state in new_state(), item size: X
 ./initiateselfI1 leak: keep id name, item size: X
 ./initiateselfI1 leak: pubkey entry, item size: X
 ./initiateselfI1 leak: rfc3110 format of public key, item size: X

--- a/tests/unit/libpluto/lp15-respondself/output1.txt
+++ b/tests/unit/libpluto/lp15-respondself/output1.txt
@@ -319,11 +319,55 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5
-| freeing state object #1
 ./respondselfR1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./respondselfR1 leak: reply packet, item size: X
+./respondselfR1 leak: saved first packet, item size: X
+./respondselfR1 leak: initiator nonce, item size: X
+./respondselfR1 leak: long term secret, item size: X
+./respondselfR1 leak: saved gi value, item size: X
+./respondselfR1 leak: nonce, item size: X
+./respondselfR1 leak: Gi, item size: X
+./respondselfR1 leak: db_attrs, item size: X
+./respondselfR1 leak: db_v2_trans, item size: X
+./respondselfR1 leak: db_v2_prop_conj, item size: X
+./respondselfR1 leak: db_v2_prop, item size: X
+./respondselfR1 leak: db_attrs, item size: X
+./respondselfR1 leak: db_v2_trans, item size: X
+./respondselfR1 leak: db_v2_prop_conj, item size: X
+./respondselfR1 leak: db_v2_trans, item size: X
+./respondselfR1 leak: db_v2_prop_conj, item size: X
+./respondselfR1 leak: db_v2_trans, item size: X
+./respondselfR1 leak: db_v2_prop_conj, item size: X
+./respondselfR1 leak: db_v2_trans, item size: X
+./respondselfR1 leak: db_v2_prop_conj, item size: X
+./respondselfR1 leak: db_v2_trans, item size: X
+./respondselfR1 leak: db_v2_prop_conj, item size: X
+./respondselfR1 leak: db_attrs, item size: X
+./respondselfR1 leak: db_v2_trans, item size: X
+./respondselfR1 leak: db_v2_prop_conj, item size: X
+./respondselfR1 leak: db_attrs, item size: X
+./respondselfR1 leak: db_v2_trans, item size: X
+./respondselfR1 leak: db_v2_prop_conj, item size: X
+./respondselfR1 leak: db_v2_trans, item size: X
+./respondselfR1 leak: db_v2_prop_conj, item size: X
+./respondselfR1 leak: db_v2_trans, item size: X
+./respondselfR1 leak: db_v2_prop_conj, item size: X
+./respondselfR1 leak: db_attrs, item size: X
+./respondselfR1 leak: db_v2_trans, item size: X
+./respondselfR1 leak: db_v2_prop_conj, item size: X
+./respondselfR1 leak: db_attrs, item size: X
+./respondselfR1 leak: db_v2_trans, item size: X
+./respondselfR1 leak: db_v2_prop_conj, item size: X
+./respondselfR1 leak: 12 * sa copy attrs array, item size: X
+./respondselfR1 leak: sa copy trans array, item size: X
+./respondselfR1 leak: sa copy prop array, item size: X
+./respondselfR1 leak: sa copy prop conj array, item size: X
+./respondselfR1 leak: sa copy prop_conj, item size: X
+./respondselfR1 leak: saved first received packet, item size: X
 ./respondselfR1 leak: ikev2_inI1outR1 KE, item size: X
+./respondselfR1 leak: struct state in new_state(), item size: X
 ./respondselfR1 leak: msg_digest, item size: X
 ./respondselfR1 leak: policies path, item size: X
 ./respondselfR1 leak: ocspcerts path, item size: X

--- a/tests/unit/libpluto/lp18-certificateselfI1/output.txt
+++ b/tests/unit/libpluto/lp18-certificateselfI1/output.txt
@@ -483,10 +483,46 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [93.184.216.34:
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
-| freeing state object #1
 ./certificateselfI1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./certificateselfI1 leak: saved first packet, item size: X
+./certificateselfI1 leak: reply packet for ikev2_parent_outI1_tail, item size: X
+./certificateselfI1 leak: sa in main_outI1, item size: X
+./certificateselfI1 leak: db_attrs, item size: X
+./certificateselfI1 leak: db_v2_trans, item size: X
+./certificateselfI1 leak: db_v2_prop_conj, item size: X
+./certificateselfI1 leak: db_v2_prop, item size: X
+./certificateselfI1 leak: db_attrs, item size: X
+./certificateselfI1 leak: db_v2_trans, item size: X
+./certificateselfI1 leak: db_v2_prop_conj, item size: X
+./certificateselfI1 leak: db_v2_trans, item size: X
+./certificateselfI1 leak: db_v2_prop_conj, item size: X
+./certificateselfI1 leak: db_v2_trans, item size: X
+./certificateselfI1 leak: db_v2_prop_conj, item size: X
+./certificateselfI1 leak: db_v2_trans, item size: X
+./certificateselfI1 leak: db_v2_prop_conj, item size: X
+./certificateselfI1 leak: db_v2_trans, item size: X
+./certificateselfI1 leak: db_v2_prop_conj, item size: X
+./certificateselfI1 leak: db_attrs, item size: X
+./certificateselfI1 leak: db_v2_trans, item size: X
+./certificateselfI1 leak: db_v2_prop_conj, item size: X
+./certificateselfI1 leak: db_attrs, item size: X
+./certificateselfI1 leak: db_v2_trans, item size: X
+./certificateselfI1 leak: db_v2_prop_conj, item size: X
+./certificateselfI1 leak: db_v2_trans, item size: X
+./certificateselfI1 leak: db_v2_prop_conj, item size: X
+./certificateselfI1 leak: db_v2_trans, item size: X
+./certificateselfI1 leak: db_v2_prop_conj, item size: X
+./certificateselfI1 leak: db_attrs, item size: X
+./certificateselfI1 leak: db_v2_trans, item size: X
+./certificateselfI1 leak: db_v2_prop_conj, item size: X
+./certificateselfI1 leak: db_attrs, item size: X
+./certificateselfI1 leak: db_v2_trans, item size: X
+./certificateselfI1 leak: db_v2_prop_conj, item size: X
+./certificateselfI1 leak: initiator nonce, item size: X
+./certificateselfI1 leak: long term secret, item size: X
+./certificateselfI1 leak: saved gi value, item size: X
 ./certificateselfI1 leak: msg_digest, item size: X
 ./certificateselfI1 leak: ikev2_outI1 KE, item size: X
 ./certificateselfI1 leak: db_attrs, item size: X
@@ -520,6 +556,12 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [93.184.216.34:
 ./certificateselfI1 leak: db_attrs, item size: X
 ./certificateselfI1 leak: db_v2_trans, item size: X
 ./certificateselfI1 leak: db_v2_prop_conj, item size: X
+./certificateselfI1 leak: 12 * sa copy attrs array, item size: X
+./certificateselfI1 leak: sa copy trans array, item size: X
+./certificateselfI1 leak: sa copy prop array, item size: X
+./certificateselfI1 leak: sa copy prop conj array, item size: X
+./certificateselfI1 leak: sa copy prop_conj, item size: X
+./certificateselfI1 leak: struct state in new_state(), item size: X
 ./certificateselfI1 leak: rfc3110 format of public key [created], item size: X
 ./certificateselfI1 leak: issuer dn, item size: X
 ./certificateselfI1 leak: keep id name, item size: X

--- a/tests/unit/libpluto/lp19-certreplyselfR1/output1.txt
+++ b/tests/unit/libpluto/lp19-certreplyselfR1/output1.txt
@@ -338,11 +338,55 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5
-| freeing state object #1
 ./certreplyselfR1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./certreplyselfR1 leak: reply packet, item size: X
+./certreplyselfR1 leak: saved first packet, item size: X
+./certreplyselfR1 leak: initiator nonce, item size: X
+./certreplyselfR1 leak: long term secret, item size: X
+./certreplyselfR1 leak: saved gi value, item size: X
+./certreplyselfR1 leak: nonce, item size: X
+./certreplyselfR1 leak: Gi, item size: X
+./certreplyselfR1 leak: db_attrs, item size: X
+./certreplyselfR1 leak: db_v2_trans, item size: X
+./certreplyselfR1 leak: db_v2_prop_conj, item size: X
+./certreplyselfR1 leak: db_v2_prop, item size: X
+./certreplyselfR1 leak: db_attrs, item size: X
+./certreplyselfR1 leak: db_v2_trans, item size: X
+./certreplyselfR1 leak: db_v2_prop_conj, item size: X
+./certreplyselfR1 leak: db_v2_trans, item size: X
+./certreplyselfR1 leak: db_v2_prop_conj, item size: X
+./certreplyselfR1 leak: db_v2_trans, item size: X
+./certreplyselfR1 leak: db_v2_prop_conj, item size: X
+./certreplyselfR1 leak: db_v2_trans, item size: X
+./certreplyselfR1 leak: db_v2_prop_conj, item size: X
+./certreplyselfR1 leak: db_v2_trans, item size: X
+./certreplyselfR1 leak: db_v2_prop_conj, item size: X
+./certreplyselfR1 leak: db_attrs, item size: X
+./certreplyselfR1 leak: db_v2_trans, item size: X
+./certreplyselfR1 leak: db_v2_prop_conj, item size: X
+./certreplyselfR1 leak: db_attrs, item size: X
+./certreplyselfR1 leak: db_v2_trans, item size: X
+./certreplyselfR1 leak: db_v2_prop_conj, item size: X
+./certreplyselfR1 leak: db_v2_trans, item size: X
+./certreplyselfR1 leak: db_v2_prop_conj, item size: X
+./certreplyselfR1 leak: db_v2_trans, item size: X
+./certreplyselfR1 leak: db_v2_prop_conj, item size: X
+./certreplyselfR1 leak: db_attrs, item size: X
+./certreplyselfR1 leak: db_v2_trans, item size: X
+./certreplyselfR1 leak: db_v2_prop_conj, item size: X
+./certreplyselfR1 leak: db_attrs, item size: X
+./certreplyselfR1 leak: db_v2_trans, item size: X
+./certreplyselfR1 leak: db_v2_prop_conj, item size: X
+./certreplyselfR1 leak: 12 * sa copy attrs array, item size: X
+./certreplyselfR1 leak: sa copy trans array, item size: X
+./certreplyselfR1 leak: sa copy prop array, item size: X
+./certreplyselfR1 leak: sa copy prop conj array, item size: X
+./certreplyselfR1 leak: sa copy prop_conj, item size: X
+./certreplyselfR1 leak: saved first received packet, item size: X
 ./certreplyselfR1 leak: ikev2_inI1outR1 KE, item size: X
+./certreplyselfR1 leak: struct state in new_state(), item size: X
 ./certreplyselfR1 leak: msg_digest, item size: X
 ./certreplyselfR1 leak: rfc3110 format of public key [created], item size: X
 ./certreplyselfR1 leak: issuer dn, item size: X

--- a/tests/unit/libpluto/lp23-davecertI1/output.txt
+++ b/tests/unit/libpluto/lp23-davecertI1/output.txt
@@ -482,10 +482,46 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [93.184.216.35:
 | ICOOKIE:  8d 0e 0f 10  11 12 13 14
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
-| freeing state object #1
 ./davecertI1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./davecertI1 leak: saved first packet, item size: X
+./davecertI1 leak: reply packet for ikev2_parent_outI1_tail, item size: X
+./davecertI1 leak: sa in main_outI1, item size: X
+./davecertI1 leak: db_attrs, item size: X
+./davecertI1 leak: db_v2_trans, item size: X
+./davecertI1 leak: db_v2_prop_conj, item size: X
+./davecertI1 leak: db_v2_prop, item size: X
+./davecertI1 leak: db_attrs, item size: X
+./davecertI1 leak: db_v2_trans, item size: X
+./davecertI1 leak: db_v2_prop_conj, item size: X
+./davecertI1 leak: db_v2_trans, item size: X
+./davecertI1 leak: db_v2_prop_conj, item size: X
+./davecertI1 leak: db_v2_trans, item size: X
+./davecertI1 leak: db_v2_prop_conj, item size: X
+./davecertI1 leak: db_v2_trans, item size: X
+./davecertI1 leak: db_v2_prop_conj, item size: X
+./davecertI1 leak: db_v2_trans, item size: X
+./davecertI1 leak: db_v2_prop_conj, item size: X
+./davecertI1 leak: db_attrs, item size: X
+./davecertI1 leak: db_v2_trans, item size: X
+./davecertI1 leak: db_v2_prop_conj, item size: X
+./davecertI1 leak: db_attrs, item size: X
+./davecertI1 leak: db_v2_trans, item size: X
+./davecertI1 leak: db_v2_prop_conj, item size: X
+./davecertI1 leak: db_v2_trans, item size: X
+./davecertI1 leak: db_v2_prop_conj, item size: X
+./davecertI1 leak: db_v2_trans, item size: X
+./davecertI1 leak: db_v2_prop_conj, item size: X
+./davecertI1 leak: db_attrs, item size: X
+./davecertI1 leak: db_v2_trans, item size: X
+./davecertI1 leak: db_v2_prop_conj, item size: X
+./davecertI1 leak: db_attrs, item size: X
+./davecertI1 leak: db_v2_trans, item size: X
+./davecertI1 leak: db_v2_prop_conj, item size: X
+./davecertI1 leak: initiator nonce, item size: X
+./davecertI1 leak: long term secret, item size: X
+./davecertI1 leak: saved gi value, item size: X
 ./davecertI1 leak: msg_digest, item size: X
 ./davecertI1 leak: ikev2_outI1 KE, item size: X
 ./davecertI1 leak: db_attrs, item size: X
@@ -519,6 +555,12 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [93.184.216.35:
 ./davecertI1 leak: db_attrs, item size: X
 ./davecertI1 leak: db_v2_trans, item size: X
 ./davecertI1 leak: db_v2_prop_conj, item size: X
+./davecertI1 leak: 12 * sa copy attrs array, item size: X
+./davecertI1 leak: sa copy trans array, item size: X
+./davecertI1 leak: sa copy prop array, item size: X
+./davecertI1 leak: sa copy prop conj array, item size: X
+./davecertI1 leak: sa copy prop_conj, item size: X
+./davecertI1 leak: struct state in new_state(), item size: X
 ./davecertI1 leak: rfc3110 format of public key [created], item size: X
 ./davecertI1 leak: issuer dn, item size: X
 ./davecertI1 leak: keep id name, item size: X

--- a/tests/unit/libpluto/lp27-dnsloadI1/output.txt
+++ b/tests/unit/libpluto/lp27-dnsloadI1/output.txt
@@ -484,10 +484,46 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
-| freeing state object #1
 ./dnscpeI1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./dnscpeI1 leak: saved first packet, item size: X
+./dnscpeI1 leak: reply packet for ikev2_parent_outI1_tail, item size: X
+./dnscpeI1 leak: sa in main_outI1, item size: X
+./dnscpeI1 leak: db_attrs, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_v2_prop, item size: X
+./dnscpeI1 leak: db_attrs, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_attrs, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_attrs, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_attrs, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_attrs, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: initiator nonce, item size: X
+./dnscpeI1 leak: long term secret, item size: X
+./dnscpeI1 leak: saved gi value, item size: X
 ./dnscpeI1 leak: msg_digest, item size: X
 ./dnscpeI1 leak: ikev2_outI1 KE, item size: X
 ./dnscpeI1 leak: db_attrs, item size: X
@@ -521,6 +557,12 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 ./dnscpeI1 leak: db_attrs, item size: X
 ./dnscpeI1 leak: db_v2_trans, item size: X
 ./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: 12 * sa copy attrs array, item size: X
+./dnscpeI1 leak: sa copy trans array, item size: X
+./dnscpeI1 leak: sa copy prop array, item size: X
+./dnscpeI1 leak: sa copy prop conj array, item size: X
+./dnscpeI1 leak: sa copy prop_conj, item size: X
+./dnscpeI1 leak: struct state in new_state(), item size: X
 ./dnscpeI1 leak: policies path, item size: X
 ./dnscpeI1 leak: ocspcerts path, item size: X
 ./dnscpeI1 leak: aacerts path, item size: X

--- a/tests/unit/libpluto/lp33-dnsload2/dnscpeI1.c
+++ b/tests/unit/libpluto/lp33-dnsload2/dnscpeI1.c
@@ -109,7 +109,6 @@ int main(int argc, char *argv[])
     st = sendI1(c1, DBG_EMITTING|DBG_CONTROL|DBG_CONTROLMORE, regression == 0);
     if(st!=NULL) {
         delete_state(st);
-        free_state(st);
     }
 
     delete_connection(c1, TRUE);

--- a/tests/unit/libpluto/lp33-dnsload2/output.txt
+++ b/tests/unit/libpluto/lp33-dnsload2/output.txt
@@ -480,6 +480,43 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 ./dnscpeI1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./dnscpeI1 leak: saved first packet, item size: X
+./dnscpeI1 leak: reply packet for ikev2_parent_outI1_tail, item size: X
+./dnscpeI1 leak: sa in main_outI1, item size: X
+./dnscpeI1 leak: db_attrs, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_v2_prop, item size: X
+./dnscpeI1 leak: db_attrs, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_attrs, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_attrs, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_attrs, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: db_attrs, item size: X
+./dnscpeI1 leak: db_v2_trans, item size: X
+./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: initiator nonce, item size: X
+./dnscpeI1 leak: long term secret, item size: X
+./dnscpeI1 leak: saved gi value, item size: X
 ./dnscpeI1 leak: msg_digest, item size: X
 ./dnscpeI1 leak: ikev2_outI1 KE, item size: X
 ./dnscpeI1 leak: db_attrs, item size: X
@@ -513,6 +550,12 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 ./dnscpeI1 leak: db_attrs, item size: X
 ./dnscpeI1 leak: db_v2_trans, item size: X
 ./dnscpeI1 leak: db_v2_prop_conj, item size: X
+./dnscpeI1 leak: 12 * sa copy attrs array, item size: X
+./dnscpeI1 leak: sa copy trans array, item size: X
+./dnscpeI1 leak: sa copy prop array, item size: X
+./dnscpeI1 leak: sa copy prop conj array, item size: X
+./dnscpeI1 leak: sa copy prop_conj, item size: X
+./dnscpeI1 leak: struct state in new_state(), item size: X
 ./dnscpeI1 leak: keep id name, item size: X
 ./dnscpeI1 leak: addrinfo sockaddr, item size: X
 ./dnscpeI1 leak: addrinfo, item size: X

--- a/tests/unit/libpluto/lp36-h2hI1/output.txt
+++ b/tests/unit/libpluto/lp36-h2hI1/output.txt
@@ -477,10 +477,46 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
-| freeing state object #1
 ./h2hI1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./h2hI1 leak: saved first packet, item size: X
+./h2hI1 leak: reply packet for ikev2_parent_outI1_tail, item size: X
+./h2hI1 leak: sa in main_outI1, item size: X
+./h2hI1 leak: db_attrs, item size: X
+./h2hI1 leak: db_v2_trans, item size: X
+./h2hI1 leak: db_v2_prop_conj, item size: X
+./h2hI1 leak: db_v2_prop, item size: X
+./h2hI1 leak: db_attrs, item size: X
+./h2hI1 leak: db_v2_trans, item size: X
+./h2hI1 leak: db_v2_prop_conj, item size: X
+./h2hI1 leak: db_v2_trans, item size: X
+./h2hI1 leak: db_v2_prop_conj, item size: X
+./h2hI1 leak: db_v2_trans, item size: X
+./h2hI1 leak: db_v2_prop_conj, item size: X
+./h2hI1 leak: db_v2_trans, item size: X
+./h2hI1 leak: db_v2_prop_conj, item size: X
+./h2hI1 leak: db_v2_trans, item size: X
+./h2hI1 leak: db_v2_prop_conj, item size: X
+./h2hI1 leak: db_attrs, item size: X
+./h2hI1 leak: db_v2_trans, item size: X
+./h2hI1 leak: db_v2_prop_conj, item size: X
+./h2hI1 leak: db_attrs, item size: X
+./h2hI1 leak: db_v2_trans, item size: X
+./h2hI1 leak: db_v2_prop_conj, item size: X
+./h2hI1 leak: db_v2_trans, item size: X
+./h2hI1 leak: db_v2_prop_conj, item size: X
+./h2hI1 leak: db_v2_trans, item size: X
+./h2hI1 leak: db_v2_prop_conj, item size: X
+./h2hI1 leak: db_attrs, item size: X
+./h2hI1 leak: db_v2_trans, item size: X
+./h2hI1 leak: db_v2_prop_conj, item size: X
+./h2hI1 leak: db_attrs, item size: X
+./h2hI1 leak: db_v2_trans, item size: X
+./h2hI1 leak: db_v2_prop_conj, item size: X
+./h2hI1 leak: initiator nonce, item size: X
+./h2hI1 leak: long term secret, item size: X
+./h2hI1 leak: saved gi value, item size: X
 ./h2hI1 leak: msg_digest, item size: X
 ./h2hI1 leak: ikev2_outI1 KE, item size: X
 ./h2hI1 leak: db_attrs, item size: X
@@ -514,6 +550,12 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 ./h2hI1 leak: db_attrs, item size: X
 ./h2hI1 leak: db_v2_trans, item size: X
 ./h2hI1 leak: db_v2_prop_conj, item size: X
+./h2hI1 leak: 12 * sa copy attrs array, item size: X
+./h2hI1 leak: sa copy trans array, item size: X
+./h2hI1 leak: sa copy prop array, item size: X
+./h2hI1 leak: sa copy prop conj array, item size: X
+./h2hI1 leak: sa copy prop_conj, item size: X
+./h2hI1 leak: struct state in new_state(), item size: X
 ./h2hI1 leak: policies path, item size: X
 ./h2hI1 leak: ocspcerts path, item size: X
 ./h2hI1 leak: aacerts path, item size: X

--- a/tests/unit/libpluto/lp37-h2hR1/output1.txt
+++ b/tests/unit/libpluto/lp37-h2hR1/output1.txt
@@ -336,11 +336,55 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28
-| freeing state object #1
 ./h2hR1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./h2hR1 leak: reply packet, item size: X
+./h2hR1 leak: saved first packet, item size: X
+./h2hR1 leak: initiator nonce, item size: X
+./h2hR1 leak: long term secret, item size: X
+./h2hR1 leak: saved gi value, item size: X
+./h2hR1 leak: nonce, item size: X
+./h2hR1 leak: Gi, item size: X
+./h2hR1 leak: db_attrs, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_v2_prop, item size: X
+./h2hR1 leak: db_attrs, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_attrs, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_attrs, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_attrs, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_attrs, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: 12 * sa copy attrs array, item size: X
+./h2hR1 leak: sa copy trans array, item size: X
+./h2hR1 leak: sa copy prop array, item size: X
+./h2hR1 leak: sa copy prop conj array, item size: X
+./h2hR1 leak: sa copy prop_conj, item size: X
+./h2hR1 leak: saved first received packet, item size: X
 ./h2hR1 leak: ikev2_inI1outR1 KE, item size: X
+./h2hR1 leak: struct state in new_state(), item size: X
 ./h2hR1 leak: msg_digest, item size: X
 ./h2hR1 leak: policies path, item size: X
 ./h2hR1 leak: ocspcerts path, item size: X

--- a/tests/unit/libpluto/lp43-parentM1/output.txt
+++ b/tests/unit/libpluto/lp43-parentM1/output.txt
@@ -459,10 +459,10 @@ RC=105 STATE_MAIN_I1: initiate
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
-| freeing state object #1
 ./parentM1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./parentM1 leak: reply packet for main_outI1, item size: X
 ./parentM1 leak: 67 * VendorID MD5, item size: X
 ./parentM1 leak: 3 * vid->data, item size: X
 ./parentM1 leak: 15 * VendorID MD5, item size: X
@@ -472,6 +472,8 @@ RC=105 STATE_MAIN_I1: initiate
 ./parentM1 leak: vid->data, item size: X
 ./parentM1 leak: 23 * VendorID MD5, item size: X
 ./parentM1 leak: vid->data, item size: X
+./parentM1 leak: sa in main_outI1, item size: X
+./parentM1 leak: struct state in new_state(), item size: X
 ./parentM1 leak: policies path, item size: X
 ./parentM1 leak: ocspcerts path, item size: X
 ./parentM1 leak: aacerts path, item size: X

--- a/tests/unit/libpluto/lp52-davecert-gatewayID-I1/output.txt
+++ b/tests/unit/libpluto/lp52-davecert-gatewayID-I1/output.txt
@@ -482,10 +482,46 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [93.184.216.35:
 | ICOOKIE:  8d 0e 0f 10  11 12 13 14
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
-| freeing state object #1
 ./davecertI1-id deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./davecertI1-id leak: saved first packet, item size: X
+./davecertI1-id leak: reply packet for ikev2_parent_outI1_tail, item size: X
+./davecertI1-id leak: sa in main_outI1, item size: X
+./davecertI1-id leak: db_attrs, item size: X
+./davecertI1-id leak: db_v2_trans, item size: X
+./davecertI1-id leak: db_v2_prop_conj, item size: X
+./davecertI1-id leak: db_v2_prop, item size: X
+./davecertI1-id leak: db_attrs, item size: X
+./davecertI1-id leak: db_v2_trans, item size: X
+./davecertI1-id leak: db_v2_prop_conj, item size: X
+./davecertI1-id leak: db_v2_trans, item size: X
+./davecertI1-id leak: db_v2_prop_conj, item size: X
+./davecertI1-id leak: db_v2_trans, item size: X
+./davecertI1-id leak: db_v2_prop_conj, item size: X
+./davecertI1-id leak: db_v2_trans, item size: X
+./davecertI1-id leak: db_v2_prop_conj, item size: X
+./davecertI1-id leak: db_v2_trans, item size: X
+./davecertI1-id leak: db_v2_prop_conj, item size: X
+./davecertI1-id leak: db_attrs, item size: X
+./davecertI1-id leak: db_v2_trans, item size: X
+./davecertI1-id leak: db_v2_prop_conj, item size: X
+./davecertI1-id leak: db_attrs, item size: X
+./davecertI1-id leak: db_v2_trans, item size: X
+./davecertI1-id leak: db_v2_prop_conj, item size: X
+./davecertI1-id leak: db_v2_trans, item size: X
+./davecertI1-id leak: db_v2_prop_conj, item size: X
+./davecertI1-id leak: db_v2_trans, item size: X
+./davecertI1-id leak: db_v2_prop_conj, item size: X
+./davecertI1-id leak: db_attrs, item size: X
+./davecertI1-id leak: db_v2_trans, item size: X
+./davecertI1-id leak: db_v2_prop_conj, item size: X
+./davecertI1-id leak: db_attrs, item size: X
+./davecertI1-id leak: db_v2_trans, item size: X
+./davecertI1-id leak: db_v2_prop_conj, item size: X
+./davecertI1-id leak: initiator nonce, item size: X
+./davecertI1-id leak: long term secret, item size: X
+./davecertI1-id leak: saved gi value, item size: X
 ./davecertI1-id leak: msg_digest, item size: X
 ./davecertI1-id leak: ikev2_outI1 KE, item size: X
 ./davecertI1-id leak: db_attrs, item size: X
@@ -519,6 +555,12 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [93.184.216.35:
 ./davecertI1-id leak: db_attrs, item size: X
 ./davecertI1-id leak: db_v2_trans, item size: X
 ./davecertI1-id leak: db_v2_prop_conj, item size: X
+./davecertI1-id leak: 12 * sa copy attrs array, item size: X
+./davecertI1-id leak: sa copy trans array, item size: X
+./davecertI1-id leak: sa copy prop array, item size: X
+./davecertI1-id leak: sa copy prop conj array, item size: X
+./davecertI1-id leak: sa copy prop_conj, item size: X
+./davecertI1-id leak: struct state in new_state(), item size: X
 ./davecertI1-id leak: rfc3110 format of public key [created], item size: X
 ./davecertI1-id leak: issuer dn, item size: X
 ./davecertI1-id leak: keep id name, item size: X

--- a/tests/unit/libpluto/lp53-davecert-gatewayID-R1/output1.txt
+++ b/tests/unit/libpluto/lp53-davecert-gatewayID-R1/output1.txt
@@ -340,11 +340,55 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ICOOKIE:  8d 0e 0f 10  11 12 13 14
 | RCOOKIE:  75 bb 19 c5  f3 60 73 6d
 | state hash entry 13
-| freeing state object #1
 ./davecert-R1-id deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./davecert-R1-id leak: reply packet, item size: X
+./davecert-R1-id leak: saved first packet, item size: X
+./davecert-R1-id leak: initiator nonce, item size: X
+./davecert-R1-id leak: long term secret, item size: X
+./davecert-R1-id leak: saved gi value, item size: X
+./davecert-R1-id leak: nonce, item size: X
+./davecert-R1-id leak: Gi, item size: X
+./davecert-R1-id leak: db_attrs, item size: X
+./davecert-R1-id leak: db_v2_trans, item size: X
+./davecert-R1-id leak: db_v2_prop_conj, item size: X
+./davecert-R1-id leak: db_v2_prop, item size: X
+./davecert-R1-id leak: db_attrs, item size: X
+./davecert-R1-id leak: db_v2_trans, item size: X
+./davecert-R1-id leak: db_v2_prop_conj, item size: X
+./davecert-R1-id leak: db_v2_trans, item size: X
+./davecert-R1-id leak: db_v2_prop_conj, item size: X
+./davecert-R1-id leak: db_v2_trans, item size: X
+./davecert-R1-id leak: db_v2_prop_conj, item size: X
+./davecert-R1-id leak: db_v2_trans, item size: X
+./davecert-R1-id leak: db_v2_prop_conj, item size: X
+./davecert-R1-id leak: db_v2_trans, item size: X
+./davecert-R1-id leak: db_v2_prop_conj, item size: X
+./davecert-R1-id leak: db_attrs, item size: X
+./davecert-R1-id leak: db_v2_trans, item size: X
+./davecert-R1-id leak: db_v2_prop_conj, item size: X
+./davecert-R1-id leak: db_attrs, item size: X
+./davecert-R1-id leak: db_v2_trans, item size: X
+./davecert-R1-id leak: db_v2_prop_conj, item size: X
+./davecert-R1-id leak: db_v2_trans, item size: X
+./davecert-R1-id leak: db_v2_prop_conj, item size: X
+./davecert-R1-id leak: db_v2_trans, item size: X
+./davecert-R1-id leak: db_v2_prop_conj, item size: X
+./davecert-R1-id leak: db_attrs, item size: X
+./davecert-R1-id leak: db_v2_trans, item size: X
+./davecert-R1-id leak: db_v2_prop_conj, item size: X
+./davecert-R1-id leak: db_attrs, item size: X
+./davecert-R1-id leak: db_v2_trans, item size: X
+./davecert-R1-id leak: db_v2_prop_conj, item size: X
+./davecert-R1-id leak: 12 * sa copy attrs array, item size: X
+./davecert-R1-id leak: sa copy trans array, item size: X
+./davecert-R1-id leak: sa copy prop array, item size: X
+./davecert-R1-id leak: sa copy prop conj array, item size: X
+./davecert-R1-id leak: sa copy prop_conj, item size: X
+./davecert-R1-id leak: saved first received packet, item size: X
 ./davecert-R1-id leak: ikev2_inI1outR1 KE, item size: X
+./davecert-R1-id leak: struct state in new_state(), item size: X
 ./davecert-R1-id leak: msg_digest, item size: X
 ./davecert-R1-id leak: rfc3110 format of public key [created], item size: X
 ./davecert-R1-id leak: issuer dn, item size: X

--- a/tests/unit/libpluto/lp61-nattI1/output.txt
+++ b/tests/unit/libpluto/lp61-nattI1/output.txt
@@ -477,10 +477,46 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [93.184.216.34:
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
-| freeing state object #1
 ./nattI1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./nattI1 leak: saved first packet, item size: X
+./nattI1 leak: reply packet for ikev2_parent_outI1_tail, item size: X
+./nattI1 leak: sa in main_outI1, item size: X
+./nattI1 leak: db_attrs, item size: X
+./nattI1 leak: db_v2_trans, item size: X
+./nattI1 leak: db_v2_prop_conj, item size: X
+./nattI1 leak: db_v2_prop, item size: X
+./nattI1 leak: db_attrs, item size: X
+./nattI1 leak: db_v2_trans, item size: X
+./nattI1 leak: db_v2_prop_conj, item size: X
+./nattI1 leak: db_v2_trans, item size: X
+./nattI1 leak: db_v2_prop_conj, item size: X
+./nattI1 leak: db_v2_trans, item size: X
+./nattI1 leak: db_v2_prop_conj, item size: X
+./nattI1 leak: db_v2_trans, item size: X
+./nattI1 leak: db_v2_prop_conj, item size: X
+./nattI1 leak: db_v2_trans, item size: X
+./nattI1 leak: db_v2_prop_conj, item size: X
+./nattI1 leak: db_attrs, item size: X
+./nattI1 leak: db_v2_trans, item size: X
+./nattI1 leak: db_v2_prop_conj, item size: X
+./nattI1 leak: db_attrs, item size: X
+./nattI1 leak: db_v2_trans, item size: X
+./nattI1 leak: db_v2_prop_conj, item size: X
+./nattI1 leak: db_v2_trans, item size: X
+./nattI1 leak: db_v2_prop_conj, item size: X
+./nattI1 leak: db_v2_trans, item size: X
+./nattI1 leak: db_v2_prop_conj, item size: X
+./nattI1 leak: db_attrs, item size: X
+./nattI1 leak: db_v2_trans, item size: X
+./nattI1 leak: db_v2_prop_conj, item size: X
+./nattI1 leak: db_attrs, item size: X
+./nattI1 leak: db_v2_trans, item size: X
+./nattI1 leak: db_v2_prop_conj, item size: X
+./nattI1 leak: initiator nonce, item size: X
+./nattI1 leak: long term secret, item size: X
+./nattI1 leak: saved gi value, item size: X
 ./nattI1 leak: msg_digest, item size: X
 ./nattI1 leak: ikev2_outI1 KE, item size: X
 ./nattI1 leak: db_attrs, item size: X
@@ -514,6 +550,12 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [93.184.216.34:
 ./nattI1 leak: db_attrs, item size: X
 ./nattI1 leak: db_v2_trans, item size: X
 ./nattI1 leak: db_v2_prop_conj, item size: X
+./nattI1 leak: 12 * sa copy attrs array, item size: X
+./nattI1 leak: sa copy trans array, item size: X
+./nattI1 leak: sa copy prop array, item size: X
+./nattI1 leak: sa copy prop conj array, item size: X
+./nattI1 leak: sa copy prop_conj, item size: X
+./nattI1 leak: struct state in new_state(), item size: X
 ./nattI1 leak: policies path, item size: X
 ./nattI1 leak: ocspcerts path, item size: X
 ./nattI1 leak: aacerts path, item size: X

--- a/tests/unit/libpluto/lp62-nattR1/output1.txt
+++ b/tests/unit/libpluto/lp62-nattR1/output1.txt
@@ -352,11 +352,55 @@ sending 432 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  64 0a 06 43  5c 7c 4b 31
 | state hash entry 5
-| freeing state object #1
 ./nattR1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./nattR1 leak: reply packet, item size: X
+./nattR1 leak: saved first packet, item size: X
+./nattR1 leak: initiator nonce, item size: X
+./nattR1 leak: long term secret, item size: X
+./nattR1 leak: saved gi value, item size: X
+./nattR1 leak: nonce, item size: X
+./nattR1 leak: Gi, item size: X
+./nattR1 leak: db_attrs, item size: X
+./nattR1 leak: db_v2_trans, item size: X
+./nattR1 leak: db_v2_prop_conj, item size: X
+./nattR1 leak: db_v2_prop, item size: X
+./nattR1 leak: db_attrs, item size: X
+./nattR1 leak: db_v2_trans, item size: X
+./nattR1 leak: db_v2_prop_conj, item size: X
+./nattR1 leak: db_v2_trans, item size: X
+./nattR1 leak: db_v2_prop_conj, item size: X
+./nattR1 leak: db_v2_trans, item size: X
+./nattR1 leak: db_v2_prop_conj, item size: X
+./nattR1 leak: db_v2_trans, item size: X
+./nattR1 leak: db_v2_prop_conj, item size: X
+./nattR1 leak: db_v2_trans, item size: X
+./nattR1 leak: db_v2_prop_conj, item size: X
+./nattR1 leak: db_attrs, item size: X
+./nattR1 leak: db_v2_trans, item size: X
+./nattR1 leak: db_v2_prop_conj, item size: X
+./nattR1 leak: db_attrs, item size: X
+./nattR1 leak: db_v2_trans, item size: X
+./nattR1 leak: db_v2_prop_conj, item size: X
+./nattR1 leak: db_v2_trans, item size: X
+./nattR1 leak: db_v2_prop_conj, item size: X
+./nattR1 leak: db_v2_trans, item size: X
+./nattR1 leak: db_v2_prop_conj, item size: X
+./nattR1 leak: db_attrs, item size: X
+./nattR1 leak: db_v2_trans, item size: X
+./nattR1 leak: db_v2_prop_conj, item size: X
+./nattR1 leak: db_attrs, item size: X
+./nattR1 leak: db_v2_trans, item size: X
+./nattR1 leak: db_v2_prop_conj, item size: X
+./nattR1 leak: 12 * sa copy attrs array, item size: X
+./nattR1 leak: sa copy trans array, item size: X
+./nattR1 leak: sa copy prop array, item size: X
+./nattR1 leak: sa copy prop conj array, item size: X
+./nattR1 leak: sa copy prop_conj, item size: X
+./nattR1 leak: saved first received packet, item size: X
 ./nattR1 leak: ikev2_inI1outR1 KE, item size: X
+./nattR1 leak: struct state in new_state(), item size: X
 ./nattR1 leak: msg_digest, item size: X
 ./nattR1 leak: policies path, item size: X
 ./nattR1 leak: ocspcerts path, item size: X

--- a/tests/unit/libpluto/lp71-alg-h2hI1/output.txt
+++ b/tests/unit/libpluto/lp71-alg-h2hI1/output.txt
@@ -192,7 +192,6 @@ sending 428 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
-| freeing state object #1
 ./h2hI1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
@@ -200,16 +199,31 @@ sending 428 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | alg_info_delref(ADDRESS) freeing alg_info
 | alg_info_delref(ADDRESS) alg_info->ref_cnt=1
 | alg_info_delref(ADDRESS) freeing alg_info
+./h2hI1 leak: saved first packet, item size: X
+./h2hI1 leak: reply packet for ikev2_parent_outI1_tail, item size: X
+./h2hI1 leak: sa in main_outI1, item size: X
+./h2hI1 leak: db_v2_trans, item size: X
+./h2hI1 leak: db_v2_prop_conj, item size: X
+./h2hI1 leak: db_v2_prop, item size: X
+./h2hI1 leak: initiator nonce, item size: X
+./h2hI1 leak: long term secret, item size: X
+./h2hI1 leak: saved gi value, item size: X
 ./h2hI1 leak: msg_digest, item size: X
 ./h2hI1 leak: ikev2_outI1 KE, item size: X
 ./h2hI1 leak: db_v2_trans, item size: X
 ./h2hI1 leak: db_v2_prop_conj, item size: X
 ./h2hI1 leak: db_v2_prop, item size: X
 ./h2hI1 leak: sa copy attrs array, item size: X
+./h2hI1 leak: sa copy trans array, item size: X
+./h2hI1 leak: sa copy prop array, item size: X
+./h2hI1 leak: sa copy prop conj array, item size: X
+./h2hI1 leak: sa copy prop_conj, item size: X
+./h2hI1 leak: sa copy attrs array, item size: X
 ./h2hI1 leak: sa copy 1 trans array, item size: X
 ./h2hI1 leak: sa copy 1 prop array, item size: X
 ./h2hI1 leak: sa copy 1 prop conj array, item size: X
 ./h2hI1 leak: sa copy prop_conj, item size: X
+./h2hI1 leak: struct state in new_state(), item size: X
 ./h2hI1 leak: policies path, item size: X
 ./h2hI1 leak: ocspcerts path, item size: X
 ./h2hI1 leak: aacerts path, item size: X

--- a/tests/unit/libpluto/lp72-alg-h2hR1/output1.txt
+++ b/tests/unit/libpluto/lp72-alg-h2hR1/output1.txt
@@ -306,11 +306,55 @@ sending 428 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28
-| freeing state object #1
 ./h2hR1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./h2hR1 leak: reply packet, item size: X
+./h2hR1 leak: saved first packet, item size: X
+./h2hR1 leak: initiator nonce, item size: X
+./h2hR1 leak: long term secret, item size: X
+./h2hR1 leak: saved gi value, item size: X
+./h2hR1 leak: nonce, item size: X
+./h2hR1 leak: Gi, item size: X
+./h2hR1 leak: db_attrs, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_v2_prop, item size: X
+./h2hR1 leak: db_attrs, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_attrs, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_attrs, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_attrs, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: db_attrs, item size: X
+./h2hR1 leak: db_v2_trans, item size: X
+./h2hR1 leak: db_v2_prop_conj, item size: X
+./h2hR1 leak: 12 * sa copy attrs array, item size: X
+./h2hR1 leak: sa copy trans array, item size: X
+./h2hR1 leak: sa copy prop array, item size: X
+./h2hR1 leak: sa copy prop conj array, item size: X
+./h2hR1 leak: sa copy prop_conj, item size: X
+./h2hR1 leak: saved first received packet, item size: X
 ./h2hR1 leak: ikev2_inI1outR1 KE, item size: X
+./h2hR1 leak: struct state in new_state(), item size: X
 ./h2hR1 leak: msg_digest, item size: X
 ./h2hR1 leak: alg_info_ike, item size: X
 ./h2hR1 leak: policies path, item size: X

--- a/tests/unit/libpluto/lp76-s2s-while-h2h-I1/output.txt
+++ b/tests/unit/libpluto/lp76-s2s-while-h2h-I1/output.txt
@@ -477,10 +477,46 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | ICOOKIE:  80 01 02 03  04 05 06 07
 | RCOOKIE:  00 00 00 00  00 00 00 00
 | state hash entry 4
-| freeing state object #1
 ./s2sI1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
+./s2sI1 leak: saved first packet, item size: X
+./s2sI1 leak: reply packet for ikev2_parent_outI1_tail, item size: X
+./s2sI1 leak: sa in main_outI1, item size: X
+./s2sI1 leak: db_attrs, item size: X
+./s2sI1 leak: db_v2_trans, item size: X
+./s2sI1 leak: db_v2_prop_conj, item size: X
+./s2sI1 leak: db_v2_prop, item size: X
+./s2sI1 leak: db_attrs, item size: X
+./s2sI1 leak: db_v2_trans, item size: X
+./s2sI1 leak: db_v2_prop_conj, item size: X
+./s2sI1 leak: db_v2_trans, item size: X
+./s2sI1 leak: db_v2_prop_conj, item size: X
+./s2sI1 leak: db_v2_trans, item size: X
+./s2sI1 leak: db_v2_prop_conj, item size: X
+./s2sI1 leak: db_v2_trans, item size: X
+./s2sI1 leak: db_v2_prop_conj, item size: X
+./s2sI1 leak: db_v2_trans, item size: X
+./s2sI1 leak: db_v2_prop_conj, item size: X
+./s2sI1 leak: db_attrs, item size: X
+./s2sI1 leak: db_v2_trans, item size: X
+./s2sI1 leak: db_v2_prop_conj, item size: X
+./s2sI1 leak: db_attrs, item size: X
+./s2sI1 leak: db_v2_trans, item size: X
+./s2sI1 leak: db_v2_prop_conj, item size: X
+./s2sI1 leak: db_v2_trans, item size: X
+./s2sI1 leak: db_v2_prop_conj, item size: X
+./s2sI1 leak: db_v2_trans, item size: X
+./s2sI1 leak: db_v2_prop_conj, item size: X
+./s2sI1 leak: db_attrs, item size: X
+./s2sI1 leak: db_v2_trans, item size: X
+./s2sI1 leak: db_v2_prop_conj, item size: X
+./s2sI1 leak: db_attrs, item size: X
+./s2sI1 leak: db_v2_trans, item size: X
+./s2sI1 leak: db_v2_prop_conj, item size: X
+./s2sI1 leak: initiator nonce, item size: X
+./s2sI1 leak: long term secret, item size: X
+./s2sI1 leak: saved gi value, item size: X
 ./s2sI1 leak: msg_digest, item size: X
 ./s2sI1 leak: ikev2_outI1 KE, item size: X
 ./s2sI1 leak: db_attrs, item size: X
@@ -514,6 +550,12 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 ./s2sI1 leak: db_attrs, item size: X
 ./s2sI1 leak: db_v2_trans, item size: X
 ./s2sI1 leak: db_v2_prop_conj, item size: X
+./s2sI1 leak: 12 * sa copy attrs array, item size: X
+./s2sI1 leak: sa copy trans array, item size: X
+./s2sI1 leak: sa copy prop array, item size: X
+./s2sI1 leak: sa copy prop conj array, item size: X
+./s2sI1 leak: sa copy prop_conj, item size: X
+./s2sI1 leak: struct state in new_state(), item size: X
 ./s2sI1 leak: policies path, item size: X
 ./s2sI1 leak: ocspcerts path, item size: X
 ./s2sI1 leak: aacerts path, item size: X


### PR DESCRIPTION
When build with ONGOING_LEAK_DETECTIVE, whack --status will now dump the memory allocations, which lets one determine what kind of objects are leaking.
Using this, it was observed that the leak was of IKEv1 state objects (and associated buffers).
It seems that during IKEv2 refactoring of delete_state(), that the state is not finally removed in the IKEv1 case, and this was added.  