### PR TITLE
T7347 dh group proposal

### DIFF
--- a/include/pluto/connections.h
+++ b/include/pluto/connections.h
@@ -257,6 +257,9 @@ struct connection {
     bool initiated;
     bool failed_ikev2;                  /* tried ikev2, but failed */
 
+    bool proposal_can_retry;		/* we will retry if current proposal fails */
+    unsigned int proposal_index;	/* incremented on retry */
+
     /* state object serial number: weak pointers */
     so_serial_t	prospective_parent_sa;  /* state we are still negotiating */
     so_serial_t newest_isakmp_sa;       /* state that is negotiated/up */

--- a/programs/pluto/ikev2.c
+++ b/programs/pluto/ikev2.c
@@ -1483,32 +1483,49 @@ void complete_v2_state_transition(struct msg_digest **mdp
 stf_status
 accept_v2_KE(struct msg_digest *md, struct state *st, chunk_t *ke, const char *name)
 {
+    struct ikev2_ke *v2ke;
     pb_stream *keyex_pbs;
     notification_t rn;
+    u_int16_t group_number;
     chunk_t dc;
+
     if (md->chain[ISAKMP_NEXT_v2KE] == NULL)
         return STF_FAIL;
+
+    /* validate the v2KE group */
+
+    v2ke = &md->chain[ISAKMP_NEXT_v2KE]->payload.v2ke;
+
+    if (st->st_oakley.group->group != v2ke->isak_group) {
+	loglog(RC_LOG_SERIOUS, "KE has DH group %u, but we selected %u",
+               v2ke->isak_group, st->st_oakley.group->group);
+        goto send_invalid_ke_ntf;
+    }
 
     keyex_pbs = &md->chain[ISAKMP_NEXT_v2KE]->pbs;
 
     /* KE in */
     rn = accept_KE(ke, name, st->st_oakley.group, keyex_pbs);
+    if (rn == NOTHING_WRONG)
+        return STF_OK;
 
-    if(rn != NOTHING_WRONG) {
-        if (rn == INVALID_KEY_INFORMATION) {
-            u_int16_t group_number = htons(st->st_oakley.group->group);
-            dc.ptr = (unsigned char *)&group_number;
-            dc.len = 2;
-            SEND_V2_NOTIFICATION_DATA(md, st, v2N_INVALID_KE_PAYLOAD, &dc);
-            /* notification sent, return failure, but prevent another
-             * notification from complete_v2_state_transition(). */
-            md->note = rn = 0;
-        }
-        delete_state(st);
-        return STF_FAIL + rn;
-    }
+    if (rn == INVALID_KEY_INFORMATION)
+        /* special case, we want to send a notification here */
+        goto send_invalid_ke_ntf;
 
-    return STF_OK;
+    /* pass any other failure up to caller */
+    return STF_FAIL+rn;
+
+send_invalid_ke_ntf:
+    group_number = htons(st->st_oakley.group->group);
+    dc.ptr = (unsigned char *)&group_number;
+    dc.len = 2;
+    SEND_V2_NOTIFICATION_DATA(md, st, v2N_INVALID_KE_PAYLOAD, &dc);
+    delete_state(st);
+    /* notification sent, return failure, but prevent another
+     * notification from complete_v2_state_transition(). */
+    md->note = 0;
+    return STF_FAIL;
 }
 
 v2_notification_t

--- a/programs/pluto/ikev2.c
+++ b/programs/pluto/ikev2.c
@@ -359,6 +359,18 @@ struct state_v2_microcode v2_state_microcode_table[] = {
       .timeout_event = EVENT_SA_REPLACE,
     },
 
+    /* state 18 */
+    { .svm_name   = "initiator-auth-failure",
+      .state      = STATE_CHILD_C0_KEYING,
+      .next_state = STATE_IKESA_DEL,
+      .flags = SMF2_STATENEEDED,
+      .req_clear_payloads = P(N),
+      .opt_clear_payloads = P(N),
+      .processor  = ikev2parent_ntf_inR2,
+      .recv_type  = ISAKMP_v2_AUTH,
+    },
+
+
     /* last entry */
     { .svm_name   = "invalid-transition",
       .state      = STATE_IKEv2_ROOF }

--- a/programs/pluto/ikev2.c
+++ b/programs/pluto/ikev2.c
@@ -159,7 +159,7 @@ struct state_v2_microcode v2_state_microcode_table[] = {
       .flags = SMF2_STATENEEDED,
       .req_clear_payloads = P(N),
       .opt_clear_payloads = P(N),
-      .processor  = ikev2parent_inR1,
+      .processor  = ikev2parent_ntf_inR1,
       .recv_type  = ISAKMP_v2_SA_INIT,
     },
 

--- a/programs/pluto/ikev2.h
+++ b/programs/pluto/ikev2.h
@@ -61,6 +61,7 @@ extern void complete_v2_state_transition(struct msg_digest **mdp
 extern stf_status process_informational_ikev2(struct msg_digest *md);
 extern stf_status ikev2parent_inI1outR1(struct msg_digest *md);
 extern stf_status ikev2parent_ntf_inR1(struct msg_digest *md);
+extern stf_status ikev2parent_ntf_inR2(struct msg_digest *md);
 extern stf_status ikev2parent_inR1failed(struct msg_digest *md);
 extern stf_status ikev2parent_inR1outI2(struct msg_digest *md);
 extern stf_status ikev2parent_inI2outR2(struct msg_digest *md);

--- a/programs/pluto/ikev2.h
+++ b/programs/pluto/ikev2.h
@@ -60,7 +60,7 @@ extern void complete_v2_state_transition(struct msg_digest **mdp
 
 extern stf_status process_informational_ikev2(struct msg_digest *md);
 extern stf_status ikev2parent_inI1outR1(struct msg_digest *md);
-extern stf_status ikev2parent_inR1(struct msg_digest *md);
+extern stf_status ikev2parent_ntf_inR1(struct msg_digest *md);
 extern stf_status ikev2parent_inR1failed(struct msg_digest *md);
 extern stf_status ikev2parent_inR1outI2(struct msg_digest *md);
 extern stf_status ikev2parent_inI2outR2(struct msg_digest *md);

--- a/programs/pluto/ikev2_parent.c
+++ b/programs/pluto/ikev2_parent.c
@@ -360,7 +360,7 @@ stf_status ikev2_decrypt_msg(struct msg_digest *md
         /* It is not always 96 bytes, it depends upon which integ algo is used*/
         if(memcmp(b12, encend, pst->st_oakley.integ_hasher->hash_integ_len)!=0) {
             openswan_log("R2 failed to match authenticator");
-            return STF_FAIL;
+            return STF_FAIL + AUTHENTICATION_FAILED;
         }
     }
 

--- a/programs/pluto/ikev2_parent.c
+++ b/programs/pluto/ikev2_parent.c
@@ -360,6 +360,10 @@ stf_status ikev2_decrypt_msg(struct msg_digest *md
         /* It is not always 96 bytes, it depends upon which integ algo is used*/
         if(memcmp(b12, encend, pst->st_oakley.integ_hasher->hash_integ_len)!=0) {
             openswan_log("R2 failed to match authenticator");
+
+            /* force the notification to go out on the next message ID */
+            st->st_msgid = md->msgid_received;
+
             return STF_FAIL + AUTHENTICATION_FAILED;
         }
     }

--- a/programs/pluto/ikev2_parent_I2.c
+++ b/programs/pluto/ikev2_parent_I2.c
@@ -481,6 +481,26 @@ static stf_status ikev2parent_retry_next_proposal(struct msg_digest *md)
         pst = state_with_serialno(st->st_clonedfrom);
     }
 
+    /* make sure we release all algorithm SPIs */
+
+    if (!st->st_ah.present && st->st_ah.our_spi) {
+            DBG(DBG_CONTROL, DBG_log("forcing release of AH spi 0x%x",
+				     st->st_ah.our_spi));
+	    st->st_ah.present = 1;
+    }
+
+    if (!st->st_esp.present && st->st_esp.our_spi) {
+            DBG(DBG_CONTROL, DBG_log("forcing release of ESP spi 0x%x",
+				     st->st_esp.our_spi));
+	    st->st_esp.present = 1;
+    }
+
+    if (!st->st_ipcomp.present && st->st_ipcomp.our_spi) {
+            DBG(DBG_CONTROL, DBG_log("forcing release of IPCOMP spi 0x%x",
+				     st->st_ipcomp.our_spi));
+	    st->st_ipcomp.present = 1;
+    }
+
     /* convince whack to wait for the new state, not the old */
 
     if (pst && pst != st) {

--- a/programs/pluto/initiate.c
+++ b/programs/pluto/initiate.c
@@ -1638,6 +1638,7 @@ static void connection_check_ddns1(struct connection *c)
      * lookup
      */
     update_host_pairs(c);
+    c->proposal_index = 0;
     initiate_connection(c->name, NULL_FD, 0, pcim_demand_crypto);
 
     /* no host pairs,  no more to do */

--- a/programs/pluto/spdb_print.c
+++ b/programs/pluto/spdb_print.c
@@ -54,6 +54,16 @@
 #include "db_ops.h"
 #include "spdb.h"
 
+#if 1
+/* print to STDOUT */
+#define print_sa_fmt(fmt,a...) \
+    printf(fmt"\n",##a)
+#else
+/* print to syslog */
+#define print_sa_fmt(fmt,a...) \
+    openswan_log(fmt, ##a)
+#endif
+
 void
 print_sa_attr_oakley(struct db_attr *at)
 {
@@ -66,7 +76,7 @@ print_sa_attr_oakley(struct db_attr *at)
     if(at->type.oakley <= oakley_attr_val_descs_size) {
 	en = oakley_attr_val_descs[at->type.oakley];
     }
-    printf("        type: %u(%s) val: %u(%s)\n"
+    print_sa_fmt("        type: %u(%s) val: %u(%s)"
 	   , at->type.oakley, enum_name(&oakley_attr_names, at->type.oakley+ISAKMP_ATTR_AF_TV)
 	   , at->val,  en ? enum_name(en, at->val) : "unknown");
 }
@@ -83,7 +93,7 @@ print_sa_attr_ipsec(struct db_attr *at)
     if(at->type.ipsec <= ipsec_attr_val_descs_size) {
 	en = ipsec_attr_val_descs[at->type.ipsec];
     }
-    printf("        type: %u(%s) val: %u(%s)\n"
+    print_sa_fmt("        type: %u(%s) val: %u(%s)"
 	   , at->type.ipsec, enum_name(&ipsec_attr_names, at->type.ipsec+ISAKMP_ATTR_AF_TV)
 	   , at->val,  en ? enum_name(en, at->val) : "unknown");
 }
@@ -92,11 +102,11 @@ void
 print_sa_trans(struct db_sa *f, struct db_trans *tr)
 {
     unsigned int i;
-    printf("      transform: %u cnt: %u\n",
+    print_sa_fmt("      transform: %u cnt: %u",
 	   tr->transid, tr->attr_cnt);
     if (!tr->attrs) {
         if (tr->attr_cnt)
-            printf("      !!! WARNING: tr->attrs found NULL\n");
+            print_sa_fmt("      !!! WARNING: tr->attrs found NULL");
         return;
     }
     for(i=0; i<tr->attr_cnt; i++) {
@@ -112,13 +122,13 @@ void
 print_sa_prop(struct db_sa *f, struct db_prop *dp)
 {
     unsigned int i;
-    printf("    protoid: %u (%s) cnt: %u\n"
+    print_sa_fmt("    protoid: %u (%s) cnt: %u"
 	   , dp->protoid
 	   , enum_name(&protocol_names, dp->protoid)
 	   , dp->trans_cnt);
     if (!dp->trans) {
         if (dp->trans_cnt)
-            printf("      !!! WARNING: dp->trans found NULL\n");
+            print_sa_fmt("      !!! WARNING: dp->trans found NULL");
         return;
     }
     for(i=0; i<dp->trans_cnt; i++) {
@@ -130,11 +140,11 @@ void
 print_sa_prop_conj(struct db_sa *f, struct db_prop_conj *pc)
 {
     unsigned int i;
-    printf("  conjunctions cnt: %u\n",
+    print_sa_fmt("  conjunctions cnt: %u",
 	   pc->prop_cnt);
     if (!pc->props) {
         if (pc->prop_cnt)
-            printf("      !!! WARNING: pc->props found NULL\n");
+            print_sa_fmt("      !!! WARNING: pc->props found NULL");
         return;
     }
     for(i=0; i<pc->prop_cnt; i++) {
@@ -146,11 +156,11 @@ void
 sa_print(struct db_sa *f)
 {
     unsigned int i;
-    printf("sa disjunct cnt: %u\n",
+    print_sa_fmt("sa disjunct cnt: %u",
 	   f->prop_conj_cnt);
     if (!f->prop_conjs) {
         if (f->prop_conj_cnt)
-            printf("      !!! WARNING: f->prop_conjs found NULL\n");
+            print_sa_fmt("      !!! WARNING: f->prop_conjs found NULL");
         return;
     }
     for(i=0; i<f->prop_conj_cnt; i++) {
@@ -168,7 +178,7 @@ print_sa_v2_attr(struct db_attr *at)
     }
 
     //en = NULL; /* XXX */
-    printf("        type: %u(%s) val: %u(%s)\n"
+    print_sa_fmt("        type: %u(%s) val: %u(%s)"
 	   , at->type.ikev2, "" /*enum_name(&oakley_attr_names, at->type+ISAKMP_ATTR_AF_TV)*/
 	   , at->val, "unknown");
 }
@@ -183,14 +193,14 @@ print_sa_v2_trans(struct db_v2_trans *tr)
 	en = ikev2_transid_val_descs[tr->transform_type];
     }
 
-    printf("      type: %u(%s) value: %u(%s) attr_cnt: %u\n"
+    print_sa_fmt("      type: %u(%s) value: %u(%s) attr_cnt: %u"
 	   , tr->transform_type
 	   , enum_name(&trans_type_names, tr->transform_type)
 	   , tr->transid, en ? enum_name(en, tr->transid) : "unknown"
 	   , tr->attr_cnt);
     if (!tr->attrs) {
         if (tr->attr_cnt)
-            printf("      !!! WARNING: tr->attrs found NULL\n");
+            print_sa_fmt("      !!! WARNING: tr->attrs found NULL");
         return;
     }
     for(i=0; i<tr->attr_cnt; i++) {
@@ -202,14 +212,14 @@ void
 print_sa_v2_prop_conj(struct db_v2_prop_conj *dp)
 {
     unsigned int i;
-    printf("    proposal #%u protoid: %u (%s) cnt: %u\n"
+    print_sa_fmt("    proposal #%u protoid: %u (%s) cnt: %u"
 	   , dp->propnum
 	   , dp->protoid
 	   , enum_name(&protocol_names, dp->protoid)
 	   , dp->trans_cnt);
     if (!dp->trans) {
         if (dp->trans_cnt)
-            printf("      !!! WARNING: dp->trans found NULL\n");
+            print_sa_fmt("      !!! WARNING: dp->trans found NULL");
         return;
     }
     for(i=0; i<dp->trans_cnt; i++) {
@@ -221,11 +231,11 @@ void
 print_sa_v2_prop(struct db_v2_prop *pc)
 {
     unsigned int i;
-    printf("  conjunctions cnt: %u\n",
+    print_sa_fmt("  conjunctions cnt: %u",
 	   pc->prop_cnt);
     if (!pc->props) {
         if (pc->prop_cnt)
-            printf("      !!! WARNING: pc->props found NULL\n");
+            print_sa_fmt("      !!! WARNING: pc->props found NULL");
         return;
     }
     for(i=0; i<pc->prop_cnt; i++) {
@@ -237,11 +247,11 @@ void
 sa_v2_print(struct db_sa *f)
 {
 	unsigned int i;
-	printf("sav2 disjoint cnt: %u\n",
+	print_sa_fmt("sav2 disjoint cnt: %u",
 	       f->prop_disj_cnt);
 	if (!f->prop_disj) {
 		if (f->prop_disj_cnt)
-			printf("      !!! WARNING: f->prop_disj found NULL\n");
+			print_sa_fmt("      !!! WARNING: f->prop_disj found NULL");
 		return;
         }
 	for(i=0; i<f->prop_disj_cnt; i++) {

--- a/tests/unit/libpluto/lp08-parentR1/R1notify-dump.txt
+++ b/tests/unit/libpluto/lp08-parentR1/R1notify-dump.txt
@@ -1,6 +1,3 @@
 IP (tos 0x0, ttl 64, id 0, offset 0, flags [none], proto UDP (17), length 68, bad cksum 0 (->4623)!)
     132.213.238.7.500 > 192.168.1.1.500: isakmp 2.0 msgid 00000000: parent_sa ikev2_init[R]:
     (n: prot_id=isakmp type=17(invalid_ke_payload))
-IP (tos 0x0, ttl 64, id 0, offset 0, flags [none], proto UDP (17), length 64, bad cksum 0 (->4627)!)
-    132.213.238.7.500 > 192.168.1.1.500: isakmp 2.0 msgid 00000000: parent_sa ikev2_init[R]:
-    (n: prot_id=isakmp type=17(invalid_ke_payload))

--- a/tests/unit/libpluto/lp08-parentR1/output1.txt
+++ b/tests/unit/libpluto/lp08-parentR1/output1.txt
@@ -229,36 +229,13 @@ sending 40 bytes for send_v2_notification through eth0:500 [132.213.238.7:500] t
 | ICOOKIE:  00 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28
-| #1 complete v2 state transition with STF_FAIL+25
-./parentR1 STATE_UNDEFINED: INVALID_KEY_INFORMATION
-./parentR1 sending notification ISAKMP_v2_SA_INIT/v2N_INVALID_KE_PAYLOAD to 192.168.1.1:500
-| **emit ISAKMP Message:
-|    initiator cookie:
-|   00 01 02 03  04 05 06 07
-|    responder cookie:
-|   de bc 58 3a  8f 40 d0 cf
-|    ISAKMP version: IKEv2 version 2.0 (rfc4306/rfc5996)
-|    exchange type: ISAKMP_v2_SA_INIT
-|    flags: ISAKMP_FLAG_RESPONSE
-|    message ID:  00 00 00 00
-| Adding a v2N Payload
-|    next-payload: ISAKMP_NEXT_v2N [@16=0x29]
-| ***emit IKEv2 Notify Payload:
-|    critical bit: none
-|    Protocol ID: PROTO_ISAKMP
-|    SPI size: 0
-|    Notify Message Type: v2N_INVALID_KE_PAYLOAD
-| emitting length of IKEv2 Notify Payload: 8
-| emitting length of ISAKMP Message: 36
-sending 36 bytes for send_v2_notification through eth0:500 [132.213.238.7:500] to 192.168.1.1:500 (using #1)
-|   00 01 02 03  04 05 06 07  de bc 58 3a  8f 40 d0 cf
-|   29 20 22 20  00 00 00 00  00 00 00 24  00 00 00 08
-|   01 00 00 11
-| state transition function for STATE_UNDEFINED failed: INVALID_KEY_INFORMATION
+| #1 complete v2 state transition with STF_FAIL
+./parentR1 STATE_UNDEFINED: (null)
+| state transition function for STATE_UNDEFINED failed: <no reason given>
 ./parentR1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete
-./parentR1 leak: 2 * notification packet, item size: X
+./parentR1 leak: notification packet, item size: X
 ./parentR1 leak: db_attrs, item size: X
 ./parentR1 leak: db_v2_trans, item size: X
 ./parentR1 leak: db_v2_prop_conj, item size: X

--- a/tests/unit/libpluto/lp70-invalid-init-msg/output1.txt
+++ b/tests/unit/libpluto/lp70-invalid-init-msg/output1.txt
@@ -139,6 +139,8 @@ RC=0 "mytunnel":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2ALLOW+IKEv2Init
 |   reject:state needed and state unavailable
 | considering state entry: 17
 |   reject:state needed and state unavailable
+| considering state entry: 18
+|   reject:state needed and state unavailable
 | did not find valid state; giving up
 ./h2hR1 sending notification ISAKMP_v2_SA_INIT/v2N_INVALID_MESSAGE_ID to 192.168.1.1:500
 | **emit ISAKMP Message:

--- a/tests/unit/libpluto/lp85-h2h-invalid-deleteSA-I3/output1.txt
+++ b/tests/unit/libpluto/lp85-h2h-invalid-deleteSA-I3/output1.txt
@@ -904,6 +904,8 @@ sending 492 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132.
 |   reject: in state: STATE_PARENT_I3, needs STATE_CHILDSA_DEL
 | considering state entry: 17
 |   reject: in state: STATE_PARENT_I3, needs STATE_CHILD_C1_KEYED
+| considering state entry: 18
+|   reject: in state: STATE_PARENT_I3, needs STATE_CHILD_C0_KEYING
 | did not find valid state; giving up
 ./deleteChildSA-invalid-msgInI3 sending encrypted notification ISAKMP_v2_INFORMATIONAL/v2N_INVALID_MESSAGE_ID to 132.213.238.7:500
 | **emit ISAKMP Message:

--- a/tests/unit/libpluto/run-unit-tests.sh
+++ b/tests/unit/libpluto/run-unit-tests.sh
@@ -87,9 +87,14 @@ else
     header() { echo "###\n### $@\n###" ; }
 fi
 
+run() {
+    echo >&2 "# $@"
+    "$@"
+}
+
 run_make_check() {
-    rm -f core
-    make $make_options check
+    run rm -f core
+    run make $make_options check
     rc=$?
     if [ $rc -ne 0 ] ; then
         if [ -f core ] ; then
@@ -105,19 +110,21 @@ do
     (
      cd $f
      header $f
-     $do_clean && make $make_options clean
-     $do_pcapupdate && make $make_options pcapupdate
-     while ! run_make_check $f;
+     $do_clean && run make $make_options clean
+     $do_pcapupdate && run make $make_options pcapupdate
+     while ! run run_make_check $f;
      do
-         if make $make_options update
+         if run make $make_options update
          then
              if $do_git_add
              then
-                 git add -p .
+                 run git add -p .
              else
                  warn "$f: ignoring changes as requested"
                  break
              fi
+         else
+             die "$f: make update failed"
          fi
      done
     )

--- a/tests/unit/libpluto/run-unit-tests.sh
+++ b/tests/unit/libpluto/run-unit-tests.sh
@@ -111,7 +111,13 @@ do
      cd $f
      header $f
      $do_clean && run make $make_options clean
-     $do_pcapupdate && run make $make_options pcapupdate
+     if $do_pcapupdate
+     then
+         if ! run make $make_options pcapupdate
+         then
+             die "$f: make pcapupdate failed"
+         fi
+     fi
      while ! run run_make_check $f;
      do
          if run make $make_options update


### PR DESCRIPTION
Many changes to make us behave properly, when both sides have multiple proposals with differing DH groups.  Corrected notification generation (we would sometimes send double notifications for a failure).  We now inspect and reject a v2KE payload DH group, if it differs from what was negotiated.  If negotiation can be retired, then a failure will trigger a second attempt with a different DH group.  Unit tests updated where appropriate.