### PR TITLE
correct how STF_FAIL+x is generated by stf_status_name()

### DIFF
--- a/lib/libpluto/pluto_constants.c
+++ b/lib/libpluto/pluto_constants.c
@@ -291,7 +291,7 @@ const char *stf_status_name(stf_status code)
 	if (ret) return ret;
 	/* decode errors past STF_FAIL */
 	snprintf(stf_status_buffer, sizeof(stf_status_buffer),
-		 "STF_FAIL%+d", code);
+		 "STF_FAIL%+d", code-STF_FAIL);
 	return stf_status_buffer;
 }
 

--- a/tests/unit/libpluto/lp06-parentR1notchosen/output.txt
+++ b/tests/unit/libpluto/lp06-parentR1notchosen/output.txt
@@ -196,7 +196,7 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | processing payload: ISAKMP_NEXT_v2V (len=16)
 | now proceed with state specific processing using state #3 responder-V2_init
 | no connection with matching policy found
-| #0 complete v2 state transition with STF_FAIL+32
+| #0 complete v2 state transition with STF_FAIL+24
 ./parentI1R1 no-state: AUTHENTICATION_FAILED
 ./parentI1R1 sending notification ISAKMP_v2_SA_INIT/v2N_AUTHENTICATION_FAILED to 10.10.5.4:500
 sending 36 bytes for send_v2_notification through eth0:500 [192.168.1.1:500] to 10.10.5.4:500 (using #0)

--- a/tests/unit/libpluto/lp45-h2hR1-noikev2/output1.txt
+++ b/tests/unit/libpluto/lp45-h2hR1-noikev2/output1.txt
@@ -123,8 +123,8 @@ RC=0 "mytunnel-no-ikev2":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+!IKEv1+IKEv2Init+S
 | searching for connection with policy = IKEv2ALLOW/-
 | find_host_connection2 returns empty (ike=mytunnel-no-ikev2/none)
 ./h2hR1-noikev2 connection refused, IKEv2 not authorized
-| processor 'responder-V2_init' returned STF_FAIL+32 (32)
-| #0 complete v2 state transition with STF_FAIL+32
+| processor 'responder-V2_init' returned STF_FAIL+24 (32)
+| #0 complete v2 state transition with STF_FAIL+24
 ./h2hR1-noikev2 no-state: AUTHENTICATION_FAILED
 ./h2hR1-noikev2 sending notification ISAKMP_v2_SA_INIT/v2N_AUTHENTICATION_FAILED to 192.168.1.1:500
 | **emit ISAKMP Message:


### PR DESCRIPTION
previously calling stf_status_name(STF_FAIL+1) would print "STF_FAIL+9"
which is incorrect.  This change subtracts STF_FAIL before printing
the trailing number.  The new function will output "STF_FAIL+1" as
expected.