### PR TITLE
wo#8180 - do not pass MAKEFLAGS explicitly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,7 @@ export OBJDIRTOP
 
 programs install clean:: ${OBJDIR}/Makefile
 	@echo OBJDIR: ${OBJDIR}
-	(cd ${ABSOBJDIR} && OBJDIRTOP=${ABSOBJDIR} OBJDIR=${ABSOBJDIR} ${MAKE} ${MAKEFLAGS} $@ )
+	(cd ${ABSOBJDIR} && OBJDIRTOP=${ABSOBJDIR} OBJDIR=${ABSOBJDIR} ${MAKE} $@ )
 
 ${OBJDIR}/Makefile: ${srcdir}/Makefile packaging/utils/makeshadowdir
 	@echo Setting up for OBJDIR=${OBJDIR}


### PR DESCRIPTION
passing MAKEFLAGS explicitly breaks builds on systems where /bin/sh symlinks to dash.