### PR TITLE
T6269 kernel alg table fix

### DIFF
--- a/programs/pluto/kernel.c
+++ b/programs/pluto/kernel.c
@@ -1388,43 +1388,52 @@ static err_t setup_esp_sa(struct connection *c
     IPsecSAref_t refhim = st->st_refhim;
 
     /* this maps IKE/IETF values into kernel identifiers */
+    /* this maps IKE/IETF values into kernel identifiers */
     static const struct esp_info esp_info[] = {
-        { FALSE, ESP_NULL, AUTH_ALGORITHM_HMAC_MD5,
-          0, HMAC_MD5_KEY_LEN,
-          SADB_EALG_NULL, SADB_AALG_MD5HMAC },
-        { FALSE, ESP_NULL, AUTH_ALGORITHM_HMAC_SHA1,
-          0, HMAC_SHA1_KEY_LEN,
-          SADB_EALG_NULL, SADB_AALG_SHA1HMAC },
+        { .transid = ESP_NULL,              .auth = AUTH_ALGORITHM_HMAC_MD5,
+          .authkeylen = HMAC_MD5_KEY_LEN,
 
-        { FALSE, ESP_DES, AUTH_ALGORITHM_NONE,
-          DES_CBC_BLOCK_SIZE, 0,
-          SADB_EALG_DESCBC, SADB_AALG_NONE },
-        { FALSE, ESP_DES, AUTH_ALGORITHM_HMAC_MD5,
-          DES_CBC_BLOCK_SIZE, HMAC_MD5_KEY_LEN,
-          SADB_EALG_DESCBC, SADB_AALG_MD5HMAC },
-        { FALSE, ESP_DES, AUTH_ALGORITHM_HMAC_SHA1,
-          DES_CBC_BLOCK_SIZE,
-          HMAC_SHA1_KEY_LEN, SADB_EALG_DESCBC, SADB_AALG_SHA1HMAC },
+          .encryptalg = SADB_EALG_NULL, .authalg = SADB_AALG_MD5HMAC },
 
-        { FALSE, ESP_3DES, AUTH_ALGORITHM_NONE,
-          DES_CBC_BLOCK_SIZE * 3, 0,
-          SADB_EALG_3DESCBC, SADB_AALG_NONE },
-        { FALSE, ESP_3DES, AUTH_ALGORITHM_HMAC_MD5,
-          DES_CBC_BLOCK_SIZE * 3, HMAC_MD5_KEY_LEN,
-          SADB_EALG_3DESCBC, SADB_AALG_MD5HMAC },
-        { FALSE, ESP_3DES, AUTH_ALGORITHM_HMAC_SHA1,
-          DES_CBC_BLOCK_SIZE * 3, HMAC_SHA1_KEY_LEN,
-          SADB_EALG_3DESCBC, SADB_AALG_SHA1HMAC },
+        { .transid = ESP_NULL,              .auth = AUTH_ALGORITHM_HMAC_SHA1,
+          .authkeylen = HMAC_SHA1_KEY_LEN,
+          .encryptalg = SADB_EALG_NULL, .authalg = SADB_AALG_SHA1HMAC },
 
-        { FALSE, ESP_AES, AUTH_ALGORITHM_NONE,
-          AES_CBC_BLOCK_SIZE, 0,
-          SADB_X_EALG_AESCBC, SADB_AALG_NONE },
-        { FALSE, ESP_AES, AUTH_ALGORITHM_HMAC_MD5,
-              AES_CBC_BLOCK_SIZE, HMAC_MD5_KEY_LEN,
-          SADB_X_EALG_AESCBC, SADB_AALG_MD5HMAC },
-        { FALSE, ESP_AES, AUTH_ALGORITHM_HMAC_SHA1,
-          AES_CBC_BLOCK_SIZE, HMAC_SHA1_KEY_LEN,
-          SADB_X_EALG_AESCBC, SADB_AALG_SHA1HMAC },
+        { .transid = ESP_DES,               .auth = AUTH_ALGORITHM_NONE,
+          .enckeylen = DES_CBC_BLOCK_SIZE,
+          .encryptalg = SADB_EALG_DESCBC, .authalg = SADB_AALG_NONE },
+
+        { .transid = ESP_DES,               .auth = AUTH_ALGORITHM_HMAC_MD5,
+          .enckeylen = DES_CBC_BLOCK_SIZE,  .authkeylen = HMAC_MD5_KEY_LEN,
+          .encryptalg = SADB_EALG_DESCBC, .authalg = SADB_AALG_MD5HMAC },
+
+        { .transid = ESP_DES,               .auth = AUTH_ALGORITHM_HMAC_SHA1,
+          .enckeylen = DES_CBC_BLOCK_SIZE,  .authkeylen = HMAC_SHA1_KEY_LEN, .encryptalg = SADB_EALG_DESCBC,
+          .authalg = SADB_AALG_SHA1HMAC },
+
+        { .transid = ESP_3DES,               .auth = AUTH_ALGORITHM_NONE,
+          .enckeylen = DES_CBC_BLOCK_SIZE * 3,
+          .encryptalg = SADB_EALG_3DESCBC, .authalg = SADB_AALG_NONE },
+
+        { .transid = ESP_3DES,               .auth = AUTH_ALGORITHM_HMAC_MD5,
+          .enckeylen = DES_CBC_BLOCK_SIZE * 3, .authkeylen = HMAC_MD5_KEY_LEN,
+          .encryptalg = SADB_EALG_3DESCBC, .authalg = SADB_AALG_MD5HMAC },
+
+        { .transid = ESP_3DES,               .auth = AUTH_ALGORITHM_HMAC_SHA1,
+          .enckeylen = DES_CBC_BLOCK_SIZE * 3, .authkeylen = HMAC_SHA1_KEY_LEN,
+          .encryptalg = SADB_EALG_3DESCBC, .authalg = SADB_AALG_SHA1HMAC },
+
+        { .transid = ESP_AES,                .auth = AUTH_ALGORITHM_NONE,
+          .enckeylen = AES_CBC_BLOCK_SIZE,
+          .encryptalg = SADB_X_EALG_AESCBC, .authalg = SADB_AALG_NONE },
+
+        { .transid = ESP_AES,                .auth = AUTH_ALGORITHM_HMAC_MD5,
+          .enckeylen = AES_CBC_BLOCK_SIZE,   .authkeylen = HMAC_MD5_KEY_LEN,
+          .encryptalg = SADB_X_EALG_AESCBC, .authalg = SADB_AALG_MD5HMAC },
+
+        { .transid = ESP_AES,                .auth = AUTH_ALGORITHM_HMAC_SHA1,
+          .enckeylen = AES_CBC_BLOCK_SIZE,   .authkeylen = HMAC_SHA1_KEY_LEN,
+          .encryptalg = SADB_X_EALG_AESCBC, .authalg = SADB_AALG_SHA1HMAC },
     };
 
     /* static const int esp_max = elemsof(esp_info); */

--- a/programs/pluto/kernel.c
+++ b/programs/pluto/kernel.c
@@ -282,13 +282,14 @@ get_my_cpi(struct state *st, bool tunnel)
 
     set_text_said(text_said, &st->st_localaddr, 0, IPPROTO_COMP);
 
-    if (kernel_ops->get_spi)
+    if (kernel_ops->get_spi) {
 	st->st_ipcomp.our_spi_in_kernel = TRUE;
         return kernel_ops->get_spi(&st->st_remoteaddr
 				   , &st->st_localaddr, IPPROTO_COMP, tunnel
 				   , get_proto_reqid()
 				   , IPCOMP_FIRST_NEGOTIATED, IPCOMP_LAST_NEGOTIATED
 				   , text_said);
+    }
 
     while (!(IPCOMP_FIRST_NEGOTIATED <= first_busy_cpi && first_busy_cpi < IPCOMP_LAST_NEGOTIATED))
     {

--- a/programs/pluto/kernel_netlink.c
+++ b/programs/pluto/kernel_netlink.c
@@ -81,19 +81,6 @@ extern char *pluto_listen;
 
 extern const struct pfkey_proto_info null_proto_info[2];
 
-static const struct pfkey_proto_info broad_proto_info[2] = {
-        {
-                proto: IPPROTO_ESP,
-                encapsulation: ENCAPSULATION_MODE_TUNNEL,
-                reqid: 0
-        },
-        {
-                proto: 0,
-                encapsulation: 0,
-                reqid: 0
-        }
-};
-
 /* Minimum priority number in SPD used by pluto. */
 #define MIN_SPD_PRIORITY 1024
 


### PR DESCRIPTION
This contains three important fixes.
Dead code gone that kicks a warning.
An if() block missing {}.
And adjustment to an initialized array that was putting data in the wrong place.
The last bit is completely replaced by new algo code, but at the intermediate state, I can't leave it wrong.
