### PR TITLE
T8451 dpd time args

### DIFF
--- a/lib/libipsecconf/keywords.c
+++ b/lib/libipsecconf/keywords.c
@@ -444,9 +444,9 @@ struct keyword_def ipsec_conf_keywords_v2[]={
     {"metric",         kv_conn|kv_auto, kt_number, KBF_METRIC, NOT_ENUM},
 
     /* DPD */
-    {"dpddelay",       kv_conn|kv_auto,kt_number, KBF_DPDDELAY, NOT_ENUM},
-    {"dpdtimeout",     kv_conn|kv_auto,kt_number,KBF_DPDTIMEOUT , NOT_ENUM},
-    {"dpdaction",      kv_conn|kv_auto,kt_enum, KBF_DPDACTION , &kw_dpdaction_list},
+    {"dpddelay",       kv_conn|kv_auto, kt_time, KBF_DPDDELAY,   NOT_ENUM},
+    {"dpdtimeout",     kv_conn|kv_auto, kt_time, KBF_DPDTIMEOUT, NOT_ENUM},
+    {"dpdaction",      kv_conn|kv_auto, kt_enum, KBF_DPDACTION,  &kw_dpdaction_list},
 
     {"mtu",            kv_conn|kv_auto,kt_number, KBF_CONNMTU, NOT_ENUM},
 

--- a/lib/libipsecconf/parser.l
+++ b/lib/libipsecconf/parser.l
@@ -5,7 +5,7 @@
 /* Openswan config file parser (parser.l)
  * Copyright (C) 2001 Mathieu Lafon - Arkoon Network Security
  * Copyright (C) 2003-2007 Michael Richardson <mcr@xelerance.com>
- * Copyright (C) 2008 D. Hugh Redelmeier <hugh@mimosa.com>
+ * Copyright (C) 2008, 2014 D. Hugh Redelmeier <hugh@mimosa.com>
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the
@@ -322,10 +322,19 @@ int parser_y_eof(void)
 
 [\t ]+			/* ignore spaces in line */ ;
 
-<USERDEF>[0-9]+         { /* process a number */
-                           yylval.num = strtoul(yytext, NULL, 10);
+<INITIAL,USERDEF>[0-9]+ { /* process a number */
+                           unsigned long val = (errno = 0, strtoul(yytext, NULL, 10));
+                           if (errno != 0 || val > UINT_MAX) {
+                               char ebuf[128];
+                          
+                               snprintf(ebuf, sizeof(ebuf),
+                                   "number too large: %s",
+                                   yytext);
+                               yyerror(ebuf);
+                           }
+                           yylval.num = val;
                            BEGIN INITIAL;
-			   return INTEGER;
+                           return INTEGER;
                         }
 
 <USERDEF>%forever       { /* a number, really 0 */

--- a/tests/functional/01-confread/cassidy.conf
+++ b/tests/functional/01-confread/cassidy.conf
@@ -20,8 +20,8 @@ conn %default
         #dpdaction=hold
 
 conn %oedefault
-        dpddelay=20
-        dpdtimeout=120
+        dpddelay=20s
+        dpdtimeout=2m
         dpdaction=hold
 
 include /etc/ipsec.d/*.conf

--- a/tests/functional/01-confread/cassidy.conf.out
+++ b/tests/functional/01-confread/cassidy.conf.out
@@ -330,8 +330,8 @@ conn cassidy--correlhorn
 	rightrsakey=0sAQPhXFiBI/83BXnfYzUYE79IXhzRwNDGi0VfQlHtS3+/6g3H0Seqs7Hr40IKrt13AtiDKOooVCBPn+lMd6hi1FWhg7bw4y6by8dr9QxcOdjdl+tFLJ8KzTk2hSwcaKBxqHm3gsuVnQByV20xcP5BVRxmekyuTcZjgavcSpTfjc3yKy9AwF9htGu5lnPjasrXSU1c2vcWSbYil/tIBGxKgprbBe4+JZYxTIENZ+kvVZTtkOAHpxizV0LQ2w2dYaqZ/SzhO0+DwgVB6/SHxCJveUwpufDqmFN99dic66Psrmacrqk1UWt4KeI5tAo7lMrOTHdarViYIuAwOCE2brcpW1/X
 	rightsourceip=209.87.252.215
 	rekey=no
-	dpddelay=0
-	dpdtimeout=0
+	dpddelay=20
+	dpdtimeout=120
 	auto=ignore
 	type=tunnel
 	compress=no
@@ -358,8 +358,8 @@ conn istari--correlhorn-extrude
 	rightrsakey=0sAQPhXFiBI/83BXnfYzUYE79IXhzRwNDGi0VfQlHtS3+/6g3H0Seqs7Hr40IKrt13AtiDKOooVCBPn+lMd6hi1FWhg7bw4y6by8dr9QxcOdjdl+tFLJ8KzTk2hSwcaKBxqHm3gsuVnQByV20xcP5BVRxmekyuTcZjgavcSpTfjc3yKy9AwF9htGu5lnPjasrXSU1c2vcWSbYil/tIBGxKgprbBe4+JZYxTIENZ+kvVZTtkOAHpxizV0LQ2w2dYaqZ/SzhO0+DwgVB6/SHxCJveUwpufDqmFN99dic66Psrmacrqk1UWt4KeI5tAo7lMrOTHdarViYIuAwOCE2brcpW1/X
 	rightsourceip=209.87.252.215
 	rekey=no
-	dpddelay=0
-	dpdtimeout=0
+	dpddelay=20
+	dpdtimeout=120
 	auto=ignore
 	type=tunnel
 	compress=no
@@ -386,8 +386,8 @@ conn franklin--correlhorn-extrude
 	rightrsakey=0sAQPhXFiBI/83BXnfYzUYE79IXhzRwNDGi0VfQlHtS3+/6g3H0Seqs7Hr40IKrt13AtiDKOooVCBPn+lMd6hi1FWhg7bw4y6by8dr9QxcOdjdl+tFLJ8KzTk2hSwcaKBxqHm3gsuVnQByV20xcP5BVRxmekyuTcZjgavcSpTfjc3yKy9AwF9htGu5lnPjasrXSU1c2vcWSbYil/tIBGxKgprbBe4+JZYxTIENZ+kvVZTtkOAHpxizV0LQ2w2dYaqZ/SzhO0+DwgVB6/SHxCJveUwpufDqmFN99dic66Psrmacrqk1UWt4KeI5tAo7lMrOTHdarViYIuAwOCE2brcpW1/X
 	rightsourceip=209.87.252.215
 	rekey=no
-	dpddelay=0
-	dpdtimeout=0
+	dpddelay=20
+	dpdtimeout=120
 	auto=ignore
 	type=tunnel
 	compress=no
@@ -414,8 +414,8 @@ conn aragorn--correlhorn-extrude
 	rightrsakey=0sAQPhXFiBI/83BXnfYzUYE79IXhzRwNDGi0VfQlHtS3+/6g3H0Seqs7Hr40IKrt13AtiDKOooVCBPn+lMd6hi1FWhg7bw4y6by8dr9QxcOdjdl+tFLJ8KzTk2hSwcaKBxqHm3gsuVnQByV20xcP5BVRxmekyuTcZjgavcSpTfjc3yKy9AwF9htGu5lnPjasrXSU1c2vcWSbYil/tIBGxKgprbBe4+JZYxTIENZ+kvVZTtkOAHpxizV0LQ2w2dYaqZ/SzhO0+DwgVB6/SHxCJveUwpufDqmFN99dic66Psrmacrqk1UWt4KeI5tAo7lMrOTHdarViYIuAwOCE2brcpW1/X
 	rightsourceip=209.87.252.215
 	rekey=no
-	dpddelay=0
-	dpdtimeout=0
+	dpddelay=20
+	dpdtimeout=120
 	auto=ignore
 	type=tunnel
 	compress=no
@@ -586,8 +586,8 @@ conn correlhorn-extrude
 	rightsubnet=209.87.252.215/32
 	rightrsakey=0sAQPhXFiBI/83BXnfYzUYE79IXhzRwNDGi0VfQlHtS3+/6g3H0Seqs7Hr40IKrt13AtiDKOooVCBPn+lMd6hi1FWhg7bw4y6by8dr9QxcOdjdl+tFLJ8KzTk2hSwcaKBxqHm3gsuVnQByV20xcP5BVRxmekyuTcZjgavcSpTfjc3yKy9AwF9htGu5lnPjasrXSU1c2vcWSbYil/tIBGxKgprbBe4+JZYxTIENZ+kvVZTtkOAHpxizV0LQ2w2dYaqZ/SzhO0+DwgVB6/SHxCJveUwpufDqmFN99dic66Psrmacrqk1UWt4KeI5tAo7lMrOTHdarViYIuAwOCE2brcpW1/X
 	rightsourceip=209.87.252.215
-	dpddelay=0
-	dpdtimeout=0
+	dpddelay=20
+	dpdtimeout=120
 	auto=ignore
 	type=tunnel
 	compress=no

--- a/tests/functional/01-confread/cassidy/etc/ipsec.d/ssw.conf
+++ b/tests/functional/01-confread/cassidy/etc/ipsec.d/ssw.conf
@@ -12,8 +12,8 @@ conn marajade-extrude-new
         rightsubnet=209.87.252.213/32
 
 conn correlhorn-extrude
-	dpddelay=0
-	dpdtimeout=0
+        dpddelay=20s
+        dpdtimeout=2m
 	right=%any
 	rightid=@correlhorn.sandelman.ca
 	rightsourceip=209.87.252.215


### PR DESCRIPTION
As stated in d0da38c, this is a port of the fix applied to libreswan in commit 2a6f1b5e987d72486b1b7eaef5f28807a48802fb, by D. Hugh Redelmeier.

After this commit, dpddelay and dpdtimeout can take values with a suffix (s,m,h,d,w).