### PR TITLE
T8938 crypto helper race

### DIFF
--- a/programs/pluto/ikev1.c
+++ b/programs/pluto/ikev1.c
@@ -2409,7 +2409,8 @@ complete_v1_state_transition(struct msg_digest **mdp, stf_status result)
 	    /* well, this should never happen during a whack, since
 	     * a whack will always force crypto.
 	     */
-	    set_suspended(st, NULL);
+	    if (st->st_suspended_md == md)
+		    set_suspended(st, NULL);
 	    pexpect(st->st_calculating == FALSE);
 	    openswan_log("message in state %s ignored due to cryptographic overload"
 			 , enum_name(&state_names, from_state));

--- a/programs/pluto/ikev1_aggr.c
+++ b/programs/pluto/ikev1_aggr.c
@@ -129,7 +129,7 @@ aggr_inI1_outR1_continue2(struct pluto_crypto_req_cont *pcrc
   passert(cur_state == NULL);
   passert(st != NULL);
 
-  passert(st->st_suspended_md == dh->md);
+  assert_suspended(st, dh->md);
   set_suspended(st, NULL);	/* no longer connected or suspended */
 
   set_cur_state(st);
@@ -176,7 +176,7 @@ aggr_inI1_outR1_continue1(struct pluto_crypto_req_cont *pcrc
   passert(cur_state == NULL);
   passert(st != NULL);
 
-  passert(st->st_suspended_md == ke->md);
+  assert_suspended(st, ke->md);
   set_suspended(st, NULL);	/* no longer connected or suspended */
 
   set_cur_state(st);
@@ -685,7 +685,7 @@ aggr_inR1_outI2_crypto_continue(struct pluto_crypto_req_cont *pcrc
   passert(cur_state == NULL);
   passert(st != NULL);
 
-  passert(st->st_suspended_md == dh->md);
+  assert_suspended(st, dh->md);
   set_suspended(st, NULL);	/* no longer connected or suspended */
 
   set_cur_state(st);
@@ -989,7 +989,7 @@ aggr_outI1_continue(struct pluto_crypto_req_cont *pcrc
   passert(cur_state == NULL);
   passert(st != NULL);
 
-  passert(st->st_suspended_md == ke->md);
+  assert_suspended(st, ke->md);
   set_suspended(st,NULL);	/* no longer connected or suspended */
 
   set_cur_state(st);

--- a/programs/pluto/ikev1_aggr.c
+++ b/programs/pluto/ikev1_aggr.c
@@ -581,6 +581,14 @@ aggr_inR1_outI2(struct msg_digest *md)
     struct state *st = md->st;
     pb_stream *keyex_pbs = &md->chain[ISAKMP_NEXT_KE]->pbs;
 
+    /* if we are already processing a packet on this st, we will be unable
+     * to start another crypto operation below */
+    if (is_suspended(st)) {
+        openswan_log("%s: already processing a suspended cyrpto operation "
+                     "on this SA, duplicate will be dropped.", __func__);
+	return STF_TOOMUCHCRYPTO;
+    }
+
     st->st_policy |= POLICY_AGGRESSIVE;
 
     if (!decode_peer_id(md, FALSE, TRUE))

--- a/programs/pluto/ikev1_main.c
+++ b/programs/pluto/ikev1_main.c
@@ -915,7 +915,7 @@ main_inR1_outI2_continue(struct pluto_crypto_req_cont *pcrc
     passert(cur_state == NULL);
     passert(st != NULL);
 
-    passert(st->st_suspended_md == ke->md);
+    assert_suspended(st, ke->md);
     set_suspended(st, NULL);	/* no longer connected or suspended */
 
     set_cur_state(st);
@@ -1109,7 +1109,7 @@ main_inI2_outR2_continue(struct pluto_crypto_req_cont *pcrc
     passert(cur_state == NULL);
     passert(st != NULL);
 
-    passert(st->st_suspended_md == ke->md);
+    assert_suspended(st, ke->md);
     set_suspended(st, NULL);	/* no longer connected or suspended */
 
     set_cur_state(st);
@@ -1669,7 +1669,7 @@ main_inR2_outI3_cryptotail(struct pluto_crypto_req_cont *pcrc
   passert(cur_state == NULL);
   passert(st != NULL);
 
-  passert(st->st_suspended_md == dh->md);
+  assert_suspended(st, dh->md);
   set_suspended(st, NULL);	/* no longer connected or suspended */
 
   set_cur_state(st);
@@ -1911,7 +1911,7 @@ key_continue(struct adns_continuation *cr
     {
 	stf_status r;
 
-	passert(st->st_suspended_md == kc->md);
+	assert_suspended(st, kc->md);
 	set_suspended(st,NULL);	/* no longer connected or suspended */
 	cur_state = st;
 

--- a/programs/pluto/ikev1_main.c
+++ b/programs/pluto/ikev1_main.c
@@ -937,6 +937,14 @@ main_inR1_outI2(struct msg_digest *md)
 {
     struct state *const st = md->st;
 
+    /* if we are already processing a packet on this st, we will be unable
+     * to start another crypto operation below */
+    if (is_suspended(st)) {
+        openswan_log("%s: already processing a suspended cyrpto operation "
+                     "on this SA, duplicate will be dropped.", __func__);
+	return STF_TOOMUCHCRYPTO;
+    }
+
     /* verify echoed SA */
     {
 	struct payload_digest *const sapd = md->chain[ISAKMP_NEXT_SA];
@@ -1129,6 +1137,15 @@ main_inI2_outR2(struct msg_digest *md)
 {
     struct state *const st = md->st;
     pb_stream *keyex_pbs = &md->chain[ISAKMP_NEXT_KE]->pbs;
+
+    /* if we are already processing a packet on this st, we will be unable
+     * to start another crypto operation below */
+    if (is_suspended(st)) {
+        openswan_log("%s: already processing a suspended cyrpto operation "
+                     "on this SA, duplicate will be dropped.", __func__);
+	return STF_TOOMUCHCRYPTO;
+    }
+
     /* KE in */
     RETURN_STF_FAILURE(accept_KE(&st->st_gi, "Gi"
 				 , st->st_oakley.group, keyex_pbs));
@@ -1696,6 +1713,14 @@ main_inR2_outI3(struct msg_digest *md)
     pb_stream *const keyex_pbs = &md->chain[ISAKMP_NEXT_KE]->pbs;
     struct state *const st = md->st;
 
+    /* if we are already processing a packet on this st, we will be unable
+     * to start another crypto operation below */
+    if (is_suspended(st)) {
+        openswan_log("%s: already processing a suspended cyrpto operation "
+                     "on this SA, duplicate will be dropped.", __func__);
+	return STF_TOOMUCHCRYPTO;
+    }
+
     /* KE in */
     RETURN_STF_FAILURE(accept_KE(&st->st_gr, "Gr"
 				 , st->st_oakley.group, keyex_pbs));
@@ -1752,6 +1777,14 @@ oakley_id_and_auth(struct msg_digest *md
     u_char hash_val[MAX_DIGEST_LEN];
     size_t hash_len;
     stf_status r = STF_OK;
+
+    /* if we are already processing a packet on this st, we will be unable
+     * to start another crypto operation below */
+    if (is_suspended(st)) {
+        openswan_log("%s: already processing a suspended cyrpto operation "
+                     "on this SA, duplicate will be dropped.", __func__);
+	return STF_TOOMUCHCRYPTO;
+    }
 
     /* ID Payload in.
      * Note: this may switch the connection being used!

--- a/programs/pluto/ikev1_quick.c
+++ b/programs/pluto/ikev1_quick.c
@@ -1388,6 +1388,14 @@ quick_inI1_outR1_start_query(struct verify_oppo_bundle *b
     ip_address client;
     err_t ugh;
 
+    /* if we are already processing a packet on this st, we will be unable
+     * to start another crypto operation below */
+    if (is_suspended(p1st)) {
+        openswan_log("%s: already processing a suspended cyrpto operation "
+                     "on this SA, duplicate will be dropped.", __func__);
+	return STF_TOOMUCHCRYPTO;
+    }
+
     /* Record that state is used by a suspended md */
     b->step = next_step;    /* not just vc->b.step */
     vc->b = *b;
@@ -1698,6 +1706,14 @@ quick_inI1_outR1_authtail(struct verify_oppo_bundle *b
 	, *his_net = &b->his.net;
     struct end our, peer;
     struct hidden_variables hv;
+
+    /* if we are already processing a packet on this st, we will be unable
+     * to start another crypto operation below */
+    if (is_suspended(p1st)) {
+        openswan_log("%s: already processing a suspended cyrpto operation "
+                     "on this SA, duplicate will be dropped.", __func__);
+	return STF_TOOMUCHCRYPTO;
+    }
 
     zero(&our); zero(&peer);
     our.host_type  = KH_IPADDR;
@@ -2372,6 +2388,14 @@ stf_status
 quick_inR1_outI2(struct msg_digest *md)
 {
     struct state *const st = md->st;
+
+    /* if we are already processing a packet on this st, we will be unable
+     * to start another crypto operation below */
+    if (is_suspended(st)) {
+        openswan_log("%s: already processing a suspended cyrpto operation "
+                     "on this SA, duplicate will be dropped.", __func__);
+	return STF_TOOMUCHCRYPTO;
+    }
 
     /* HASH(2) in */
     CHECK_QUICK_HASH(md

--- a/programs/pluto/ikev1_quick.c
+++ b/programs/pluto/ikev1_quick.c
@@ -746,9 +746,10 @@ quick_outI1_continue(struct pluto_crypto_req_cont *pcrc
     passert(ugh == NULL);
     passert(cur_state == NULL);
     passert(st != NULL);
+    passert(qke->md == NULL);	// there is no md, because we are initiating
 
     set_cur_state(st);	/* we must reset before exit */
-    set_suspended(st, NULL);
+    //set_suspended(st, NULL);
     e = quick_outI1_tail(pcrc, r, st);
     if (e == STF_INTERNAL_ERROR)
 	loglog(RC_LOG_SERIOUS, "%s: quick_outI1_tail() failed with STF_INTERNAL_ERROR", __FUNCTION__);
@@ -2027,6 +2028,7 @@ quick_inI1_outR1_authtail(struct verify_oppo_bundle *b
 	    if(ci < st->st_import) ci = st->st_import;
 
 	    qke->md = md;
+	    set_suspended(st, md);
 	    pcrc_init(&qke->qke_pcrc);
 	    qke->qke_pcrc.pcrc_func = quick_inI1_outR1_cryptocontinue1;
 

--- a/programs/pluto/ikev1_quick.c
+++ b/programs/pluto/ikev1_quick.c
@@ -1353,7 +1353,7 @@ quick_inI1_outR1_continue(struct adns_continuation *cr, err_t ugh)
     /* if st == NULL, our state has been deleted -- just clean up */
     if (st != NULL)
     {
-	passert(st->st_suspended_md == b->md);
+	assert_suspended(st, b->md);
 	set_suspended(st, NULL);	/* no longer connected or suspended */
 	cur_state = st;
 	if (!b->failure_ok && ugh != NULL)

--- a/programs/pluto/ikev2.c
+++ b/programs/pluto/ikev2.c
@@ -1427,7 +1427,8 @@ void complete_v2_state_transition(struct msg_digest **mdp
 	 * returned by build_ke() or build_nonce().
 	 */
 	if (st) {
-		set_suspended(st, NULL);
+		if (st->st_suspended_md == md)
+                    set_suspended(st, NULL);
 		pexpect(st->st_calculating == FALSE);
 	}
 	openswan_log("message in state %s ignored due to "

--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -1646,6 +1646,7 @@ static void ikev2child_inCI1_continue2(struct pluto_crypto_req_cont *pcrc
         return;
     }
 
+    passert(st->st_suspended_md == dh->md);
     set_suspended(st,NULL);        /* no longer connected or suspended */
     set_cur_state(st);
     st->st_calculating = FALSE;
@@ -1954,6 +1955,7 @@ static void ikev2child_inCR1_continue(struct pluto_crypto_req_cont *pcrc
         return;
     }
 
+    passert(st->st_suspended_md == dh->md);
     set_suspended(st, NULL);        /* no longer connected or suspended */
     set_cur_state(st);
     st->st_calculating = FALSE;

--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -1418,6 +1418,14 @@ static stf_status ikev2child_inCI1_pfs(struct msg_digest *md)
 {
     struct state *st = md->st;
 
+    /* if we are already processing a packet on this st, we will be unable
+     * to start another crypto operation below */
+    if (is_suspended(st)) {
+        openswan_log("%s: already processing a suspended cyrpto operation "
+                     "on this SA, duplicate will be dropped.", __func__);
+	return STF_TOOMUCHCRYPTO;
+    }
+
     loglog(RC_COMMENT, "msgid=%u CHILD_SA PFS rekey message received from %s:%u on %s (port=%d)"
            , md->msgid_received
            , ip_str(&md->sender), (unsigned)md->sender_port
@@ -1858,6 +1866,14 @@ static stf_status ikev2child_inCR1_pfs(struct msg_digest *md)
 {
     struct state *st = md->st;
     stf_status e;
+
+    /* if we are already processing a packet on this st, we will be unable
+     * to start another crypto operation below */
+    if (is_suspended(st)) {
+        openswan_log("%s: already processing a suspended cyrpto operation "
+                     "on this SA, duplicate will be dropped.", __func__);
+	return STF_TOOMUCHCRYPTO;
+    }
 
     /* Gr in */
     e = accept_v2_KE(md, st, &st->st_gr, "Gr");

--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -1187,7 +1187,7 @@ ikev2child_outC1_continue(struct pluto_crypto_req_cont *pcrc
     passert(cur_state == NULL);
     passert(st != NULL);
 
-    passert(st->st_suspended_md == dh->md);
+    assert_suspended(st, dh->md);
     set_suspended(st,NULL);        /* no longer connected or suspended */
 
     set_cur_state(st);
@@ -1568,7 +1568,7 @@ static void ikev2child_inCI1_continue1(struct pluto_crypto_req_cont *pcrc
     passert(cur_state == NULL);
     passert(st != NULL);
 
-    passert(st->st_suspended_md == ke->md);
+    assert_suspended(st, ke->md);
     set_suspended(st,NULL);        /* no longer connected or suspended */
     set_cur_state(st);
 
@@ -1646,7 +1646,7 @@ static void ikev2child_inCI1_continue2(struct pluto_crypto_req_cont *pcrc
         return;
     }
 
-    passert(st->st_suspended_md == dh->md);
+    assert_suspended(st, dh->md);
     set_suspended(st,NULL);        /* no longer connected or suspended */
     set_cur_state(st);
     st->st_calculating = FALSE;
@@ -1955,7 +1955,7 @@ static void ikev2child_inCR1_continue(struct pluto_crypto_req_cont *pcrc
         return;
     }
 
-    passert(st->st_suspended_md == dh->md);
+    assert_suspended(st, dh->md);
     set_suspended(st, NULL);        /* no longer connected or suspended */
     set_cur_state(st);
     st->st_calculating = FALSE;

--- a/programs/pluto/ikev2_parent_I1.c
+++ b/programs/pluto/ikev2_parent_I1.c
@@ -154,6 +154,10 @@ ikev2parent_outI1_withstate(struct state *st
                                         , c->spd.this.xauth_server
                                         , c->spd.this.xauth_client);
 
+    /* assumption is that we are starting with a new state,
+     * so there should never be a suspended MD here */
+    assert (!is_suspended(st));
+
     /* set up new state */
     st->st_ikev2 = TRUE;
     change_state(st, STATE_PARENT_I1);
@@ -298,7 +302,7 @@ ikev2_parent_outI1_continue(struct pluto_crypto_req_cont *pcrc
     passert(cur_state == NULL);
     passert(st != NULL);
 
-    passert(st->st_suspended_md == ke->md);
+    assert_suspended(st, ke->md);
     set_suspended(st,NULL);	/* no longer connected or suspended */
 
     set_cur_state(st);

--- a/programs/pluto/ikev2_parent_I2.c
+++ b/programs/pluto/ikev2_parent_I2.c
@@ -46,6 +46,14 @@ stf_status ikev2parent_inR1outI2(struct msg_digest *md)
     /* struct connection *c = st->st_connection; */
     pb_stream *keyex_pbs;
 
+    /* if we are already processing a packet on this st, we will be unable
+     * to start another crypto operation below */
+    if (is_suspended(st)) {
+        openswan_log("%s: already processing a suspended cyrpto operation "
+                     "on this SA, duplicate will be dropped.", __func__);
+	return STF_TOOMUCHCRYPTO;
+    }
+
     /* record IKE version numbers -- used mostly in logging */
     st->st_ike_maj        = md->maj;
     st->st_ike_min        = md->min;

--- a/programs/pluto/ikev2_parent_I2.c
+++ b/programs/pluto/ikev2_parent_I2.c
@@ -200,7 +200,7 @@ ikev2_parent_inR1outI2_continue(struct pluto_crypto_req_cont *pcrc
     passert(cur_state == NULL);
     passert(st != NULL);
 
-    passert(st->st_suspended_md == dh->md);
+    assert_suspended(st, dh->md);
     set_suspended(st,NULL);        /* no longer connected or suspended */
 
     set_cur_state(st);

--- a/programs/pluto/ikev2_parent_R1.c
+++ b/programs/pluto/ikev2_parent_R1.c
@@ -243,7 +243,7 @@ ikev2_parent_inI1outR1_continue(struct pluto_crypto_req_cont *pcrc
     passert(cur_state == NULL);
     passert(st != NULL);
 
-    passert(st->st_suspended_md == ke->md);
+    assert_suspended(st, ke->md);
     set_suspended(st,NULL);        /* no longer connected or suspended */
 
     set_cur_state(st);

--- a/programs/pluto/ikev2_parent_R2.c
+++ b/programs/pluto/ikev2_parent_R2.c
@@ -110,7 +110,7 @@ ikev2_parent_inI2outR2_continue(struct pluto_crypto_req_cont *pcrc
     passert(cur_state == NULL);
     passert(st != NULL);
 
-    passert(st->st_suspended_md == dh->md);
+    assert_suspended(st, dh->md);
     set_suspended(st,NULL);        /* no longer connected or suspended */
 
     set_cur_state(st);

--- a/programs/pluto/ikev2_parent_R2.c
+++ b/programs/pluto/ikev2_parent_R2.c
@@ -46,6 +46,14 @@ stf_status ikev2parent_inI2outR2(struct msg_digest *md)
     struct state *st = md->st;
     /* struct connection *c = st->st_connection; */
 
+    /* if we are already processing a packet on this st, we will be unable
+     * to start another crypto operation below */
+    if (is_suspended(st)) {
+        openswan_log("%s: already processing a suspended cyrpto operation "
+                     "on this SA, duplicate will be dropped.", __func__);
+	return STF_TOOMUCHCRYPTO;
+    }
+
     /*
      * the initiator sent us an encrypted payload. We need to calculate
      * our g^xy, and skeyseed values, and then decrypt the payload.

--- a/programs/pluto/state.h
+++ b/programs/pluto/state.h
@@ -158,6 +158,26 @@ struct hidden_variables {
     ip_address     st_natd;
 };
 
+/* return true if the state has async crypto operation */
+#define is_suspended(st) ((READ_ONCE(st->st_suspended_md)) != NULL)
+
+/* assert that state and md are bound on async crypto operation */
+#define assert_suspended(_st,_md) do { \
+    passert((_st)); \
+    if ((_st)->st_suspended_md != (_md)) { \
+        DBG_log("%s:%u st=%p->st_suspended_md=%p != md=%p", \
+                __func__, __LINE__, (_st), \
+                (_st) ? (_st)->st_suspended_md : NULL, (_md)); \
+        impossible(); \
+    } \
+    if((_md) && (_md)->st != (_st)) { \
+        DBG_log("%s:%u md=%p->st=%p != st=%p", \
+                __func__, __LINE__, (_md), (_md)->st, (_st)); \
+        impossible(); \
+    } \
+} while(0)
+
+
 /* assign or clear (md==NULL) async crypto operation */
 #define set_suspended(_st,_md) do { \
     struct msg_digest *had_md = READ_ONCE((_st)->st_suspended_md); \

--- a/programs/pluto/state.h
+++ b/programs/pluto/state.h
@@ -183,14 +183,16 @@ struct hidden_variables {
     struct msg_digest *had_md = READ_ONCE((_st)->st_suspended_md); \
     if (_md) { /* we are about to suspend the md */ \
         if (had_md) { \
-            DBG_log("%s:%u set_suspended() called on #%lu with md=%p, already claimed by md=%p", \
-                    __func__, __LINE__, (_st)->st_serialno, (_md), had_md); \
+            DBG_log("%s:%u set_suspended() called on #%lu with md=%p, already claimed by md=%p (at %s:%u)", \
+                    __func__, __LINE__, (_st)->st_serialno, (_md), had_md, \
+		    (_st)->st_suspended_md_func, (_st)->st_suspended_md_line); \
             impossible(); \
         } \
     } else { /* we are resuming a suspended md */ \
         if (!had_md) { \
-            DBG_log("%s:%u set_suspended() called on #%lu with md=NULL, but st_suspended_md was already NULL", \
-                    __func__, __LINE__, (_st)->st_serialno); \
+            DBG_log("%s:%u set_suspended() called on #%lu with md=NULL, but st_suspended_md was already NULL (at %s:%u)", \
+                    __func__, __LINE__, (_st)->st_serialno, \
+		    (_st)->st_suspended_md_func, (_st)->st_suspended_md_line); \
             impossible(); \
         } \
     } \

--- a/tests/unit/libpluto/lp203-ca-h2hI2/output1.txt
+++ b/tests/unit/libpluto/lp203-ca-h2hI2/output1.txt
@@ -279,10 +279,10 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | ikev2 parent SA details
 | ikev2 I 0x8001020304050607 0xdebc583a8f40d0cf sha1:0xf4c101c72118cf31d4682f68b9a29c07 aes128:0x0d085cb0db3e856c4d4745cc1ff5c9274f580827f03c1aad
 | ikev2 R 0x8001020304050607 0xdebc583a8f40d0cf sha1:0xe7354351e9a081c365b2761ac5f815ea aes128:0x8f01464a6b1a7aaf8b8a969c88f3cc8ef82a96cd7218fc11
-| WARNING: ikev2_parent_inR1outI2_tail:246: encryptor 'aes' expects keylen 16/128, SA #1 INITIATOR keylen is 24
-| WARNING: ikev2_parent_inR1outI2_tail:246: encryptor 'aes' expects keylen 16/128, SA #1 RESPONDER keylen is 24
-| WARNING: ikev2_parent_inR1outI2_tail:246: hasher 'sha1' expects keylen 20/20, SA #1 INITIATOR keylen is 16
-| WARNING: ikev2_parent_inR1outI2_tail:246: hasher 'sha1' expects keylen 20/20, SA #1 RESPONDER keylen is 16
+| WARNING: ikev2_parent_inR1outI2_tail:254: encryptor 'aes' expects keylen 16/128, SA #1 INITIATOR keylen is 24
+| WARNING: ikev2_parent_inR1outI2_tail:254: encryptor 'aes' expects keylen 16/128, SA #1 RESPONDER keylen is 24
+| WARNING: ikev2_parent_inR1outI2_tail:254: hasher 'sha1' expects keylen 20/20, SA #1 INITIATOR keylen is 16
+| WARNING: ikev2_parent_inR1outI2_tail:254: hasher 'sha1' expects keylen 20/20, SA #1 RESPONDER keylen is 16
 | duplicating state object #1
 | creating state object #2 at Z
 | ICOOKIE:  80 01 02 03  04 05 06 07

--- a/tests/unit/libpluto/lp204-ca-h2hR2/output1.txt
+++ b/tests/unit/libpluto/lp204-ca-h2hR2/output1.txt
@@ -486,10 +486,10 @@ sending 457 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | ikev2 parent SA details
 | ikev2 I 0x8001020304050607 0xdebc583a8f40d0cf sha1:0xf4c101c72118cf31d4682f68b9a29c07 aes128:0x0d085cb0db3e856c4d4745cc1ff5c9274f580827f03c1aad
 | ikev2 R 0x8001020304050607 0xdebc583a8f40d0cf sha1:0xe7354351e9a081c365b2761ac5f815ea aes128:0x8f01464a6b1a7aaf8b8a969c88f3cc8ef82a96cd7218fc11
-| WARNING: ikev2_parent_inI2outR2_tail:159: encryptor 'aes' expects keylen 16/128, SA #1 INITIATOR keylen is 24
-| WARNING: ikev2_parent_inI2outR2_tail:159: encryptor 'aes' expects keylen 16/128, SA #1 RESPONDER keylen is 24
-| WARNING: ikev2_parent_inI2outR2_tail:159: hasher 'sha1' expects keylen 20/20, SA #1 INITIATOR keylen is 16
-| WARNING: ikev2_parent_inI2outR2_tail:159: hasher 'sha1' expects keylen 20/20, SA #1 RESPONDER keylen is 16
+| WARNING: ikev2_parent_inI2outR2_tail:167: encryptor 'aes' expects keylen 16/128, SA #1 INITIATOR keylen is 24
+| WARNING: ikev2_parent_inI2outR2_tail:167: encryptor 'aes' expects keylen 16/128, SA #1 RESPONDER keylen is 24
+| WARNING: ikev2_parent_inI2outR2_tail:167: hasher 'sha1' expects keylen 20/20, SA #1 INITIATOR keylen is 16
+| WARNING: ikev2_parent_inI2outR2_tail:167: hasher 'sha1' expects keylen 20/20, SA #1 RESPONDER keylen is 16
 | decrypting as RESPONDER, using INITIATOR keys
 | WARNING: ikev2_decrypt_msg:335: encryptor 'aes' expects keylen 16/128, SA #1 INITIATOR keylen is 24
 | WARNING: ikev2_decrypt_msg:335: encryptor 'aes' expects keylen 16/128, SA #1 RESPONDER keylen is 24

--- a/tests/unit/libpluto/lp205-ca-h2hI3/output1.txt
+++ b/tests/unit/libpluto/lp205-ca-h2hI3/output1.txt
@@ -297,10 +297,10 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | ikev2 parent SA details
 | ikev2 I 0x8001020304050607 0xdebc583a8f40d0cf sha1:0xf4c101c72118cf31d4682f68b9a29c07 aes128:0x0d085cb0db3e856c4d4745cc1ff5c9274f580827f03c1aad
 | ikev2 R 0x8001020304050607 0xdebc583a8f40d0cf sha1:0xe7354351e9a081c365b2761ac5f815ea aes128:0x8f01464a6b1a7aaf8b8a969c88f3cc8ef82a96cd7218fc11
-| WARNING: ikev2_parent_inR1outI2_tail:246: encryptor 'aes' expects keylen 16/128, SA #1 INITIATOR keylen is 24
-| WARNING: ikev2_parent_inR1outI2_tail:246: encryptor 'aes' expects keylen 16/128, SA #1 RESPONDER keylen is 24
-| WARNING: ikev2_parent_inR1outI2_tail:246: hasher 'sha1' expects keylen 20/20, SA #1 INITIATOR keylen is 16
-| WARNING: ikev2_parent_inR1outI2_tail:246: hasher 'sha1' expects keylen 20/20, SA #1 RESPONDER keylen is 16
+| WARNING: ikev2_parent_inR1outI2_tail:254: encryptor 'aes' expects keylen 16/128, SA #1 INITIATOR keylen is 24
+| WARNING: ikev2_parent_inR1outI2_tail:254: encryptor 'aes' expects keylen 16/128, SA #1 RESPONDER keylen is 24
+| WARNING: ikev2_parent_inR1outI2_tail:254: hasher 'sha1' expects keylen 20/20, SA #1 INITIATOR keylen is 16
+| WARNING: ikev2_parent_inR1outI2_tail:254: hasher 'sha1' expects keylen 20/20, SA #1 RESPONDER keylen is 16
 | duplicating state object #1
 | creating state object #2 at Z
 | ICOOKIE:  80 01 02 03  04 05 06 07


### PR DESCRIPTION
this patch set avoids running multiple crypto-helpers for the same state.  some cleanup was done to correctly set and clear st->st_suspended_md.  both IKEv1 and IKEv2 would previously allow starting a crypto-helper on a duplicate packet.  they now drop the duplicates, and return an error.