### PR TITLE
T9094 pfs=yes rekey

### DIFF
--- a/programs/pluto/hostpair.c
+++ b/programs/pluto/hostpair.c
@@ -119,7 +119,7 @@ void host_pair_enqueue_pending(const struct connection *c
 
 struct pending **host_pair_first_pending(const struct connection *c)
 {
-    if(c->IPhost_pair == NULL) return NULL;
+    if(c == NULL || c->IPhost_pair == NULL) return NULL;
 
     return &c->IPhost_pair->pending;
 }

--- a/programs/pluto/ikev2.c
+++ b/programs/pluto/ikev2.c
@@ -1571,7 +1571,6 @@ send_invalid_ke_ntf:
     dc.ptr = (unsigned char *)&group_number;
     dc.len = 2;
     SEND_V2_NOTIFICATION_DATA(md, st, v2N_INVALID_KE_PAYLOAD, &dc);
-    delete_state(st);
     /* notification sent, return failure, but prevent another
      * notification from complete_v2_state_transition(). */
     md->note = 0;

--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -1625,7 +1625,8 @@ static void ikev2child_inCI1_continue1(struct pluto_crypto_req_cont *pcrc
     return;
 
  returnerr:
-    /* XXX send an error notification to initiator, from variable e */
+    /* error notification was already sent, kill the state */
+    md->st = NULL;
     delete_state(st);
     reset_globals();
     return;
@@ -1878,8 +1879,10 @@ static stf_status ikev2child_inCR1_pfs(struct msg_digest *md)
     /* Gr in */
     e = accept_v2_KE(md, st, &st->st_gr, "Gr");
     if(e != STF_OK) {
-        /* feel something shoud be done with e */
+        /* feel something should be done with e */
         loglog(RC_LOG_SERIOUS, "no valid KE payload found");
+        md->st = NULL;
+        delete_state(st);
         return STF_FAIL; /* XXX - invalid packet notify? */
     }
 

--- a/programs/pluto/ikev2_parent_R1.c
+++ b/programs/pluto/ikev2_parent_R1.c
@@ -347,6 +347,9 @@ ikev2_parent_inI1outR1_tail(struct pluto_crypto_req_cont *pcrc
     }
 
     if((notok = accept_v2_KE(md, st, &st->st_gi, "Gi"))!=STF_OK) {
+        /* error notification was already sent, kill the state */
+        md->st = NULL;
+        delete_state(st);
         return notok;
     }
 

--- a/programs/pluto/state.c
+++ b/programs/pluto/state.c
@@ -345,6 +345,12 @@ unhash_state(struct state *st)
 	if(*p != st) {
 	    p = state_hash(st->st_icookie, zero_cookie, NULL);
 	}
+        if (!*p) {
+            DBG(DBG_CONTROL
+                , DBG_log("state object #%lu not found in state hash."
+                          , st->st_serialno));
+            return;
+        }
     } else {
 	p = &st->st_hashchain_prev->st_hashchain_next;
     }

--- a/tests/unit/libpluto/lp08-parentR1/output1.txt
+++ b/tests/unit/libpluto/lp08-parentR1/output1.txt
@@ -230,9 +230,9 @@ sending 40 bytes for send_v2_notification through eth0:500 [132.213.238.7:500] t
 | ICOOKIE:  00 01 02 03  04 05 06 07
 | RCOOKIE:  de bc 58 3a  8f 40 d0 cf
 | state hash entry 28
-| #1 complete v2 state transition with STF_FAIL
-./parentR1 STATE_UNDEFINED: (null)
-| state transition function for STATE_UNDEFINED failed: <no reason given>
+| #0 complete v2 state transition with STF_FAIL
+./parentR1 no-state: (null)
+| state transition function for no-state failed: <no reason given>
 ./parentR1 deleting connection
 | pass 0: considering CHILD SAs to delete
 | pass 1: considering PARENT SAs to delete


### PR DESCRIPTION
Fix for crash when we interop with strongSwan when pfs=yes, IKE and phase2alg specify a different DH group, and strongSwan requests a rekey.