### PR TITLE
Clean compile connections.c & decrementing warns in pluto_constants.c

### DIFF
--- a/include/constants.h
+++ b/include/constants.h
@@ -58,6 +58,7 @@ typedef int bool;
 #define dup_any(fd) ((fd) == NULL_FD? NULL_FD : dup(fd))
 #define close_any(fd) { if ((fd) != NULL_FD) { close(fd); (fd) = NULL_FD; } }
 
+#include <inttypes.h>
 
 #ifdef HAVE_LIBNSS
 # include <prcpucfg.h>

--- a/include/pluto/connections.h
+++ b/include/pluto/connections.h
@@ -108,13 +108,13 @@
  *   as the original policy, even though its subnets might be smaller.
  * - display format: n,m
  */
-typedef unsigned long policy_prio_t;
+typedef uint32_t policy_prio_t;
 #define BOTTOM_PRIO   ((policy_prio_t)0)	/* smaller than any real prio */
 #define set_policy_prio(c) { (c)->prio = \
 	((policy_prio_t)(c)->spd.this.client.maskbits << 16) \
 	| ((policy_prio_t)(c)->spd.that.client.maskbits << 8) \
 	| (policy_prio_t)1; }
-#define POLICY_PRIO_BUF	(3+1+3+1)
+#define POLICY_PRIO_BUF	(3+1+3+1+10) 
 extern void fmt_policy_prio(policy_prio_t pp, char buf[POLICY_PRIO_BUF]);
 
 /* Note that we include this even if not X509, because we do not want the

--- a/lib/libpluto/pluto_constants.c
+++ b/lib/libpluto/pluto_constants.c
@@ -375,7 +375,7 @@ prettypolicy(lset_t policy)
     const char *bn = bitnamesofb(sa_policy_bit_names
 				 , policy & ~(POLICY_SHUNT_MASK | POLICY_FAIL_MASK)
 				 , pbitnamesbuf, sizeof(pbitnamesbuf));
-    static char buf[200];   /* NOT RE-ENTRANT!  I hope that it is big enough! */
+    static char buf[512];   /* NOT RE-ENTRANT!  I hope that it is big enough! */
     lset_t shunt = (policy & POLICY_SHUNT_MASK) >> POLICY_SHUNT_SHIFT;
     lset_t fail = (policy & POLICY_FAIL_MASK) >> POLICY_FAIL_SHIFT;
 

--- a/programs/pluto/connections.c
+++ b/programs/pluto/connections.c
@@ -1690,7 +1690,7 @@ fmt_policy_prio(policy_prio_t pp, char buf[POLICY_PRIO_BUF])
     if (pp == BOTTOM_PRIO)
 	snprintf(buf, POLICY_PRIO_BUF, "0");
     else
-	snprintf(buf, POLICY_PRIO_BUF, "%lu,%lu"
+	snprintf(buf, POLICY_PRIO_BUF, "%" PRIu32 ",%" PRIu32
 	    , pp>>16, (pp & ~(~(policy_prio_t)0 << 16)) >> 8);
 }
 
@@ -1831,7 +1831,7 @@ find_connection_for_clients(struct spd_route **srp,
 		    subnettot(&c->spd.this.client, 0, c_ocb, sizeof(c_ocb));
 		    subnettot(&c->spd.that.client, 0, c_pcb, sizeof(c_pcb));
  		    DBG_log("find_connection: "
- 			    "conn \"%s\"%s has compatible peers: %s -> %s [pri: %ld]"
+ 			    "conn \"%s\"%s has compatible peers: %s -> %s [pri: %" PRIu32 "]"
 			    , c->name
 			    , (fmt_conn_instance(c, cib), cib)
 			    , c_ocb, c_pcb, prio);
@@ -1849,7 +1849,7 @@ find_connection_for_clients(struct spd_route **srp,
 		{
 		    char cib[CONN_INST_BUF];
 		    char cib2[CONN_INST_BUF];
-		    DBG_log("find_connection: comparing best \"%s\"%s [pri:%ld]{%p} (child %s) to \"%s\"%s [pri:%ld]{%p} (child %s)"
+		    DBG_log("find_connection: comparing best \"%s\"%s [pri:%" PRIu32 "]{%p} (child %s) to \"%s\"%s [pri:%" PRIu32 "]{%p} (child %s)"
 			    , best->name
 			    , (fmt_conn_instance(best, cib), cib)
 			    , best_prio
@@ -1886,7 +1886,7 @@ find_connection_for_clients(struct spd_route **srp,
 	if (best)
 	{
 	    char cib[CONN_INST_BUF];
-	    DBG_log("find_connection: concluding with \"%s\"%s [pri:%ld]{%p} kind=%s"
+	    DBG_log("find_connection: concluding with \"%s\"%s [pri:%" PRIu32 "]{%p} kind=%s"
 		    , best->name
 		    , (fmt_conn_instance(best, cib), cib)
 		    , best_prio
@@ -2856,7 +2856,7 @@ fc_try(const struct connection *c
 	best = NULL;
 
     DBG(DBG_CONTROLMORE,
-	DBG_log("  fc_try concluding with %s [%ld]"
+	DBG_log("  fc_try concluding with %s [%" PRIu32 "]"
 		, (best ? best->name : "none"), best_prio)
     )
 
@@ -2961,7 +2961,7 @@ fc_try_oppo(const struct connection *c
     }
 
     DBG(DBG_CONTROLMORE,
-	DBG_log("  fc_try_oppo concluding with %s [%ld]"
+	DBG_log("  fc_try_oppo concluding with %s [%" PRIu32 "]"
 		, (best ? best->name : "none"), best_prio)
     )
     return best;


### PR DESCRIPTION
* incr static char buf
  it was warn:
`
lib/libpluto/pluto_constants.c: In function ‘prettypolicy’:
lib/libpluto/pluto_constants.c:384:39: warning: ‘%s’ directive output may be truncated writing up to 8 bytes into a region of size between 0 and 200 [-Wformat-truncation=]
     snprintf(buf, sizeof(buf), "%s%s%s%s%s%s%s"
                                       ^~
In file included from /usr/include/stdio.h:873,
                 from lib/libpluto/pluto_constants.c:23:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output 1 or more bytes (assuming 240) into a destination of size 200
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
`
+ include inttypes.h to have possibility to use macro PRIu32 we need it for crossplatfoms
* incr size of POLICY_PRIO_BUF
* change type of policy_prio_t to uint32_t

Now it's possible compile connections.c without GCC Warns like:
`
programs/pluto/connections.c: In function ‘fmt_policy_prio’:
programs/pluto/connections.c:1693:34: warning: ‘%lu’ directive output may be truncated writing between 1 and 15 bytes into a region of size 8 [-Wformat-truncation=]
  snprintf(buf, POLICY_PRIO_BUF, "%lu,%lu"
                                  ^~~
programs/pluto/connections.c:1693:33: note: directive argument in the range [0, 281474976710655]
  snprintf(buf, POLICY_PRIO_BUF, "%lu,%lu"
                                 ^~~~~~~~~
programs/pluto/connections.c:1693:33: note: directive argument in the range [0, 255]
In file included from /usr/include/stdio.h:873,
                 from programs/pluto/connections.c:21:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 4 and 20 bytes into a destination of size 8
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
programs/pluto/connections.c: In function ‘show_one_connection’:
programs/pluto/connections.c:1693:34: warning: ‘%lu’ directive output may be truncated writing between 1 and 15 bytes into a region of size 8 [-Wformat-truncation=]
  snprintf(buf, POLICY_PRIO_BUF, "%lu,%lu"
                                  ^~~
programs/pluto/connections.c:1693:33: note: directive argument in the range [0, 281474976710655]
  snprintf(buf, POLICY_PRIO_BUF, "%lu,%lu"
                                 ^~~~~~~~~
programs/pluto/connections.c:1693:33: note: directive argument in the range [0, 255]
In file included from /usr/include/stdio.h:873,
                 from programs/pluto/connections.c:21:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 4 and 20 bytes into a destination of size 8
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
`

I have tested it with some VMs and with bare hardware in different scenarios
Looks good
`000 #2: "test-prod":500 IKEv1.0 STATE_QUICK_I2 (sent QI2, IPsec SA established); EVENT_SA_REPLACE in 823s; newest IPSEC; eroute owner; isakmp#1; idle; import:admin initiate
000 #2: "test-prod" esp.380e47d1@172.21.0.146 esp.818b380c@172.21.22.202 comp.5393@172.21.0.146 comp.569e@172.21.22.202 ref=0 refhim=4294901761
000 #1: "test-prod":500 IKEv1.0 STATE_MAIN_I4 (ISAKMP SA established); EVENT_SA_REPLACE in 3144s; newest ISAKMP; lastdpd=-1s(seq in:0 out:0); idle; import:admin initiate
`