### PR TITLE
+16 to the buffer size of status

### DIFF
--- a/programs/pluto/adns.c
+++ b/programs/pluto/adns.c
@@ -312,7 +312,7 @@ worker(int qfd, int afd)
         struct addrinfo *result;
         struct addrinfo hints;
         int s;
-        char status[1024];
+        char status[1024+16]; // this must shut up GCC
 
 	enum helper_exit_status r = read_pipe(qfd, (unsigned char *)&q
 	    , sizeof(q), sizeof(q));


### PR DESCRIPTION
Incr 'status' size to get rid of
 programs/pluto/adns.c: In function ‘master’:
 programs/pluto/adns.c:332:50: warning: ‘%s’ directive output may be truncated writing up to 1026 bytes into a region of size 1017 [-Wformat-truncation=]
         snprintf(status, sizeof(status), "query: %s", q.name_buf);
                                                  ^~   ~~~~~~~~~~
 In file included from /usr/include/stdio.h:873,
                 from programs/pluto/adns.c:45:
 /usr/include/x86_64-linux-gnu/bits/stdio2.h:67:10: note: ‘__builtin___snprintf_chk’ output between 8 and 1034 bytes into a destination of size 1024
   return __builtin___snprintf_chk (__s, __n, __USE_FORTIFY_LEVEL - 1,
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
        __bos (__s), __fmt, __va_arg_pack ());
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~