### PR TITLE
Null pointer check. One Segfault less.

### DIFF
--- a/programs/pluto/spdb_struct.c
+++ b/programs/pluto/spdb_struct.c
@@ -313,7 +313,8 @@ oakley_alg_makedb(struct alg_info_ike *ai
 	}
 	transcnt++;
     }
-    gsp->parentSA = TRUE;
+    if (gsp != NULL) gsp->parentSA = TRUE;
+    DBG(DBG_CONTROL, DBG_log("oakley_alg_makedb() returning %p", gsp));
 
     return gsp;
 }

--- a/tests/unit/libpluto/lp71-alg-h2hI1/output.txt
+++ b/tests/unit/libpluto/lp71-alg-h2hI1/output.txt
@@ -58,6 +58,7 @@ RC=0 "alttunnel":   ESP algorithms loaded: none
 | inserting state object #1 bucket: 4
 ./h2hI1 initiating v2 parent SA
 ./h2hI1 STATE_PARENT_I1: initiate
+| oakley_alg_makedb() returning 0x
 | ikev2 parent outI1: calculated ke+nonce, sending I1
 | **emit ISAKMP Message:
 |    initiator cookie:

--- a/tests/utils/whack-processing.sed
+++ b/tests/utils/whack-processing.sed
@@ -8,3 +8,4 @@ s/releasing whack for .* (sock=.*)/releasing whack for #X (sock=Y)/
 /newest ISAKMP SA/d
 s/(expires .*)/(expires SOMETIME)/
 s/RC=0 [A-Z][a-z][a-z] [0-9][0-9] [0-9][0-9]:[0-9][0-9]:[0-9][0-9] UTC 20[0-9][0-9], [0-9]* RSA \(\S\+\) key/RC=0 DATE RSA \1 key/
+s/oakley_alg_makedb() returning 0x[0-9|a-f]*/oakley_alg_makedb() returning 0x/


### PR DESCRIPTION
if we have in conn something like to:
ike=des-sha1

We will got Segmentation fault

"test-prod" #1: initiating Main Mode
| **emit ISAKMP Message:
|    initiator cookie:
|   d6 7c ed c7  6d 20 0c c9
|    responder cookie:
|   00 00 00 00  00 00 00 00
|    ISAKMP version: ISAKMP Version 1.0 (rfc2407)
|    exchange type: ISAKMP_XCHG_IDPROT
|    flags: none
|    message ID:  00 00 00 00
| oakley_alg_makedb() ike enc ealg=1 not present
| oakley_alg_makedb() ike enc ealg=1 not present
Segmentation fault (core dumped)
pluto_crypto_helper: helper [nonnss] (0) is exiting normally

 gdb /usr/local/libexec/ipsec/pluto -c core
Core was generated by `/usr/local/libexec/ipsec/pluto --nofork --secretsfile /etc/ipsec.secrets --ipse'.
Program terminated with signal SIGSEGV, Segmentation fault.
    at programs/pluto/spdb_struct.c:316
316         gsp->parentSA = TRUE;

'cause gsp is NULL
Let's add null pointer checking.
And some DBG_log

Now we don't have crash ipsec and lose all valid connections with des in only one 'conn' and can
establish connection with ike=des
and can see in log
| oakley_alg_makedb() ike enc ealg=1 not present
| oakley_alg_makedb() ike enc ealg=1 not present
| oakley_alg_makedb() returning (nil)

000 "test-prod":   IKE algorithms wanted: DES_CBC(1)_000-SHA1(2)_000-MODP1536(5), DES_CBC(1)_000-SHA1(2)_000-MODP1024(2); flags=-strict
000 "test-prod":   IKE algorithms found:  DES_CBC(1)_000-SHA1(2)_000-MODP1536(5), DES_CBC(1)_000-SHA1(2)_000-MODP1024(2); flags=-strict
