### PR TITLE
T9234 transport ikev2 rekey

### DIFF
--- a/programs/pluto/ikev2_child.c
+++ b/programs/pluto/ikev2_child.c
@@ -2199,6 +2199,23 @@ static stf_status ikev2child_inCR1_tail(struct msg_digest *md, struct state *st)
         return e;
     }
 
+    /* if rekeying an existing connection, inherit tunnel/transport mode */
+    {
+        struct state *est;
+        est = state_with_serialno(c->newest_ipsec_sa);
+        if (est && est->st_esp.attrs.encapsulation != ENCAPSULATION_MODE_UNSPECIFIED) {
+            /* in that case, we will use the same mode */
+            st->st_esp.attrs.encapsulation = est->st_esp.attrs.encapsulation;
+            DBG(DBG_CONTROLMORE,
+                DBG_log("Rekeying #%lu from existing state #%lu, "
+                        "will inherit %s encapsulation (%d)",
+                        st->st_serialno, est->st_serialno,
+                        st->st_esp.attrs.encapsulation == ENCAPSULATION_MODE_TUNNEL ? "tunnel" :
+                        st->st_esp.attrs.encapsulation == ENCAPSULATION_MODE_TRANSPORT ? "transport" : "?",
+                        st->st_esp.attrs.encapsulation));
+        }
+    }
+
     {
         v2_notification_t rn;
         struct payload_digest *const sa_pd = md->chain[ISAKMP_NEXT_v2SA];

--- a/programs/pluto/kernel_netlink.c
+++ b/programs/pluto/kernel_netlink.c
@@ -847,6 +847,7 @@ netlink_raw_eroute(const ip_address *this_host
 	memset(tmpl, 0, sizeof(tmpl));
 	for (i = 0; proto_info[i].proto; i++)
 	{
+            passert(i<4);
 	    tmpl[i].reqid = proto_info[i].reqid;
 	    tmpl[i].id.proto = proto_info[i].proto;
 	    tmpl[i].optional =

--- a/programs/pluto/spdb_v2_struct.c
+++ b/programs/pluto/spdb_v2_struct.c
@@ -1439,7 +1439,8 @@ ikev2_parse_child_sa_body(
     st->st_esp.attrs.spi = itl->spi_values[itl->spi_values_next -1];
 
     /* could get changed by a notify */
-    st->st_esp.attrs.encapsulation = ENCAPSULATION_MODE_TUNNEL;
+    if (st->st_esp.attrs.encapsulation == ENCAPSULATION_MODE_UNSPECIFIED)
+        st->st_esp.attrs.encapsulation = ENCAPSULATION_MODE_TUNNEL;
 
     if (r_sa_pbs != NULL)
     {

--- a/tests/unit/libpluto/lp48-rekeyikev2-inCR1/output1.txt
+++ b/tests/unit/libpluto/lp48-rekeyikev2-inCR1/output1.txt
@@ -1041,6 +1041,7 @@ sending 604 bytes for ikev2child_outC1_tail through eth0:500 [192.168.1.1:500] t
 |   endport: 65535
 |   ip low: fd68:c9f9:4157::
 |   ip high: fd68:c9f9:4157:0:ffff:ffff:ffff:ffff
+| Rekeying #3 from existing state #2, will inherit tunnel encapsulation (1)
 | empty esp_info, returning defaults
 | ***parse IKEv2 Proposal Substructure Payload:
 |    length: 40

--- a/tests/unit/libpluto/lp58-rekeyv2nopfs-inCR1/output1.txt
+++ b/tests/unit/libpluto/lp58-rekeyv2nopfs-inCR1/output1.txt
@@ -915,6 +915,7 @@ sending 348 bytes for ikev2child_outC1_tail through eth0:500 [192.168.1.1:500] t
 |   endport: 65535
 |   ip low: fd68:c9f9:4157::
 |   ip high: fd68:c9f9:4157:0:ffff:ffff:ffff:ffff
+| Rekeying #3 from existing state #2, will inherit tunnel encapsulation (1)
 | empty esp_info, returning defaults
 | ikev2_derive_child_keys: using oakley_sha for prf+ (SA #3 cloned from #1)
 | childsacalc.ni  80 01 02 03  04 05 06 07  08 09 0a 0b  0c 0d 0e 0f


### PR DESCRIPTION
Prior to this work, OpenSWAN would be unable to rekey a transport connection using IKEv2.  That's because the only time that 'est->st_esp.attrs.encapsulation' would be set to TRANSPORT was when it received a v2N_USE_TRANSPORT_MODE notification.  Since a child SA rekey does not use this notification, we would assume the rekey was for a tunnel mode connection.  The change inherits the negotiated mode from the previous connection when rekeying.