### PR TITLE
lib/libpluto/writehackmsg.c: fix build on musl

### DIFF
--- a/lib/libpluto/writewhackmsg.c
+++ b/lib/libpluto/writewhackmsg.c
@@ -33,6 +33,7 @@
 #include <arpa/inet.h>
 #include <resolv.h>
 #include <fcntl.h>
+#include <limits.h>  /* for PATH_MAX */
 #include <time.h>
 
 #include <openswan.h>


### PR DESCRIPTION
Include <limits.h> for PATH_MAX to fix build failure under musl

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>