### PR TITLE
wo#10083 - Fix gateway rekey with roadwarrior peer

### DIFF
--- a/programs/pluto/ikev1_aggr.c
+++ b/programs/pluto/ikev1_aggr.c
@@ -1096,6 +1096,15 @@ aggr_outI1(int whack_sock,
 	openswan_log("initiating Aggressive Mode #%lu to replace #%lu, connection \"%s\""
 		     , st->st_serialno, predecessor->st_serialno
 		     , st->st_connection->name);
+
+	/* If no st_remoteaddr/st_remoteport, use info from predecessor */
+	if (ip_address_isany(&st->st_remoteaddr)) {
+	    st->st_remoteaddr = predecessor->st_remoteaddr;
+	    st->st_remoteport = predecessor->st_remoteport;
+	    DBG(DBG_CONTROL,
+		DBG_log("no st_remoteaddr/st_remoteport, using %s:%u from predecessor state",
+			ip_str(&st->st_remoteaddr), st->st_remoteport));
+	}
     }
 
     {

--- a/programs/pluto/ikev1_main.c
+++ b/programs/pluto/ikev1_main.c
@@ -161,8 +161,18 @@ main_outI1(int whack_sock
 
     if (predecessor == NULL)
 	openswan_log("initiating Main Mode");
-    else
+    else {
 	openswan_log("initiating Main Mode to replace #%lu", predecessor->st_serialno);
+
+	/* If no st_remoteaddr/st_remoteport, use info from predecessor */
+	if (ip_address_isany(&st->st_remoteaddr)) {
+	    st->st_remoteaddr = predecessor->st_remoteaddr;
+	    st->st_remoteport = predecessor->st_remoteport;
+	    DBG(DBG_CONTROL,
+		DBG_log("no st_remoteaddr/st_remoteport, using %s:%u from predecessor state",
+			ip_str(&st->st_remoteaddr), st->st_remoteport));
+	}
+    }
 
     /* set up reply */
     zero(reply_buffer);

--- a/programs/pluto/ikev2_parent_I1.c
+++ b/programs/pluto/ikev2_parent_I1.c
@@ -181,8 +181,18 @@ ikev2parent_outI1_withstate(struct state *st
 
     if (predecessor == NULL)
         openswan_log("initiating v2 parent SA");
-    else
+    else {
         openswan_log("initiating v2 parent SA to replace #%lu", predecessor->st_serialno);
+
+        /* If no st_remoteaddr/st_remoteport, use info from predecessor */
+        if (ip_address_isany(&st->st_remoteaddr)) {
+            st->st_remoteaddr = predecessor->st_remoteaddr;
+            st->st_remoteport = predecessor->st_remoteport;
+            DBG(DBG_CONTROL,
+                DBG_log("no st_remoteaddr/st_remoteport, using %s:%u from predecessor state",
+                        ip_str(&st->st_remoteaddr), st->st_remoteport));
+        }
+    }
 
     if (predecessor != NULL) {
         /* replace the existing pending SA */


### PR DESCRIPTION
If the gateway initiates an ISAKMP SA rekey vs. a roadwarrior
peer it was sending packets to itself (0.0.0.0) and not using
the remote host/port info from the predecessor state.