### PR TITLE
mort/bug5715

### DIFF
--- a/lib/libipsecconf/confread.c
+++ b/lib/libipsecconf/confread.c
@@ -1041,6 +1041,15 @@ static int validate_family_consistency(const char *connname,
         nfamily = right = left = family;
     }
 
+    /* If family is set, and left and right are either unset or agree
+     * with family, then use it.
+     */
+    if(family != 0 &&
+       (left  == 0 || left  == family) &&
+       (right == 0 || right == family)) {
+        nfamily = left = right = family;
+    }
+
     /* if family is blank, and left and right are set to the same value,
      * then set family to that value.
      */

--- a/tests/functional/01-confread/Makefile
+++ b/tests/functional/01-confread/Makefile
@@ -29,6 +29,7 @@ check: OUTPUT
 	../readwritetest ${READWRITE} dooku certpercent.conf berri-strongswan.conf
 	../readwritetest ${READWRITE} dooku n2n-transport.conf n2n-transport.conf
 	: ../readwritetest ${READWRITE} dooku brokenspace.conf brokenspace.conf
+	../readwritetest ${READWRITE} ipv6-inconsistent ipv6-inconsistent.conf ipv6-inconsistent.conf
 	[ ! -f core ]
 
 OUTPUT:

--- a/tests/functional/01-confread/ipv6-inconsistent.conf
+++ b/tests/functional/01-confread/ipv6-inconsistent.conf
@@ -1,0 +1,9 @@
+version 2.0
+
+config setup
+	nat_traversal=yes
+	virtual_private=%v4:10.0.0.0/8,%v4:192.168.0.0/16,%v4:172.16.0.0/12,%v4:25.0.0.0/8,%v6:fd00::/8,%v6:fe80::/10
+	oe=off
+	protostack=auto
+
+include /etc/ipsec.d/conns/*.conn

--- a/tests/functional/01-confread/ipv6-inconsistent.conf.out
+++ b/tests/functional/01-confread/ipv6-inconsistent.conf.out
@@ -1,0 +1,35 @@
+#conn test-conn loaded
+
+version 2.0
+
+config setup
+	oe=no
+	nat_traversal=yes
+	virtual_private=%v4:10.0.0.0/8,%v4:192.168.0.0/16,%v4:172.16.0.0/12,%v4:25.0.0.0/8,%v6:fd00::/8,%v6:fe80::/10
+	protostack=auto
+
+
+# begin conn test-conn
+conn test-conn
+	left=2001:db8::2
+	leftsubnet=2001:db8:1::/60
+	right=2001:db8:2::af83
+	authby=secret
+	salifetime=1200
+	ikelifetime=3600
+	ike=aes128-sha2_256;modp8192!
+	phase2alg=aes128-sha1;modp8192
+	auto=ignore
+	type=tunnel
+	compress=no
+	pfs=yes
+	rekey=yes
+	overlapip=no
+	authby=secret
+	phase2=esp
+	ikev2=never
+	endaddrfamily=ipv6
+	tunneladdrfamily=ipv6
+# end conn test-conn
+
+# end of config

--- a/tests/functional/01-confread/ipv6-inconsistent/etc/ipsec.d/conns/inconsistent.conn
+++ b/tests/functional/01-confread/ipv6-inconsistent/etc/ipsec.d/conns/inconsistent.conn
@@ -1,0 +1,19 @@
+#
+# This used to give an error of
+# 'inconsistent left/right tunnel address family: policy=ipv6 left=ipv6 right=value:0'
+#
+# Adding rightsubnet=<IP>/128 fixed the problem.
+
+conn test-conn
+	ikev2=no
+	ike=aes128-sha2_256;modp8192!
+	phase2alg=aes128-sha1;modp8192
+	ikelifetime=3600s
+	salifetime=1200s
+	authby=secret
+	connaddrfamily=ipv6
+	left=2001:db8::2
+	leftsubnet=2001:db8:1:2::/60
+	right=2001:db8:2::af83
+	#rightsubnet=2001:db8:2::af83/128
+	auto=ignore


### PR DESCRIPTION
This prevents an error message if connaddrfamily= is specified and
one of the left/rightsubnet= statements is omitted from the connection
specification.

Aiming for inclusion in 2.6.52dev