### PR TITLE
wo#10213: Don't prevent responder peer from initiating SA rekey

### DIFF
--- a/programs/pluto/ikev1_quick.c
+++ b/programs/pluto/ikev1_quick.c
@@ -1188,14 +1188,6 @@ quick_inI1_outR1(struct msg_digest *md)
     struct payload_digest *const id_pd = md->chain[ISAKMP_NEXT_ID];
     struct verify_oppo_bundle b;
 
-    /* we are responding to this exchange */
-    if (p1st->st_orig_initiator) {
-	loglog(RC_LOG_SERIOUS,
-	       "Unexpected quick mode R1 state for INITIATOR of #%ld",
-	       p1st->st_serialno);
-	return STF_FAIL + SITUATION_NOT_SUPPORTED;
-    }
-
     /* HASH(1) in */
     CHECK_QUICK_HASH(md
 	, quick_mode_hash12(hash_val, hash_pbs->roof, md->message_pbs.roof


### PR DESCRIPTION
If the peer manages to send us a SA rekey, then accept it.
Strongswan will sometimes do this because OSW doesn't yet support
RFC4478 and is slower to rekey the Parent SA than strongswan would
like.