### PR TITLE
fix build with gcc 10

### DIFF
--- a/include/ipsecconf/keywords.h
+++ b/include/ipsecconf/keywords.h
@@ -314,7 +314,7 @@ struct config_parsed {
     bool                got_default;
 };
 
-const struct keyword_enum_values kw_connaddrfamily_list;
+extern const struct keyword_enum_values kw_connaddrfamily_list;
 
 extern struct keyword_def ipsec_conf_keywords_v2[];
 extern const int ipsec_conf_keywords_v2_count;

--- a/include/pluto_constants.h
+++ b/include/pluto_constants.h
@@ -665,7 +665,7 @@ enum keyword_host {
     KH_IPADDR       = LOOSE_ENUM_OTHER,
 };
 /* keyword_name(&kw_host_list, type, buffer[KEYWORD_NAME_BUFLEN]) */
-struct keyword_enum_values kw_host_list;
+extern struct keyword_enum_values kw_host_list;
 #define KH_ISWILDCARD(type)  ((type) == KH_ANY || (type) == KH_DEFAULTROUTE)
 #define KH_ISKNOWNADDR(type) ((type) == KH_IPADDR || (type)==KH_IFACE)
 


### PR DESCRIPTION
Define `kw_host_list` and `kw_connaddrfamily_list` as extern to avoid the following build failure with gcc 10 (which defaults to -fno-common):

```
/home/peko/autobuild/instance-1/output-1/host/lib/gcc/arm-buildroot-linux-gnueabihf/10.2.0/../../../../arm-buildroot-linux-gnueabihf/bin/ld: initiate.o:/home/peko/autobuild/instance-1/output-1/build/openswan-2.6.51.5/include/pluto_constants.h:650: multiple definition of `kw_host_list'; connections.o:/home/peko/autobuild/instance-1/output-1/build/openswan-2.6.51.5/include/pluto_constants.h:650: first defined here
```

Fixes:
 - http://autobuild.buildroot.org/results/650fc0046fd063c70e17ce5ebd9592195657434d

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>