### PR TITLE
Mort/bug10380 ikev2 rekey fuzz

### DIFF
--- a/programs/pluto/ikev2_parent.c
+++ b/programs/pluto/ikev2_parent.c
@@ -53,6 +53,7 @@
 #include "ipsec_doi.h"
 #include "vendor.h"
 #include "timer.h"
+#include "replace.h"
 #include "ike_continuations.h"
 #include "cookie.h"
 #include "rnd.h"

--- a/programs/pluto/ikev2_parent_I2.c
+++ b/programs/pluto/ikev2_parent_I2.c
@@ -275,8 +275,7 @@ ikev2_parent_inR1outI2_tail(struct pluto_crypto_req_cont *pcrc
     md->pst= pst;
 
     /* parent had crypto failed, replace it with rekey! */
-    delete_event(pst);
-    event_schedule(EVENT_SA_REPLACE, c->sa_ike_life_seconds, pst);
+    schedule_sa_replace_event(TRUE, c->sa_ike_life_seconds, c, pst);
 
     /* record first packet for later checking of signature */
     clonetochunk(pst->st_firstpacket_him, md->packet_pbs.start

--- a/programs/pluto/ikev2_parent_R2.c
+++ b/programs/pluto/ikev2_parent_R2.c
@@ -302,8 +302,7 @@ ikev2_parent_inI2outR2_tail(struct pluto_crypto_req_cont *pcrc
     c->newest_isakmp_sa = st->st_serialno;
     md->pst = st;
 
-    delete_event(st);
-    event_schedule(EVENT_SA_REPLACE, c->sa_ike_life_seconds, st);
+    schedule_sa_replace_event(FALSE, c->sa_ike_life_seconds, c, st);
 
     /* switch to port 4500, if necessary */
     ikev2_update_nat_ports(st);

--- a/programs/pluto/replace.c
+++ b/programs/pluto/replace.c
@@ -176,3 +176,27 @@ sa_expire(struct state *st)
     }
     delete_state(st);
 }
+
+void
+schedule_sa_replace_event(bool is_initiator, unsigned long delay,
+		          struct connection *c, struct state *st)
+{
+    unsigned long marg = c->sa_rekey_margin;
+    enum event_type ev = EVENT_SA_REPLACE;
+
+    if(is_initiator)
+        marg += marg
+                * c->sa_rekey_fuzz / 100.E0
+                * (rand() / (RAND_MAX + 1.E0));
+    else
+        marg /= 2;
+
+    delete_event(st);
+    if(delay > marg) {
+        delay -= marg;
+        st->st_margin = marg;
+    } else {
+        ev = EVENT_SA_EXPIRE;
+    }
+    event_schedule(ev, delay, st);
+}

--- a/programs/pluto/replace.h
+++ b/programs/pluto/replace.h
@@ -20,6 +20,8 @@ struct state;
 
 extern void sa_replace(struct state *st, int type);
 extern void sa_expire(struct state *st);
+extern void schedule_sa_replace_event(bool is_initiator, unsigned long delay,
+                                      struct connection *c, struct state *st);
 
 #endif /* _TIMER_H */
 

--- a/tests/unit/libpluto/lp06-parentR1notchosen/Makefile
+++ b/tests/unit/libpluto/lp06-parentR1notchosen/Makefile
@@ -36,6 +36,7 @@ EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_derived_keys.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_prfplus.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_x509.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/state.o
+EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/replace.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/msgdigest.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/hmac.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/plutoalg.o

--- a/tests/unit/libpluto/lp07-orient/Makefile
+++ b/tests/unit/libpluto/lp07-orient/Makefile
@@ -34,6 +34,7 @@ EXTRALIBS+=${OBJDIRTOP}/programs/pluto/ikev2_derived_keys.o
 EXTRALIBS+=${OBJDIRTOP}/programs/pluto/ikev2_prfplus.o
 EXTRALIBS+=${OBJDIRTOP}/programs/pluto/ikev2_x509.o
 EXTRALIBS+=${OBJDIRTOP}/programs/pluto/state.o
+EXTRALIBS+=${OBJDIRTOP}/programs/pluto/replace.o
 EXTRALIBS+=${OBJDIRTOP}/programs/pluto/msgdigest.o
 EXTRALIBS+=${OBJDIRTOP}/programs/pluto/hmac.o
 EXTRALIBS+=${OBJDIRTOP}/programs/pluto/plutoalg.o

--- a/tests/unit/libpluto/lp13-objectlist.make
+++ b/tests/unit/libpluto/lp13-objectlist.make
@@ -12,6 +12,7 @@ EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_derived_keys.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_prfplus.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_x509.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/state.o
+EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/replace.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/msgdigest.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/hmac.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/plutoalg.o

--- a/tests/unit/libpluto/lp14-initiateself/Makefile
+++ b/tests/unit/libpluto/lp14-initiateself/Makefile
@@ -37,6 +37,7 @@ EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_derived_keys.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_prfplus.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_x509.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/state.o
+EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/replace.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/msgdigest.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/hmac.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/keys.o

--- a/tests/unit/libpluto/lp15-respondself/Makefile
+++ b/tests/unit/libpluto/lp15-respondself/Makefile
@@ -35,6 +35,7 @@ EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_derived_keys.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_prfplus.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_x509.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/state.o
+EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/replace.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/msgdigest.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/hmac.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/plutoalg.o

--- a/tests/unit/libpluto/lp16-initiateselfI2/Makefile
+++ b/tests/unit/libpluto/lp16-initiateselfI2/Makefile
@@ -33,6 +33,7 @@ EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_derived_keys.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_prfplus.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_x509.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/state.o
+EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/replace.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/msgdigest.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/hmac.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/keys.o

--- a/tests/unit/libpluto/lp17-childselfpolicy/Makefile
+++ b/tests/unit/libpluto/lp17-childselfpolicy/Makefile
@@ -34,6 +34,7 @@ EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_derived_keys.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_prfplus.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_x509.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/state.o
+EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/replace.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/msgdigest.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/hmac.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/keys.o

--- a/tests/unit/libpluto/lp203-ca-h2hI2/output1.txt
+++ b/tests/unit/libpluto/lp203-ca-h2hI2/output1.txt
@@ -549,10 +549,10 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | emitting length of IKEv2 Encryption Payload: 1600
 | emitting length of ISAKMP Message: 1628
 | encrypting as INITIATOR, parent SA #1
-| WARNING: ikev2_encrypt_msg:268: encryptor 'aes' expects keylen 16/128, SA #2 INITIATOR keylen is 24
-| WARNING: ikev2_encrypt_msg:268: encryptor 'aes' expects keylen 16/128, SA #2 RESPONDER keylen is 24
-| WARNING: ikev2_encrypt_msg:268: hasher 'sha1' expects keylen 20/20, SA #2 INITIATOR keylen is 16
-| WARNING: ikev2_encrypt_msg:268: hasher 'sha1' expects keylen 20/20, SA #2 RESPONDER keylen is 16
+| WARNING: ikev2_encrypt_msg:269: encryptor 'aes' expects keylen 16/128, SA #2 INITIATOR keylen is 24
+| WARNING: ikev2_encrypt_msg:269: encryptor 'aes' expects keylen 16/128, SA #2 RESPONDER keylen is 24
+| WARNING: ikev2_encrypt_msg:269: hasher 'sha1' expects keylen 20/20, SA #2 INITIATOR keylen is 16
+| WARNING: ikev2_encrypt_msg:269: hasher 'sha1' expects keylen 20/20, SA #2 RESPONDER keylen is 16
 | data before encryption:
 |   25 00 00 54  09 00 00 00  30 4a 31 0b  30 09 06 03
 |   55 04 06 13  02 43 41 31  0b 30 09 06  03 55 04 08
@@ -998,10 +998,10 @@ sending 1628 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132
 | emitting length of IKEv2 Encryption Payload: 48
 | emitting length of ISAKMP Message: 76
 | encrypting as INITIATOR, parent SA #1
-| WARNING: ikev2_encrypt_msg:268: encryptor 'aes' expects keylen 16/128, SA #1 INITIATOR keylen is 24
-| WARNING: ikev2_encrypt_msg:268: encryptor 'aes' expects keylen 16/128, SA #1 RESPONDER keylen is 24
-| WARNING: ikev2_encrypt_msg:268: hasher 'sha1' expects keylen 20/20, SA #1 INITIATOR keylen is 16
-| WARNING: ikev2_encrypt_msg:268: hasher 'sha1' expects keylen 20/20, SA #1 RESPONDER keylen is 16
+| WARNING: ikev2_encrypt_msg:269: encryptor 'aes' expects keylen 16/128, SA #1 INITIATOR keylen is 24
+| WARNING: ikev2_encrypt_msg:269: encryptor 'aes' expects keylen 16/128, SA #1 RESPONDER keylen is 24
+| WARNING: ikev2_encrypt_msg:269: hasher 'sha1' expects keylen 20/20, SA #1 INITIATOR keylen is 16
+| WARNING: ikev2_encrypt_msg:269: hasher 'sha1' expects keylen 20/20, SA #1 RESPONDER keylen is 16
 | data before encryption:
 |   00 00 00 08  01 00 00 00  00 01 02 03  04 05 06 07
 | data after encryption:

--- a/tests/unit/libpluto/lp204-ca-h2hR2/output1.txt
+++ b/tests/unit/libpluto/lp204-ca-h2hR2/output1.txt
@@ -493,10 +493,10 @@ sending 457 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | WARNING: ikev2_parent_inI2outR2_tail:167: hasher 'sha1' expects keylen 20/20, SA #1 INITIATOR keylen is 16
 | WARNING: ikev2_parent_inI2outR2_tail:167: hasher 'sha1' expects keylen 20/20, SA #1 RESPONDER keylen is 16
 | decrypting as RESPONDER, using INITIATOR keys
-| WARNING: ikev2_decrypt_msg:335: encryptor 'aes' expects keylen 16/128, SA #1 INITIATOR keylen is 24
-| WARNING: ikev2_decrypt_msg:335: encryptor 'aes' expects keylen 16/128, SA #1 RESPONDER keylen is 24
-| WARNING: ikev2_decrypt_msg:335: hasher 'sha1' expects keylen 20/20, SA #1 INITIATOR keylen is 16
-| WARNING: ikev2_decrypt_msg:335: hasher 'sha1' expects keylen 20/20, SA #1 RESPONDER keylen is 16
+| WARNING: ikev2_decrypt_msg:336: encryptor 'aes' expects keylen 16/128, SA #1 INITIATOR keylen is 24
+| WARNING: ikev2_decrypt_msg:336: encryptor 'aes' expects keylen 16/128, SA #1 RESPONDER keylen is 24
+| WARNING: ikev2_decrypt_msg:336: hasher 'sha1' expects keylen 20/20, SA #1 INITIATOR keylen is 16
+| WARNING: ikev2_decrypt_msg:336: hasher 'sha1' expects keylen 20/20, SA #1 RESPONDER keylen is 16
 | data being hmac:  80 01 02 03  04 05 06 07  de bc 58 3a  8f 40 d0 cf
 |   2e 20 23 08  00 00 00 01  00 00 06 5c  23 00 06 40
 |   80 01 02 03  04 05 06 07  08 09 0a 0b  0c 0d 0e 0f
@@ -1323,10 +1323,10 @@ sending 457 bytes for STATE_IKEv2_START through eth0:500 [132.213.238.7:500] to 
 | emitting length of IKEv2 Encryption Payload: 1472
 | emitting length of ISAKMP Message: 1500
 | encrypting as RESPONDER, parent SA #1
-| WARNING: ikev2_encrypt_msg:268: encryptor 'aes' expects keylen 16/128, SA #2 INITIATOR keylen is 24
-| WARNING: ikev2_encrypt_msg:268: encryptor 'aes' expects keylen 16/128, SA #2 RESPONDER keylen is 24
-| WARNING: ikev2_encrypt_msg:268: hasher 'sha1' expects keylen 20/20, SA #2 INITIATOR keylen is 16
-| WARNING: ikev2_encrypt_msg:268: hasher 'sha1' expects keylen 20/20, SA #2 RESPONDER keylen is 16
+| WARNING: ikev2_encrypt_msg:269: encryptor 'aes' expects keylen 16/128, SA #2 INITIATOR keylen is 24
+| WARNING: ikev2_encrypt_msg:269: encryptor 'aes' expects keylen 16/128, SA #2 RESPONDER keylen is 24
+| WARNING: ikev2_encrypt_msg:269: hasher 'sha1' expects keylen 20/20, SA #2 INITIATOR keylen is 16
+| WARNING: ikev2_encrypt_msg:269: hasher 'sha1' expects keylen 20/20, SA #2 RESPONDER keylen is 16
 | data before encryption:
 |   25 00 00 54  09 00 00 00  30 4a 31 0b  30 09 06 03
 |   55 04 06 13  02 43 41 31  0b 30 09 06  03 55 04 08

--- a/tests/unit/libpluto/lp205-ca-h2hI3/output1.txt
+++ b/tests/unit/libpluto/lp205-ca-h2hI3/output1.txt
@@ -567,10 +567,10 @@ sending 892 bytes for ikev2_parent_outI1_common through eth0:500 [192.168.1.1:50
 | emitting length of IKEv2 Encryption Payload: 1600
 | emitting length of ISAKMP Message: 1628
 | encrypting as INITIATOR, parent SA #1
-| WARNING: ikev2_encrypt_msg:268: encryptor 'aes' expects keylen 16/128, SA #2 INITIATOR keylen is 24
-| WARNING: ikev2_encrypt_msg:268: encryptor 'aes' expects keylen 16/128, SA #2 RESPONDER keylen is 24
-| WARNING: ikev2_encrypt_msg:268: hasher 'sha1' expects keylen 20/20, SA #2 INITIATOR keylen is 16
-| WARNING: ikev2_encrypt_msg:268: hasher 'sha1' expects keylen 20/20, SA #2 RESPONDER keylen is 16
+| WARNING: ikev2_encrypt_msg:269: encryptor 'aes' expects keylen 16/128, SA #2 INITIATOR keylen is 24
+| WARNING: ikev2_encrypt_msg:269: encryptor 'aes' expects keylen 16/128, SA #2 RESPONDER keylen is 24
+| WARNING: ikev2_encrypt_msg:269: hasher 'sha1' expects keylen 20/20, SA #2 INITIATOR keylen is 16
+| WARNING: ikev2_encrypt_msg:269: hasher 'sha1' expects keylen 20/20, SA #2 RESPONDER keylen is 16
 | data before encryption:
 |   25 00 00 54  09 00 00 00  30 4a 31 0b  30 09 06 03
 |   55 04 06 13  02 43 41 31  0b 30 09 06  03 55 04 08
@@ -1109,10 +1109,10 @@ sending 1628 bytes for STATE_PARENT_I1 through eth0:500 [192.168.1.1:500] to 132
 | now proceed with state specific processing using state #2 initiator-auth-process
 | ikev2 parent inR2: calculating g^{xy} in order to decrypt I2
 | decrypting as INITIATOR, using RESPONDER keys
-| WARNING: ikev2_decrypt_msg:335: encryptor 'aes' expects keylen 16/128, SA #2 INITIATOR keylen is 24
-| WARNING: ikev2_decrypt_msg:335: encryptor 'aes' expects keylen 16/128, SA #2 RESPONDER keylen is 24
-| WARNING: ikev2_decrypt_msg:335: hasher 'sha1' expects keylen 20/20, SA #2 INITIATOR keylen is 16
-| WARNING: ikev2_decrypt_msg:335: hasher 'sha1' expects keylen 20/20, SA #2 RESPONDER keylen is 16
+| WARNING: ikev2_decrypt_msg:336: encryptor 'aes' expects keylen 16/128, SA #2 INITIATOR keylen is 24
+| WARNING: ikev2_decrypt_msg:336: encryptor 'aes' expects keylen 16/128, SA #2 RESPONDER keylen is 24
+| WARNING: ikev2_decrypt_msg:336: hasher 'sha1' expects keylen 20/20, SA #2 INITIATOR keylen is 16
+| WARNING: ikev2_decrypt_msg:336: hasher 'sha1' expects keylen 20/20, SA #2 RESPONDER keylen is 16
 | data being hmac:  80 01 02 03  04 05 06 07  de bc 58 3a  8f 40 d0 cf
 |   2e 20 23 20  00 00 00 01  00 00 05 dc  24 00 05 c0
 |   80 01 02 03  04 05 06 07  08 09 0a 0b  0c 0d 0e 0f
@@ -1664,10 +1664,10 @@ RC=0 #1: "home":500 IKEv2.0 STATE_PARENT_I3 (PARENT SA established); none in -1s
 | emitting length of IKEv2 Encryption Payload: 48
 | emitting length of ISAKMP Message: 76
 | encrypting as INITIATOR, parent SA #1
-| WARNING: ikev2_encrypt_msg:268: encryptor 'aes' expects keylen 16/128, SA #1 INITIATOR keylen is 24
-| WARNING: ikev2_encrypt_msg:268: encryptor 'aes' expects keylen 16/128, SA #1 RESPONDER keylen is 24
-| WARNING: ikev2_encrypt_msg:268: hasher 'sha1' expects keylen 20/20, SA #1 INITIATOR keylen is 16
-| WARNING: ikev2_encrypt_msg:268: hasher 'sha1' expects keylen 20/20, SA #1 RESPONDER keylen is 16
+| WARNING: ikev2_encrypt_msg:269: encryptor 'aes' expects keylen 16/128, SA #1 INITIATOR keylen is 24
+| WARNING: ikev2_encrypt_msg:269: encryptor 'aes' expects keylen 16/128, SA #1 RESPONDER keylen is 24
+| WARNING: ikev2_encrypt_msg:269: hasher 'sha1' expects keylen 20/20, SA #1 INITIATOR keylen is 16
+| WARNING: ikev2_encrypt_msg:269: hasher 'sha1' expects keylen 20/20, SA #1 RESPONDER keylen is 16
 | data before encryption:
 |   00 00 00 08  01 00 00 00  00 01 02 03  04 05 06 07
 | data after encryption:

--- a/tests/unit/libpluto/lp66-natt-replaceI/rekeyParentSA.c
+++ b/tests/unit/libpluto/lp66-natt-replaceI/rekeyParentSA.c
@@ -4,14 +4,13 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include "../lp13-parentI3/parentI3_head.c"
+#include "../../programs/pluto/replace.h"
 #include "seam_x509.c"
 #include "seam_gi_sha1.c"
 #include "seam_gi_sha1_group14.c"
 #include "seam_finish.c"
 #include "seam_ikev2_sendI1.c"
 #include "seam_debug.c"
-
-#include "../../programs/pluto/replace.c"
 
 #define TESTNAME "rekeyParentSA"
 

--- a/tests/unit/libpluto/lp67-natt-replaceR/rekeyParentSA.c
+++ b/tests/unit/libpluto/lp67-natt-replaceR/rekeyParentSA.c
@@ -1,13 +1,12 @@
 /* we want to link against the real timer code for this test */
 #define NAT_TRAVERSAL
 #include "../lp12-parentR2/parentR2_head.c"
+#include "../../programs/pluto/replace.h"
 #include "seam_host_jamesjohnson.c"
 #include "seam_x509.c"
 #include "seam_debug.c"
 #include "seam_gr_sha1_group14.c"
 #include "seam_finish.c"
-
-#include "../../programs/pluto/replace.c"
 
 #define TESTNAME "rekeyParentSA"
 

--- a/tests/unit/libpluto/lp77-del-matching-st/Makefile
+++ b/tests/unit/libpluto/lp77-del-matching-st/Makefile
@@ -36,6 +36,7 @@ EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_derived_keys.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_prfplus.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/ikev2_x509.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/state.o
+EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/replace.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/msgdigest.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/hmac.o
 EXTRAOBJS+=${OBJDIRTOP}/programs/pluto/plutoalg.o


### PR DESCRIPTION
Looking for this to be pulled into 2.6.52dev.

It refactors out the rekey fuzzing timeouts, and then applies them to ikev2.