### PR TITLE
pluto: add ALLOW_MICROSOFT_BAD_PROPOSAL for self-proposals

### DIFF
--- a/programs/pluto/ikev1_quick.c
+++ b/programs/pluto/ikev1_quick.c
@@ -602,7 +602,12 @@ check_net_id(struct isakmp_ipsec_id *id
     } else if(!end->has_client && !subnetisaddr(&net_temp, endip)) {
         loglog(RC_LOG_SERIOUS, "%s subnet returned does not match my self-proposal - us:%s vs them:%s",
                which,subxmt,subrec);
-        bad_proposal = TRUE;
+#ifdef ALLOW_MICROSOFT_BAD_PROPOSAL
+	loglog(RC_LOG_SERIOUS, "Allowing questionable self-proposal anyway [ALLOW_MICROSOFT_BAD_PROPOSAL]");
+	bad_proposal = FALSE;
+#else
+	bad_proposal = TRUE;
+#endif
     }
 
     if(*protoid != id->isaiid_protoid) {


### PR DESCRIPTION
Earlier commit, introduced checking for self-proposals. Yet the commit
did not add the ALLOW_MICROSOFT_BAD_PROPOSAL workaround in said case.

Add the workaround, since it's required in a number of cases:
https://bbs.archlinux.org/viewtopic.php?id=253434

Fixes: 3a9afb0bf ("wo#6211 . the check on the peers reply should also use localaddr when checking")

/cc @mcr @shussain 