### PR TITLE
lib/libopenswan/constants.c: fix build on uclibc-ng

### DIFF
--- a/lib/libopenswan/constants.c
+++ b/lib/libopenswan/constants.c
@@ -1429,8 +1429,8 @@ static const char *const rr_qtype_name[] = {
 	NULL
     };
 
-enum_names rr_qtype_names = { ns_t_tkey, ns_t_any
-			      , rr_qtype_name, &rr_type_names };
+/* ns_t_tkey doesn't exist in uclibc-ng, so use ns_t_tsig-1 as the start value */
+enum_names rr_qtype_names = { ns_t_tsig - 1, ns_t_any, rr_qtype_name, &rr_type_names };
 
 static const char *const rr_class_name[] = {
 	"C_IN",	/* 1 the arpa internet */


### PR DESCRIPTION
Use `ns_t_tsig - 1` instead of `ns_t_tkey` which is not defined in uclibc-ng resulting in the following build failure:

```
openswan-2.6.52.2/lib/libopenswan/constants.c:1432:31: error: ‘ns_t_tkey’ undeclared here (not in a function)
 enum_names rr_qtype_names = { ns_t_tkey, ns_t_any
                               ^
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>