### PR TITLE
Mort/2.6.53dev 

### DIFF
--- a/include/pluto/ike_alg.h
+++ b/include/pluto/ike_alg.h
@@ -157,7 +157,7 @@ extern struct db_sa *kernel_alg_makedb(lset_t policy
 extern int ike_alg_sha2_init(void);
 
 /* Translate from IKEv1->IKEv2 */
-extern enum ikev2_trans_type_integ ikev1toikev2integ(enum oakley_hash_t num);
+extern enum ikev2_trans_type_integ ikev1toikev2integ(enum ikev1_auth_attribute num);
 
 #endif /* _IKE_ALG_H */
 

--- a/lib/libalgoparse/ipsecalg.c
+++ b/lib/libalgoparse/ipsecalg.c
@@ -189,27 +189,27 @@ alg_info_esp_defaults(void)
 }
 
 /* Translate from IKEv1->IKEv2 */
-enum ikev2_trans_type_integ ikev1toikev2integ(enum oakley_hash_t num)
+enum ikev2_trans_type_integ ikev1toikev2integ(enum ikev1_auth_attribute num)
 {
     switch(num) {
-    case OAKLEY_MD5:
+    case AUTH_ALGORITHM_HMAC_MD5:
         return IKEv2_AUTH_HMAC_MD5_96;
-    case OAKLEY_SHA1:
+    case AUTH_ALGORITHM_HMAC_SHA1:
         return IKEv2_AUTH_HMAC_SHA1_96;
-    case OAKLEY_TIGER:
-        return IKEv2_AUTH_NONE;
-    case OAKLEY_SHA2_256:
+    case AUTH_ALGORITHM_DES_MAC:
+        return IKEv2_AUTH_DES_MAC;
+    case AUTH_ALGORITHM_KPDK:
+        return IKEv2_AUTH_KPDK_MD5;
+    case AUTH_ALGORITHM_HMAC_SHA2_256:
         return IKEv2_AUTH_HMAC_SHA2_256_128;
-    case OAKLEY_SHA2_384:
+    case AUTH_ALGORITHM_HMAC_SHA2_384:
         return IKEv2_AUTH_HMAC_SHA2_384_192;
-    case OAKLEY_SHA2_512:
+    case AUTH_ALGORITHM_HMAC_SHA2_512:
         return IKEv2_AUTH_HMAC_SHA2_512_256;
+    default:
+	return IKEv2_AUTH_NONE;
     }
-    return IKEv2_AUTH_NONE;
 }
-
-
-
 
 /*
  * Local Variables:

--- a/programs/pluto/spdb_v1_struct.c
+++ b/programs/pluto/spdb_v1_struct.c
@@ -222,14 +222,14 @@ ikev1_alg_makedb(lset_t policy, struct alg_info_ike *ei, bool oneproposal UNUSED
 }
 
 struct db_sa *
-kernel_alg_makedb(lset_t policy UNUSED, struct alg_info_esp *ei, enum phase1_role role)
+kernel_alg_makedb(lset_t policy, struct alg_info_esp *ei, enum phase1_role role)
 {
 	struct db_sa *sadb;
 
     sadb = alginfo2child_db2(ei);
     sadb->parentSA = FALSE;
 
-    if(!extrapolate_v1_from_v2(sadb, policy, role)) {
+    if(!(policy & POLICY_IKEV1_DISABLE) && !extrapolate_v1_from_v2(sadb, policy, role)) {
         openswan_log("failed to create v1 IPsec policy from v2 settings");
 	return NULL;
     }

--- a/programs/pluto/spdb_v1_struct.c
+++ b/programs/pluto/spdb_v1_struct.c
@@ -105,6 +105,8 @@ int v2tov1_encr_child(enum ikev2_trans_type_encr encr)
         return ESP_3DES;
     case  IKEv2_ENCR_CAST:
         return ESP_CAST;
+    case  IKEv2_ENCR_NULL:
+        return ESP_NULL;
     case  IKEv2_ENCR_AES_CBC:
         return ESP_AES;
     default:

--- a/tests/unit/libalgoparse/Makefile
+++ b/tests/unit/libalgoparse/Makefile
@@ -24,7 +24,7 @@ UNITTESTS+=ap05-ikev1toikev2
 UNITTESTS+=ap06-algo2ikev2
 
 ERROR_CHECK=$(if ${KEEPGOING},,set -e;)
-clean check pcapupdate:
+clean check pcapupdate update:
 	@${ERROR_CHECK} for unittest in ${UNITTESTS}; do ${MAKE} -C $$unittest $@; done
 
 testlist:

--- a/tests/unit/libalgoparse/ap01-alginfo/Makefile
+++ b/tests/unit/libalgoparse/ap01-alginfo/Makefile
@@ -51,6 +51,8 @@ update:
 clean:
 	-@rm -f ${TESTNAME}
 
+pcapupdate:
+	@true
 
 # Local Variables:
 # compile-command: "make check"

--- a/tests/unit/libalgoparse/ap02-algonames/Makefile
+++ b/tests/unit/libalgoparse/ap02-algonames/Makefile
@@ -41,12 +41,11 @@ check:
 	${COREULIMIT} && ./${TESTNAME} ${UNITTESTARGS}
 	@: recordresults lib-$testobj "$testexpect" "$stat" lib-$testobj false
 
-update:
-	cp OUTPUT/${TESTNAME}.txt output.txt
-
 clean:
 	-@rm -f ${TESTNAME}
 
+update pcapupdate:
+	@true
 
 # Local Variables:
 # compile-command: "make check"

--- a/tests/unit/libalgoparse/ap03-espinfo/Makefile
+++ b/tests/unit/libalgoparse/ap03-espinfo/Makefile
@@ -49,6 +49,8 @@ update:
 clean:
 	-@rm -f ${TESTNAME}
 
+pcapupdate:
+	@true
 
 # Local Variables:
 # compile-command: "make check"

--- a/tests/unit/libalgoparse/ap04-kernelalg2ikev2/Makefile
+++ b/tests/unit/libalgoparse/ap04-kernelalg2ikev2/Makefile
@@ -47,5 +47,5 @@ update:
 clean:
 	-@rm -f ${TESTNAME}
 
-
-
+pcapupdate:
+	@true

--- a/tests/unit/libalgoparse/ap05-ikev1toikev2/Makefile
+++ b/tests/unit/libalgoparse/ap05-ikev1toikev2/Makefile
@@ -47,5 +47,5 @@ update:
 clean:
 	-@rm -f ${TESTNAME}
 
-
-
+pcapupdate:
+	@true

--- a/tests/unit/libalgoparse/ap05-ikev1toikev2/ikev1toikev2.c
+++ b/tests/unit/libalgoparse/ap05-ikev1toikev2/ikev1toikev2.c
@@ -30,11 +30,13 @@ int main(int argc, char *argv[])
 
     tool_init_log();
 
-    passert(ikev1toikev2integ(OAKLEY_MD5)    == IKEv2_AUTH_HMAC_MD5_96);
-    passert(ikev1toikev2integ(OAKLEY_SHA1)   == IKEv2_AUTH_HMAC_SHA1_96);
-    passert(ikev1toikev2integ(OAKLEY_SHA2_256) == IKEv2_AUTH_HMAC_SHA2_256_128);
-    passert(ikev1toikev2integ(OAKLEY_SHA2_384) == IKEv2_AUTH_HMAC_SHA2_384_192);
-    passert(ikev1toikev2integ(OAKLEY_SHA2_512) == IKEv2_AUTH_HMAC_SHA2_512_256);
+    passert(ikev1toikev2integ(AUTH_ALGORITHM_HMAC_MD5)      == IKEv2_AUTH_HMAC_MD5_96);
+    passert(ikev1toikev2integ(AUTH_ALGORITHM_HMAC_SHA1)     == IKEv2_AUTH_HMAC_SHA1_96);
+    passert(ikev1toikev2integ(AUTH_ALGORITHM_DES_MAC)       == IKEv2_AUTH_DES_MAC);
+    passert(ikev1toikev2integ(AUTH_ALGORITHM_KPDK)          == IKEv2_AUTH_KPDK_MD5);
+    passert(ikev1toikev2integ(AUTH_ALGORITHM_HMAC_SHA2_256) == IKEv2_AUTH_HMAC_SHA2_256_128);
+    passert(ikev1toikev2integ(AUTH_ALGORITHM_HMAC_SHA2_384) == IKEv2_AUTH_HMAC_SHA2_384_192);
+    passert(ikev1toikev2integ(AUTH_ALGORITHM_HMAC_SHA2_512) == IKEv2_AUTH_HMAC_SHA2_512_256);
 
     report_leaks();
     tool_close_log();

--- a/tests/unit/libalgoparse/ap06-algo2ikev2/Makefile
+++ b/tests/unit/libalgoparse/ap06-algo2ikev2/Makefile
@@ -53,5 +53,5 @@ clean:
 	-rm -f ${TESTNAME} .gdbinit
 	-rm -rf OUTPUT/${TESTNAME}.txt
 
-
-
+pcapupdate:
+	@true

--- a/tests/unit/libalgoparse/ap06-algo2ikev2/output.txt
+++ b/tests/unit/libalgoparse/ap06-algo2ikev2/output.txt
@@ -81,19 +81,24 @@ ike_alg_register_prf(): Activating prf-hmac-md5: Ok (ret=0)
 | sa disjunct cnt: 1 
 |   conjunctions cnt: 1 
 |     protoid: 1 (PROTO_ISAKMP) cnt: 5 
-|       transform: 12 cnt: 2 
+|       transform: 12 cnt: 3 
+|         type: 6(KEY_LENGTH) val: 128(unknown) 
 |         type: 5(AUTH_ALGORITHM) val: 5(AUTH_ALGORITHM_HMAC_SHA2_256) 
 |         type: 3(GROUP_DESCRIPTION) val: 14(OAKLEY_GROUP_MODP2048) 
-|       transform: 12 cnt: 2 
+|       transform: 12 cnt: 3 
+|         type: 6(KEY_LENGTH) val: 128(unknown) 
 |         type: 5(AUTH_ALGORITHM) val: 2(AUTH_ALGORITHM_HMAC_SHA1) 
 |         type: 3(GROUP_DESCRIPTION) val: 14(OAKLEY_GROUP_MODP2048) 
-|       transform: 12 cnt: 2 
+|       transform: 12 cnt: 3 
+|         type: 6(KEY_LENGTH) val: 128(unknown) 
 |         type: 5(AUTH_ALGORITHM) val: 5(AUTH_ALGORITHM_HMAC_SHA2_256) 
 |         type: 3(GROUP_DESCRIPTION) val: 5(OAKLEY_GROUP_MODP1536) 
-|       transform: 12 cnt: 2 
+|       transform: 12 cnt: 3 
+|         type: 6(KEY_LENGTH) val: 128(unknown) 
 |         type: 5(AUTH_ALGORITHM) val: 2(AUTH_ALGORITHM_HMAC_SHA1) 
 |         type: 3(GROUP_DESCRIPTION) val: 5(OAKLEY_GROUP_MODP1536) 
-|       transform: 12 cnt: 2 
+|       transform: 12 cnt: 3 
+|         type: 6(KEY_LENGTH) val: 128(unknown) 
 |         type: 5(AUTH_ALGORITHM) val: 5(AUTH_ALGORITHM_HMAC_SHA2_256) 
 |         type: 3(GROUP_DESCRIPTION) val: 15(OAKLEY_GROUP_MODP3072) 
 | free now

--- a/tests/unit/libpluto/lp43-parentM1/I1-dump.txt
+++ b/tests/unit/libpluto/lp43-parentM1/I1-dump.txt
@@ -1,12 +1,12 @@
-IP (tos 0x0, ttl 64, id 0, offset 0, flags [none], proto UDP (17), length 292, bad cksum 0 (->4543)!)
+IP (tos 0x0, ttl 64, id 0, offset 0, flags [none], proto UDP (17), length 312, bad cksum 0 (->452f)!)
     192.168.1.1.500 > 132.213.238.7.500: isakmp 1.0 msgid 00000000: phase 1 I ident:
     (sa: doi=ipsec situation=identity
         (p: #0 protoid=isakmp transform=5
-            (t: #0 id=ike (type=lifetype value=sec)(type=lifeduration value=0e10)(type=auth value=rsa sig)(type=enc value=aes)(type=hash value=sha2-256)(type=group desc value=modp2048))
-            (t: #1 id=ike (type=lifetype value=sec)(type=lifeduration value=0e10)(type=auth value=rsa sig)(type=enc value=aes)(type=hash value=sha1)(type=group desc value=modp2048))
-            (t: #2 id=ike (type=lifetype value=sec)(type=lifeduration value=0e10)(type=auth value=rsa sig)(type=enc value=aes)(type=hash value=sha2-256)(type=group desc value=modp1536))
-            (t: #3 id=ike (type=lifetype value=sec)(type=lifeduration value=0e10)(type=auth value=rsa sig)(type=enc value=aes)(type=hash value=sha1)(type=group desc value=modp1536))
-            (t: #4 id=ike (type=lifetype value=sec)(type=lifeduration value=0e10)(type=auth value=rsa sig)(type=enc value=aes)(type=hash value=sha2-256)(type=group desc value=modp3072))))
+            (t: #0 id=ike (type=lifetype value=sec)(type=lifeduration value=0e10)(type=auth value=rsa sig)(type=enc value=aes)(type=keylen value=0080)(type=hash value=sha2-256)(type=group desc value=modp2048))
+            (t: #1 id=ike (type=lifetype value=sec)(type=lifeduration value=0e10)(type=auth value=rsa sig)(type=enc value=aes)(type=keylen value=0080)(type=hash value=sha1)(type=group desc value=modp2048))
+            (t: #2 id=ike (type=lifetype value=sec)(type=lifeduration value=0e10)(type=auth value=rsa sig)(type=enc value=aes)(type=keylen value=0080)(type=hash value=sha2-256)(type=group desc value=modp1536))
+            (t: #3 id=ike (type=lifetype value=sec)(type=lifeduration value=0e10)(type=auth value=rsa sig)(type=enc value=aes)(type=keylen value=0080)(type=hash value=sha1)(type=group desc value=modp1536))
+            (t: #4 id=ike (type=lifetype value=sec)(type=lifeduration value=0e10)(type=auth value=rsa sig)(type=enc value=aes)(type=keylen value=0080)(type=hash value=sha2-256)(type=group desc value=modp3072))))
     (vid: len=12)
     (vid: len=16)
     (vid: len=16)

--- a/tests/unit/libpluto/lp43-parentM1/output1.txt
+++ b/tests/unit/libpluto/lp43-parentM1/output1.txt
@@ -147,6 +147,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    length/value: 7
 |     [7 is OAKLEY_AES_CBC]
 | ******emit ISAKMP Oakley attribute:
+|    af+type: OAKLEY_KEY_LENGTH
+|    length/value: 128
+| ******emit ISAKMP Oakley attribute:
 |    af+type: OAKLEY_HASH_ALGORITHM
 |    length/value: 4
 |     [4 is OAKLEY_SHA2_256]
@@ -154,7 +157,7 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    af+type: OAKLEY_GROUP_DESCRIPTION
 |    length/value: 14
 |     [14 is OAKLEY_GROUP_MODP2048]
-| emitting length of ISAKMP Transform Payload (ISAKMP): 32
+| emitting length of ISAKMP Transform Payload (ISAKMP): 36
 | *****emit ISAKMP Transform Payload (ISAKMP):
 |    transform number: 1
 |    transform ID: KEY_IKE
@@ -174,6 +177,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    length/value: 7
 |     [7 is OAKLEY_AES_CBC]
 | ******emit ISAKMP Oakley attribute:
+|    af+type: OAKLEY_KEY_LENGTH
+|    length/value: 128
+| ******emit ISAKMP Oakley attribute:
 |    af+type: OAKLEY_HASH_ALGORITHM
 |    length/value: 2
 |     [2 is OAKLEY_SHA1]
@@ -181,7 +187,7 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    af+type: OAKLEY_GROUP_DESCRIPTION
 |    length/value: 14
 |     [14 is OAKLEY_GROUP_MODP2048]
-| emitting length of ISAKMP Transform Payload (ISAKMP): 32
+| emitting length of ISAKMP Transform Payload (ISAKMP): 36
 | *****emit ISAKMP Transform Payload (ISAKMP):
 |    transform number: 2
 |    transform ID: KEY_IKE
@@ -201,6 +207,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    length/value: 7
 |     [7 is OAKLEY_AES_CBC]
 | ******emit ISAKMP Oakley attribute:
+|    af+type: OAKLEY_KEY_LENGTH
+|    length/value: 128
+| ******emit ISAKMP Oakley attribute:
 |    af+type: OAKLEY_HASH_ALGORITHM
 |    length/value: 4
 |     [4 is OAKLEY_SHA2_256]
@@ -208,7 +217,7 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    af+type: OAKLEY_GROUP_DESCRIPTION
 |    length/value: 5
 |     [5 is OAKLEY_GROUP_MODP1536]
-| emitting length of ISAKMP Transform Payload (ISAKMP): 32
+| emitting length of ISAKMP Transform Payload (ISAKMP): 36
 | *****emit ISAKMP Transform Payload (ISAKMP):
 |    transform number: 3
 |    transform ID: KEY_IKE
@@ -228,6 +237,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    length/value: 7
 |     [7 is OAKLEY_AES_CBC]
 | ******emit ISAKMP Oakley attribute:
+|    af+type: OAKLEY_KEY_LENGTH
+|    length/value: 128
+| ******emit ISAKMP Oakley attribute:
 |    af+type: OAKLEY_HASH_ALGORITHM
 |    length/value: 2
 |     [2 is OAKLEY_SHA1]
@@ -235,7 +247,7 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    af+type: OAKLEY_GROUP_DESCRIPTION
 |    length/value: 5
 |     [5 is OAKLEY_GROUP_MODP1536]
-| emitting length of ISAKMP Transform Payload (ISAKMP): 32
+| emitting length of ISAKMP Transform Payload (ISAKMP): 36
 | *****emit ISAKMP Transform Payload (ISAKMP):
 |    transform number: 4
 |    transform ID: KEY_IKE
@@ -255,6 +267,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    length/value: 7
 |     [7 is OAKLEY_AES_CBC]
 | ******emit ISAKMP Oakley attribute:
+|    af+type: OAKLEY_KEY_LENGTH
+|    length/value: 128
+| ******emit ISAKMP Oakley attribute:
 |    af+type: OAKLEY_HASH_ALGORITHM
 |    length/value: 4
 |     [4 is OAKLEY_SHA2_256]
@@ -262,9 +277,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    af+type: OAKLEY_GROUP_DESCRIPTION
 |    length/value: 15
 |     [15 is OAKLEY_GROUP_MODP3072]
-| emitting length of ISAKMP Transform Payload (ISAKMP): 32
-| emitting length of ISAKMP Proposal Payload: 168
-| emitting length of ISAKMP Security Association Payload: 180
+| emitting length of ISAKMP Transform Payload (ISAKMP): 36
+| emitting length of ISAKMP Proposal Payload: 188
+| emitting length of ISAKMP Security Association Payload: 200
 | ***emit ISAKMP Vendor ID Payload:
 | emitting 12 raw bytes of Vendor ID into ISAKMP Vendor ID Payload
 | Vendor ID  4f 45 ab ab  ab ab ab ab  ab ab ab ab
@@ -278,25 +293,26 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 | emitting 16 raw bytes of V_ID into ISAKMP Vendor ID Payload
 | V_ID  4a 13 1c 81  07 03 58 45  5c 57 28 f2  0e 95 45 2f
 | emitting length of ISAKMP Vendor ID Payload: 20
-| emitting length of ISAKMP Message: 264
-sending 264 bytes for main_outI1 through eth0:500 [192.168.1.1:500] to 132.213.238.7:500 (using #1)
+| emitting length of ISAKMP Message: 284
+sending 284 bytes for main_outI1 through eth0:500 [192.168.1.1:500] to 132.213.238.7:500 (using #1)
 |   80 01 02 03  04 05 06 07  00 00 00 00  00 00 00 00
-|   01 10 02 00  00 00 00 00  00 00 01 08  0d 00 00 b4
-|   00 00 00 01  00 00 00 01  00 00 00 a8  00 01 00 05
-|   03 00 00 20  00 01 00 00  80 0b 00 01  80 0c 0e 10
-|   80 03 00 03  80 01 00 07  80 02 00 04  80 04 00 0e
-|   03 00 00 20  01 01 00 00  80 0b 00 01  80 0c 0e 10
-|   80 03 00 03  80 01 00 07  80 02 00 02  80 04 00 0e
-|   03 00 00 20  02 01 00 00  80 0b 00 01  80 0c 0e 10
-|   80 03 00 03  80 01 00 07  80 02 00 04  80 04 00 05
-|   03 00 00 20  03 01 00 00  80 0b 00 01  80 0c 0e 10
-|   80 03 00 03  80 01 00 07  80 02 00 02  80 04 00 05
-|   00 00 00 20  04 01 00 00  80 0b 00 01  80 0c 0e 10
-|   80 03 00 03  80 01 00 07  80 02 00 04  80 04 00 0f
-|   0d 00 00 10  4f 45 ab ab  ab ab ab ab  ab ab ab ab
-|   0d 00 00 14  af ca d7 13  68 a1 f1 c9  6b 86 96 fc
-|   77 57 01 00  00 00 00 14  4a 13 1c 81  07 03 58 45
-|   5c 57 28 f2  0e 95 45 2f
+|   01 10 02 00  00 00 00 00  00 00 01 1c  0d 00 00 c8
+|   00 00 00 01  00 00 00 01  00 00 00 bc  00 01 00 05
+|   03 00 00 24  00 01 00 00  80 0b 00 01  80 0c 0e 10
+|   80 03 00 03  80 01 00 07  80 0e 00 80  80 02 00 04
+|   80 04 00 0e  03 00 00 24  01 01 00 00  80 0b 00 01
+|   80 0c 0e 10  80 03 00 03  80 01 00 07  80 0e 00 80
+|   80 02 00 02  80 04 00 0e  03 00 00 24  02 01 00 00
+|   80 0b 00 01  80 0c 0e 10  80 03 00 03  80 01 00 07
+|   80 0e 00 80  80 02 00 04  80 04 00 05  03 00 00 24
+|   03 01 00 00  80 0b 00 01  80 0c 0e 10  80 03 00 03
+|   80 01 00 07  80 0e 00 80  80 02 00 02  80 04 00 05
+|   00 00 00 24  04 01 00 00  80 0b 00 01  80 0c 0e 10
+|   80 03 00 03  80 01 00 07  80 0e 00 80  80 02 00 04
+|   80 04 00 0f  0d 00 00 10  4f 45 70 6c  75 74 6f 75
+|   6e 69 74 30  0d 00 00 14  af ca d7 13  68 a1 f1 c9
+|   6b 86 96 fc  77 57 01 00  00 00 00 14  4a 13 1c 81
+|   07 03 58 45  5c 57 28 f2  0e 95 45 2f
 RC=105 STATE_MAIN_I1: initiate
 ./parentM1 deleting state #1 (STATE_MAIN_I1)
 | removing state object #1
@@ -318,8 +334,8 @@ RC=105 STATE_MAIN_I1: initiate
 ./parentM1 leak: vid->data, item size: X
 ./parentM1 leak: sa in main_outI1, item size: X
 ./parentM1 leak: v1 policy proposal conj, item size: X
-./parentM1 leak: db_context->attrs (expand), item size: X
 ./parentM1 leak: db_context->trans (expand), item size: X
+./parentM1 leak: db_context->attrs (expand), item size: X
 ./parentM1 leak: db_context, item size: X
 ./parentM1 leak: db2_expand->attrs, item size: X
 ./parentM1 leak: db_context->trans (expand), item size: X

--- a/tests/unit/libpluto/lp67-ike2ops/output.txt
+++ b/tests/unit/libpluto/lp67-ike2ops/output.txt
@@ -28,9 +28,10 @@ PSK:
 v1 (PSK):| sa disjunct cnt: 1 
 |   conjunctions cnt: 1 
 |     protoid: 1 (PROTO_ISAKMP) cnt: 1 
-|       transform: 1 cnt: 4 
+|       transform: 1 cnt: 5 
 |         type: 3(OAKLEY_AUTHENTICATION_METHOD) val: 1(OAKLEY_PRESHARED_KEY) 
 |         type: 1(OAKLEY_ENCRYPTION_ALGORITHM) val: 7(OAKLEY_AES_CBC) 
+|         type: 14(OAKLEY_KEY_LENGTH) val: 128(unknown) 
 |         type: 2(OAKLEY_HASH_ALGORITHM) val: 2(OAKLEY_SHA1) 
 |         type: 4(OAKLEY_GROUP_DESCRIPTION) val: 14(OAKLEY_GROUP_MODP2048) 
 
@@ -50,9 +51,10 @@ RSA:
 v1 (RSA):| sa disjunct cnt: 1 
 |   conjunctions cnt: 1 
 |     protoid: 1 (PROTO_ISAKMP) cnt: 1 
-|       transform: 1 cnt: 4 
+|       transform: 1 cnt: 5 
 |         type: 3(OAKLEY_AUTHENTICATION_METHOD) val: 3(OAKLEY_RSA_SIG) 
 |         type: 1(OAKLEY_ENCRYPTION_ALGORITHM) val: 7(OAKLEY_AES_CBC) 
+|         type: 14(OAKLEY_KEY_LENGTH) val: 128(unknown) 
 |         type: 2(OAKLEY_HASH_ALGORITHM) val: 2(OAKLEY_SHA1) 
 |         type: 4(OAKLEY_GROUP_DESCRIPTION) val: 14(OAKLEY_GROUP_MODP2048) 
 
@@ -72,14 +74,16 @@ RSA+PSK:
 v1 (RSA+PSK):| sa disjunct cnt: 1 
 |   conjunctions cnt: 1 
 |     protoid: 1 (PROTO_ISAKMP) cnt: 2 
-|       transform: 1 cnt: 4 
+|       transform: 1 cnt: 5 
 |         type: 3(OAKLEY_AUTHENTICATION_METHOD) val: 1(OAKLEY_PRESHARED_KEY) 
 |         type: 1(OAKLEY_ENCRYPTION_ALGORITHM) val: 7(OAKLEY_AES_CBC) 
+|         type: 14(OAKLEY_KEY_LENGTH) val: 128(unknown) 
 |         type: 2(OAKLEY_HASH_ALGORITHM) val: 2(OAKLEY_SHA1) 
 |         type: 4(OAKLEY_GROUP_DESCRIPTION) val: 14(OAKLEY_GROUP_MODP2048) 
-|       transform: 1 cnt: 4 
+|       transform: 1 cnt: 5 
 |         type: 3(OAKLEY_AUTHENTICATION_METHOD) val: 3(OAKLEY_RSA_SIG) 
 |         type: 1(OAKLEY_ENCRYPTION_ALGORITHM) val: 7(OAKLEY_AES_CBC) 
+|         type: 14(OAKLEY_KEY_LENGTH) val: 128(unknown) 
 |         type: 2(OAKLEY_HASH_ALGORITHM) val: 2(OAKLEY_SHA1) 
 |         type: 4(OAKLEY_GROUP_DESCRIPTION) val: 14(OAKLEY_GROUP_MODP2048) 
 
@@ -219,34 +223,40 @@ default RSA:
 default v1 (RSA):| sa disjunct cnt: 1 
 |   conjunctions cnt: 1 
 |     protoid: 1 (PROTO_ISAKMP) cnt: 6 
-|       transform: 1 cnt: 4 
+|       transform: 1 cnt: 5 
 |         type: 3(OAKLEY_AUTHENTICATION_METHOD) val: 3(OAKLEY_RSA_SIG) 
 |         type: 1(OAKLEY_ENCRYPTION_ALGORITHM) val: 7(OAKLEY_AES_CBC) 
+|         type: 14(OAKLEY_KEY_LENGTH) val: 128(unknown) 
 |         type: 2(OAKLEY_HASH_ALGORITHM) val: 4(OAKLEY_SHA2_256) 
 |         type: 4(OAKLEY_GROUP_DESCRIPTION) val: 14(OAKLEY_GROUP_MODP2048) 
-|       transform: 1 cnt: 4 
+|       transform: 1 cnt: 5 
 |         type: 3(OAKLEY_AUTHENTICATION_METHOD) val: 3(OAKLEY_RSA_SIG) 
 |         type: 1(OAKLEY_ENCRYPTION_ALGORITHM) val: 7(OAKLEY_AES_CBC) 
+|         type: 14(OAKLEY_KEY_LENGTH) val: 128(unknown) 
 |         type: 2(OAKLEY_HASH_ALGORITHM) val: 2(OAKLEY_SHA1) 
 |         type: 4(OAKLEY_GROUP_DESCRIPTION) val: 14(OAKLEY_GROUP_MODP2048) 
-|       transform: 1 cnt: 4 
+|       transform: 1 cnt: 5 
 |         type: 3(OAKLEY_AUTHENTICATION_METHOD) val: 3(OAKLEY_RSA_SIG) 
 |         type: 1(OAKLEY_ENCRYPTION_ALGORITHM) val: 7(OAKLEY_AES_CBC) 
+|         type: 14(OAKLEY_KEY_LENGTH) val: 128(unknown) 
 |         type: 2(OAKLEY_HASH_ALGORITHM) val: 4(OAKLEY_SHA2_256) 
 |         type: 4(OAKLEY_GROUP_DESCRIPTION) val: 5(OAKLEY_GROUP_MODP1536) 
-|       transform: 1 cnt: 4 
+|       transform: 1 cnt: 5 
 |         type: 3(OAKLEY_AUTHENTICATION_METHOD) val: 3(OAKLEY_RSA_SIG) 
 |         type: 1(OAKLEY_ENCRYPTION_ALGORITHM) val: 7(OAKLEY_AES_CBC) 
+|         type: 14(OAKLEY_KEY_LENGTH) val: 128(unknown) 
 |         type: 2(OAKLEY_HASH_ALGORITHM) val: 2(OAKLEY_SHA1) 
 |         type: 4(OAKLEY_GROUP_DESCRIPTION) val: 5(OAKLEY_GROUP_MODP1536) 
-|       transform: 1 cnt: 4 
+|       transform: 1 cnt: 5 
 |         type: 3(OAKLEY_AUTHENTICATION_METHOD) val: 3(OAKLEY_RSA_SIG) 
 |         type: 1(OAKLEY_ENCRYPTION_ALGORITHM) val: 7(OAKLEY_AES_CBC) 
+|         type: 14(OAKLEY_KEY_LENGTH) val: 128(unknown) 
 |         type: 2(OAKLEY_HASH_ALGORITHM) val: 4(OAKLEY_SHA2_256) 
 |         type: 4(OAKLEY_GROUP_DESCRIPTION) val: 15(OAKLEY_GROUP_MODP3072) 
-|       transform: 1 cnt: 4 
+|       transform: 1 cnt: 5 
 |         type: 3(OAKLEY_AUTHENTICATION_METHOD) val: 3(OAKLEY_RSA_SIG) 
 |         type: 1(OAKLEY_ENCRYPTION_ALGORITHM) val: 7(OAKLEY_AES_CBC) 
+|         type: 14(OAKLEY_KEY_LENGTH) val: 128(unknown) 
 |         type: 2(OAKLEY_HASH_ALGORITHM) val: 2(OAKLEY_SHA1) 
 |         type: 4(OAKLEY_GROUP_DESCRIPTION) val: 15(OAKLEY_GROUP_MODP3072) 
 | for input ike=aes128-sha1-sha1-modp2048
@@ -386,9 +396,10 @@ default v1 (RSA):| sa disjunct cnt: 1
 strong v1 (RSA):| sa disjunct cnt: 1 
 |   conjunctions cnt: 1 
 |     protoid: 1 (PROTO_ISAKMP) cnt: 1 
-|       transform: 1 cnt: 4 
+|       transform: 1 cnt: 5 
 |         type: 3(OAKLEY_AUTHENTICATION_METHOD) val: 3(OAKLEY_RSA_SIG) 
 |         type: 1(OAKLEY_ENCRYPTION_ALGORITHM) val: 7(OAKLEY_AES_CBC) 
+|         type: 14(OAKLEY_KEY_LENGTH) val: 256(unknown) 
 |         type: 2(OAKLEY_HASH_ALGORITHM) val: 6(OAKLEY_SHA2_512) 
 |         type: 4(OAKLEY_GROUP_DESCRIPTION) val: 14(OAKLEY_GROUP_MODP2048) 
 ./lp67-ike2ops leak: 2 * alg_info_ike, item size: 2064

--- a/tests/unit/libpluto/lp74-parentM2/output1.txt
+++ b/tests/unit/libpluto/lp74-parentM2/output1.txt
@@ -159,6 +159,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    length/value: 7
 |     [7 is OAKLEY_AES_CBC]
 | ******emit ISAKMP Oakley attribute:
+|    af+type: OAKLEY_KEY_LENGTH
+|    length/value: 128
+| ******emit ISAKMP Oakley attribute:
 |    af+type: OAKLEY_HASH_ALGORITHM
 |    length/value: 4
 |     [4 is OAKLEY_SHA2_256]
@@ -166,7 +169,7 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    af+type: OAKLEY_GROUP_DESCRIPTION
 |    length/value: 14
 |     [14 is OAKLEY_GROUP_MODP2048]
-| emitting length of ISAKMP Transform Payload (ISAKMP): 32
+| emitting length of ISAKMP Transform Payload (ISAKMP): 36
 | *****emit ISAKMP Transform Payload (ISAKMP):
 |    transform number: 1
 |    transform ID: KEY_IKE
@@ -186,6 +189,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    length/value: 7
 |     [7 is OAKLEY_AES_CBC]
 | ******emit ISAKMP Oakley attribute:
+|    af+type: OAKLEY_KEY_LENGTH
+|    length/value: 128
+| ******emit ISAKMP Oakley attribute:
 |    af+type: OAKLEY_HASH_ALGORITHM
 |    length/value: 2
 |     [2 is OAKLEY_SHA1]
@@ -193,7 +199,7 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    af+type: OAKLEY_GROUP_DESCRIPTION
 |    length/value: 14
 |     [14 is OAKLEY_GROUP_MODP2048]
-| emitting length of ISAKMP Transform Payload (ISAKMP): 32
+| emitting length of ISAKMP Transform Payload (ISAKMP): 36
 | *****emit ISAKMP Transform Payload (ISAKMP):
 |    transform number: 2
 |    transform ID: KEY_IKE
@@ -213,6 +219,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    length/value: 7
 |     [7 is OAKLEY_AES_CBC]
 | ******emit ISAKMP Oakley attribute:
+|    af+type: OAKLEY_KEY_LENGTH
+|    length/value: 128
+| ******emit ISAKMP Oakley attribute:
 |    af+type: OAKLEY_HASH_ALGORITHM
 |    length/value: 4
 |     [4 is OAKLEY_SHA2_256]
@@ -220,7 +229,7 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    af+type: OAKLEY_GROUP_DESCRIPTION
 |    length/value: 5
 |     [5 is OAKLEY_GROUP_MODP1536]
-| emitting length of ISAKMP Transform Payload (ISAKMP): 32
+| emitting length of ISAKMP Transform Payload (ISAKMP): 36
 | *****emit ISAKMP Transform Payload (ISAKMP):
 |    transform number: 3
 |    transform ID: KEY_IKE
@@ -240,6 +249,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    length/value: 7
 |     [7 is OAKLEY_AES_CBC]
 | ******emit ISAKMP Oakley attribute:
+|    af+type: OAKLEY_KEY_LENGTH
+|    length/value: 128
+| ******emit ISAKMP Oakley attribute:
 |    af+type: OAKLEY_HASH_ALGORITHM
 |    length/value: 2
 |     [2 is OAKLEY_SHA1]
@@ -247,7 +259,7 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    af+type: OAKLEY_GROUP_DESCRIPTION
 |    length/value: 5
 |     [5 is OAKLEY_GROUP_MODP1536]
-| emitting length of ISAKMP Transform Payload (ISAKMP): 32
+| emitting length of ISAKMP Transform Payload (ISAKMP): 36
 | *****emit ISAKMP Transform Payload (ISAKMP):
 |    transform number: 4
 |    transform ID: KEY_IKE
@@ -267,6 +279,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    length/value: 7
 |     [7 is OAKLEY_AES_CBC]
 | ******emit ISAKMP Oakley attribute:
+|    af+type: OAKLEY_KEY_LENGTH
+|    length/value: 128
+| ******emit ISAKMP Oakley attribute:
 |    af+type: OAKLEY_HASH_ALGORITHM
 |    length/value: 4
 |     [4 is OAKLEY_SHA2_256]
@@ -274,9 +289,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    af+type: OAKLEY_GROUP_DESCRIPTION
 |    length/value: 15
 |     [15 is OAKLEY_GROUP_MODP3072]
-| emitting length of ISAKMP Transform Payload (ISAKMP): 32
-| emitting length of ISAKMP Proposal Payload: 168
-| emitting length of ISAKMP Security Association Payload: 180
+| emitting length of ISAKMP Transform Payload (ISAKMP): 36
+| emitting length of ISAKMP Proposal Payload: 188
+| emitting length of ISAKMP Security Association Payload: 200
 | ***emit ISAKMP Vendor ID Payload:
 | emitting 12 raw bytes of Vendor ID into ISAKMP Vendor ID Payload
 | Vendor ID  4f 45 ab ab  ab ab ab ab  ab ab ab ab
@@ -311,30 +326,31 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 | emitting 16 raw bytes of V_ID into ISAKMP Vendor ID Payload
 | V_ID  44 85 15 2d  18 b6 bb cd  0b e8 a8 46  95 79 dd cc
 | emitting length of ISAKMP Vendor ID Payload: 20
-| emitting length of ISAKMP Message: 344
-sending 344 bytes for main_outI1 through eth0:500 [93.184.216.34:55044] to 132.213.238.7:500 (using #1)
+| emitting length of ISAKMP Message: 364
+sending 364 bytes for main_outI1 through eth0:500 [93.184.216.34:55044] to 132.213.238.7:500 (using #1)
 |   80 01 02 03  04 05 06 07  00 00 00 00  00 00 00 00
-|   01 10 02 00  00 00 00 00  00 00 01 58  0d 00 00 b4
-|   00 00 00 01  00 00 00 01  00 00 00 a8  00 01 00 05
-|   03 00 00 20  00 01 00 00  80 0b 00 01  80 0c 0e 10
-|   80 03 00 03  80 01 00 07  80 02 00 04  80 04 00 0e
-|   03 00 00 20  01 01 00 00  80 0b 00 01  80 0c 0e 10
-|   80 03 00 03  80 01 00 07  80 02 00 02  80 04 00 0e
-|   03 00 00 20  02 01 00 00  80 0b 00 01  80 0c 0e 10
-|   80 03 00 03  80 01 00 07  80 02 00 04  80 04 00 05
-|   03 00 00 20  03 01 00 00  80 0b 00 01  80 0c 0e 10
-|   80 03 00 03  80 01 00 07  80 02 00 02  80 04 00 05
-|   00 00 00 20  04 01 00 00  80 0b 00 01  80 0c 0e 10
-|   80 03 00 03  80 01 00 07  80 02 00 04  80 04 00 0f
-|   0d 00 00 10  4f 45 ab ab  ab ab ab ab  ab ab ab ab
-|   0d 00 00 14  af ca d7 13  68 a1 f1 c9  6b 86 96 fc
-|   77 57 01 00  0d 00 00 14  4a 13 1c 81  07 03 58 45
-|   5c 57 28 f2  0e 95 45 2f  0d 00 00 14  7d 94 19 a6
-|   53 10 ca 6f  2c 17 9d 92  15 52 9d 56  0d 00 00 14
-|   90 cb 80 91  3e bb 69 6e  08 63 81 b5  ec 42 7b 1f
-|   0d 00 00 14  cd 60 46 43  35 df 21 f8  7c fd b2 fc
-|   68 b6 a4 48  00 00 00 14  44 85 15 2d  18 b6 bb cd
-|   0b e8 a8 46  95 79 dd cc
+|   01 10 02 00  00 00 00 00  00 00 01 6c  0d 00 00 c8
+|   00 00 00 01  00 00 00 01  00 00 00 bc  00 01 00 05
+|   03 00 00 24  00 01 00 00  80 0b 00 01  80 0c 0e 10
+|   80 03 00 03  80 01 00 07  80 0e 00 80  80 02 00 04
+|   80 04 00 0e  03 00 00 24  01 01 00 00  80 0b 00 01
+|   80 0c 0e 10  80 03 00 03  80 01 00 07  80 0e 00 80
+|   80 02 00 02  80 04 00 0e  03 00 00 24  02 01 00 00
+|   80 0b 00 01  80 0c 0e 10  80 03 00 03  80 01 00 07
+|   80 0e 00 80  80 02 00 04  80 04 00 05  03 00 00 24
+|   03 01 00 00  80 0b 00 01  80 0c 0e 10  80 03 00 03
+|   80 01 00 07  80 0e 00 80  80 02 00 02  80 04 00 05
+|   00 00 00 24  04 01 00 00  80 0b 00 01  80 0c 0e 10
+|   80 03 00 03  80 01 00 07  80 0e 00 80  80 02 00 04
+|   80 04 00 0f  0d 00 00 10  4f 45 70 6c  75 74 6f 75
+|   6e 69 74 30  0d 00 00 14  af ca d7 13  68 a1 f1 c9
+|   6b 86 96 fc  77 57 01 00  0d 00 00 14  4a 13 1c 81
+|   07 03 58 45  5c 57 28 f2  0e 95 45 2f  0d 00 00 14
+|   7d 94 19 a6  53 10 ca 6f  2c 17 9d 92  15 52 9d 56
+|   0d 00 00 14  90 cb 80 91  3e bb 69 6e  08 63 81 b5
+|   ec 42 7b 1f  0d 00 00 14  cd 60 46 43  35 df 21 f8
+|   7c fd b2 fc  68 b6 a4 48  00 00 00 14  44 85 15 2d
+|   18 b6 bb cd  0b e8 a8 46  95 79 dd cc
 RC=105 STATE_MAIN_I1: initiate
 0: output to OUTPUT/parentM2.pcap
 |   =========== input from pcap file parentN1.pcap ========
@@ -522,8 +538,8 @@ sending 380 bytes for STATE_MAIN_I1 through eth0:500 [93.184.216.34:55044] to 13
 ./parentM2 leak: vid->data, item size: X
 ./parentM2 leak: sa in main_outI1, item size: X
 ./parentM2 leak: v1 policy proposal conj, item size: X
-./parentM2 leak: db_context->attrs (expand), item size: X
 ./parentM2 leak: db_context->trans (expand), item size: X
+./parentM2 leak: db_context->attrs (expand), item size: X
 ./parentM2 leak: db_context, item size: X
 ./parentM2 leak: db2_expand->attrs, item size: X
 ./parentM2 leak: db_context->trans (expand), item size: X

--- a/tests/unit/libpluto/lp76-parentM3/output1.txt
+++ b/tests/unit/libpluto/lp76-parentM3/output1.txt
@@ -147,6 +147,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    length/value: 7
 |     [7 is OAKLEY_AES_CBC]
 | ******emit ISAKMP Oakley attribute:
+|    af+type: OAKLEY_KEY_LENGTH
+|    length/value: 128
+| ******emit ISAKMP Oakley attribute:
 |    af+type: OAKLEY_HASH_ALGORITHM
 |    length/value: 4
 |     [4 is OAKLEY_SHA2_256]
@@ -154,7 +157,7 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    af+type: OAKLEY_GROUP_DESCRIPTION
 |    length/value: 14
 |     [14 is OAKLEY_GROUP_MODP2048]
-| emitting length of ISAKMP Transform Payload (ISAKMP): 32
+| emitting length of ISAKMP Transform Payload (ISAKMP): 36
 | *****emit ISAKMP Transform Payload (ISAKMP):
 |    transform number: 1
 |    transform ID: KEY_IKE
@@ -174,6 +177,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    length/value: 7
 |     [7 is OAKLEY_AES_CBC]
 | ******emit ISAKMP Oakley attribute:
+|    af+type: OAKLEY_KEY_LENGTH
+|    length/value: 128
+| ******emit ISAKMP Oakley attribute:
 |    af+type: OAKLEY_HASH_ALGORITHM
 |    length/value: 2
 |     [2 is OAKLEY_SHA1]
@@ -181,7 +187,7 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    af+type: OAKLEY_GROUP_DESCRIPTION
 |    length/value: 14
 |     [14 is OAKLEY_GROUP_MODP2048]
-| emitting length of ISAKMP Transform Payload (ISAKMP): 32
+| emitting length of ISAKMP Transform Payload (ISAKMP): 36
 | *****emit ISAKMP Transform Payload (ISAKMP):
 |    transform number: 2
 |    transform ID: KEY_IKE
@@ -201,6 +207,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    length/value: 7
 |     [7 is OAKLEY_AES_CBC]
 | ******emit ISAKMP Oakley attribute:
+|    af+type: OAKLEY_KEY_LENGTH
+|    length/value: 128
+| ******emit ISAKMP Oakley attribute:
 |    af+type: OAKLEY_HASH_ALGORITHM
 |    length/value: 4
 |     [4 is OAKLEY_SHA2_256]
@@ -208,7 +217,7 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    af+type: OAKLEY_GROUP_DESCRIPTION
 |    length/value: 5
 |     [5 is OAKLEY_GROUP_MODP1536]
-| emitting length of ISAKMP Transform Payload (ISAKMP): 32
+| emitting length of ISAKMP Transform Payload (ISAKMP): 36
 | *****emit ISAKMP Transform Payload (ISAKMP):
 |    transform number: 3
 |    transform ID: KEY_IKE
@@ -228,6 +237,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    length/value: 7
 |     [7 is OAKLEY_AES_CBC]
 | ******emit ISAKMP Oakley attribute:
+|    af+type: OAKLEY_KEY_LENGTH
+|    length/value: 128
+| ******emit ISAKMP Oakley attribute:
 |    af+type: OAKLEY_HASH_ALGORITHM
 |    length/value: 2
 |     [2 is OAKLEY_SHA1]
@@ -235,7 +247,7 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    af+type: OAKLEY_GROUP_DESCRIPTION
 |    length/value: 5
 |     [5 is OAKLEY_GROUP_MODP1536]
-| emitting length of ISAKMP Transform Payload (ISAKMP): 32
+| emitting length of ISAKMP Transform Payload (ISAKMP): 36
 | *****emit ISAKMP Transform Payload (ISAKMP):
 |    transform number: 4
 |    transform ID: KEY_IKE
@@ -255,6 +267,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    length/value: 7
 |     [7 is OAKLEY_AES_CBC]
 | ******emit ISAKMP Oakley attribute:
+|    af+type: OAKLEY_KEY_LENGTH
+|    length/value: 128
+| ******emit ISAKMP Oakley attribute:
 |    af+type: OAKLEY_HASH_ALGORITHM
 |    length/value: 4
 |     [4 is OAKLEY_SHA2_256]
@@ -262,9 +277,9 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 |    af+type: OAKLEY_GROUP_DESCRIPTION
 |    length/value: 15
 |     [15 is OAKLEY_GROUP_MODP3072]
-| emitting length of ISAKMP Transform Payload (ISAKMP): 32
-| emitting length of ISAKMP Proposal Payload: 168
-| emitting length of ISAKMP Security Association Payload: 180
+| emitting length of ISAKMP Transform Payload (ISAKMP): 36
+| emitting length of ISAKMP Proposal Payload: 188
+| emitting length of ISAKMP Security Association Payload: 200
 | ***emit ISAKMP Vendor ID Payload:
 | emitting 12 raw bytes of Vendor ID into ISAKMP Vendor ID Payload
 | Vendor ID  4f 45 ab ab  ab ab ab ab  ab ab ab ab
@@ -274,24 +289,25 @@ RC=0 "t4901":   policy: RSASIG+ENCRYPT+TUNNEL+PFS+SAREFTRACK; prio: 64,64; inter
 | emitting 16 raw bytes of V_ID into ISAKMP Vendor ID Payload
 | V_ID  af ca d7 13  68 a1 f1 c9  6b 86 96 fc  77 57 01 00
 | emitting length of ISAKMP Vendor ID Payload: 20
-| emitting length of ISAKMP Message: 244
-sending 244 bytes for main_outI1 through eth0:500 [93.184.216.34:55044] to 132.213.238.7:500 (using #1)
+| emitting length of ISAKMP Message: 264
+sending 264 bytes for main_outI1 through eth0:500 [93.184.216.34:55044] to 132.213.238.7:500 (using #1)
 |   80 01 02 03  04 05 06 07  00 00 00 00  00 00 00 00
-|   01 10 02 00  00 00 00 00  00 00 00 f4  0d 00 00 b4
-|   00 00 00 01  00 00 00 01  00 00 00 a8  00 01 00 05
-|   03 00 00 20  00 01 00 00  80 0b 00 01  80 0c 0e 10
-|   80 03 00 03  80 01 00 07  80 02 00 04  80 04 00 0e
-|   03 00 00 20  01 01 00 00  80 0b 00 01  80 0c 0e 10
-|   80 03 00 03  80 01 00 07  80 02 00 02  80 04 00 0e
-|   03 00 00 20  02 01 00 00  80 0b 00 01  80 0c 0e 10
-|   80 03 00 03  80 01 00 07  80 02 00 04  80 04 00 05
-|   03 00 00 20  03 01 00 00  80 0b 00 01  80 0c 0e 10
-|   80 03 00 03  80 01 00 07  80 02 00 02  80 04 00 05
-|   00 00 00 20  04 01 00 00  80 0b 00 01  80 0c 0e 10
-|   80 03 00 03  80 01 00 07  80 02 00 04  80 04 00 0f
-|   0d 00 00 10  4f 45 ab ab  ab ab ab ab  ab ab ab ab
-|   00 00 00 14  af ca d7 13  68 a1 f1 c9  6b 86 96 fc
-|   77 57 01 00
+|   01 10 02 00  00 00 00 00  00 00 01 08  0d 00 00 c8
+|   00 00 00 01  00 00 00 01  00 00 00 bc  00 01 00 05
+|   03 00 00 24  00 01 00 00  80 0b 00 01  80 0c 0e 10
+|   80 03 00 03  80 01 00 07  80 0e 00 80  80 02 00 04
+|   80 04 00 0e  03 00 00 24  01 01 00 00  80 0b 00 01
+|   80 0c 0e 10  80 03 00 03  80 01 00 07  80 0e 00 80
+|   80 02 00 02  80 04 00 0e  03 00 00 24  02 01 00 00
+|   80 0b 00 01  80 0c 0e 10  80 03 00 03  80 01 00 07
+|   80 0e 00 80  80 02 00 04  80 04 00 05  03 00 00 24
+|   03 01 00 00  80 0b 00 01  80 0c 0e 10  80 03 00 03
+|   80 01 00 07  80 0e 00 80  80 02 00 02  80 04 00 05
+|   00 00 00 24  04 01 00 00  80 0b 00 01  80 0c 0e 10
+|   80 03 00 03  80 01 00 07  80 0e 00 80  80 02 00 04
+|   80 04 00 0f  0d 00 00 10  4f 45 70 6c  75 74 6f 75
+|   6e 69 74 30  00 00 00 14  af ca d7 13  68 a1 f1 c9
+|   6b 86 96 fc  77 57 01 00
 RC=105 STATE_MAIN_I1: initiate
 0: input from parentN1.pcap
 |   =========== input from pcap file parentN1.pcap ========
@@ -537,7 +553,7 @@ picking: eth0:500  outside: 55044 <=> d: 55044
 | my identity  62 65 72 72  69 2e 74 65  73 74 69 6e  67 2e 78 65
 |   6c 65 72 61  6e 63 65 2e  63 6f 6d
 | emitting length of ISAKMP Identification Payload (IPsec DOI): 35
-| hashing 176 bytes of SA
+| hashing 196 bytes of SA
 | started looking for secret for @berri.testing.xelerance.com->132.213.238.7 of kind PPK_RSA
 | actually looking for secret for @berri.testing.xelerance.com->132.213.238.7 of kind PPK_RSA
 | line 1: key type PPK_RSA(@berri.testing.xelerance.com) to type PPK_RSA
@@ -550,49 +566,49 @@ picking: eth0:500  outside: 55044 <=> d: 55044
 | signing hash with RSA Key *AQN7wUerV
 | ***emit ISAKMP Signature Payload:
 | emitting 256 raw bytes of SIG_I into ISAKMP Signature Payload
-| SIG_I  19 07 35 1e  63 37 08 9e  ce e3 7e 16  9b 63 5b f5
-|   3b 11 d3 c1  b8 72 85 d1  07 58 a4 d2  27 45 91 10
-|   49 62 03 24  c0 61 09 ec  a3 66 76 d7  df 96 a0 8d
-|   dd 08 ad 49  79 83 2c 84  37 93 4a 4b  70 94 bb 80
-|   2b db 36 4f  88 4e c9 66  da 80 38 7e  31 23 32 16
-|   12 66 05 bd  77 a2 a6 3a  0f 14 9c 63  d3 d8 9f b2
-|   0a 88 59 3d  76 96 82 88  0a 19 0a d6  fe 90 3d 80
-|   89 2a fc e5  6e 2a 48 c9  d3 61 fb 85  fc 59 95 b7
-|   c5 10 18 c4  cc 02 e7 3d  06 b4 4e 0a  40 5c 3a a9
-|   27 cf 2e 1e  fc 5e 3a e0  92 ef 7d 34  04 0b bb d9
-|   93 c0 97 54  c8 99 8d a8  6f d2 ad b4  a6 f8 ca 0a
-|   d7 53 ad da  72 f6 26 d1  ad 6b 88 1d  43 ae ef 49
-|   dc 81 9c 76  16 94 3c e9  d7 d4 01 47  e8 ba e8 4e
-|   4b c3 31 4e  55 2d b8 fe  3a db d2 91  de 24 17 58
-|   82 db 48 68  0e 13 4d 61  1f d2 04 3a  e6 10 e3 c1
-|   5e b5 ec 2d  48 36 c2 21  3f e9 db cb  a3 66 d2 73
+| SIG_I  6e b9 cd e0  41 5e d3 51  17 f6 b7 6b  11 1e 41 41
+|   0e aa 5d 23  7f ff 37 a9  3e 0b 99 eb  d8 29 82 be
+|   af fc df 88  d7 be 9d 19  a5 80 ee 60  8e 1a 92 7c
+|   f9 12 ad cf  04 3f 6d 72  d2 c7 d5 6b  e8 4a 4a d7
+|   b9 61 05 36  1a 64 f2 28  d0 e6 c5 57  52 fe 60 d1
+|   68 11 f1 43  0f fb 68 01  ef 88 02 4d  e3 a9 13 d5
+|   de 5f 6a b9  88 26 bd b1  a0 36 0e 49  26 aa 66 11
+|   67 45 81 b3  89 83 92 55  9e e7 96 b1  de b5 c0 66
+|   18 1e 23 98  15 92 79 bf  eb 84 c4 8e  35 39 6e 29
+|   24 df e1 a1  92 65 af f5  f6 56 37 f4  45 1c 4f bf
+|   17 a1 78 98  43 be 6e 5d  eb 33 10 bb  90 ad ac b9
+|   ca 23 f3 5d  8f a8 9d 6e  3f 85 fe 31  40 7d f0 62
+|   5a e3 39 76  36 d5 b4 a4  65 0c 8b de  32 74 c8 4a
+|   6d 07 e9 59  6c 0a 74 af  80 6d 5b 5f  42 cc 90 8c
+|   d6 ad e4 38  b6 4b 97 95  79 34 0d 22  f7 c2 c5 b0
+|   38 78 0e aa  f5 44 b5 4e  26 04 61 46  66 1a cb f4
 | emitting length of ISAKMP Signature Payload: 260
 | encrypting:
 |   09 00 00 23  02 00 00 00  62 65 72 72  69 2e 74 65
 |   73 74 69 6e  67 2e 78 65  6c 65 72 61  6e 63 65 2e
-|   63 6f 6d 00  00 01 04 19  07 35 1e 63  37 08 9e ce
-|   e3 7e 16 9b  63 5b f5 3b  11 d3 c1 b8  72 85 d1 07
-|   58 a4 d2 27  45 91 10 49  62 03 24 c0  61 09 ec a3
-|   66 76 d7 df  96 a0 8d dd  08 ad 49 79  83 2c 84 37
-|   93 4a 4b 70  94 bb 80 2b  db 36 4f 88  4e c9 66 da
-|   80 38 7e 31  23 32 16 12  66 05 bd 77  a2 a6 3a 0f
-|   14 9c 63 d3  d8 9f b2 0a  88 59 3d 76  96 82 88 0a
-|   19 0a d6 fe  90 3d 80 89  2a fc e5 6e  2a 48 c9 d3
-|   61 fb 85 fc  59 95 b7 c5  10 18 c4 cc  02 e7 3d 06
-|   b4 4e 0a 40  5c 3a a9 27  cf 2e 1e fc  5e 3a e0 92
-|   ef 7d 34 04  0b bb d9 93  c0 97 54 c8  99 8d a8 6f
-|   d2 ad b4 a6  f8 ca 0a d7  53 ad da 72  f6 26 d1 ad
-|   6b 88 1d 43  ae ef 49 dc  81 9c 76 16  94 3c e9 d7
-|   d4 01 47 e8  ba e8 4e 4b  c3 31 4e 55  2d b8 fe 3a
-|   db d2 91 de  24 17 58 82  db 48 68 0e  13 4d 61 1f
-|   d2 04 3a e6  10 e3 c1 5e  b5 ec 2d 48  36 c2 21 3f
-|   e9 db cb a3  66 d2 73
+|   63 6f 6d 00  00 01 04 6e  b9 cd e0 41  5e d3 51 17
+|   f6 b7 6b 11  1e 41 41 0e  aa 5d 23 7f  ff 37 a9 3e
+|   0b 99 eb d8  29 82 be af  fc df 88 d7  be 9d 19 a5
+|   80 ee 60 8e  1a 92 7c f9  12 ad cf 04  3f 6d 72 d2
+|   c7 d5 6b e8  4a 4a d7 b9  61 05 36 1a  64 f2 28 d0
+|   e6 c5 57 52  fe 60 d1 68  11 f1 43 0f  fb 68 01 ef
+|   88 02 4d e3  a9 13 d5 de  5f 6a b9 88  26 bd b1 a0
+|   36 0e 49 26  aa 66 11 67  45 81 b3 89  83 92 55 9e
+|   e7 96 b1 de  b5 c0 66 18  1e 23 98 15  92 79 bf eb
+|   84 c4 8e 35  39 6e 29 24  df e1 a1 92  65 af f5 f6
+|   56 37 f4 45  1c 4f bf 17  a1 78 98 43  be 6e 5d eb
+|   33 10 bb 90  ad ac b9 ca  23 f3 5d 8f  a8 9d 6e 3f
+|   85 fe 31 40  7d f0 62 5a  e3 39 76 36  d5 b4 a4 65
+|   0c 8b de 32  74 c8 4a 6d  07 e9 59 6c  0a 74 af 80
+|   6d 5b 5f 42  cc 90 8c d6  ad e4 38 b6  4b 97 95 79
+|   34 0d 22 f7  c2 c5 b0 38  78 0e aa f5  44 b5 4e 26
+|   04 61 46 66  1a cb f4
 | IV:
 |   bc d5 89 68  0c 42 2e cd  14 72 ae a3  97 42 67 41
 | unpadded size is: 295
 | emitting 9 zero bytes of encryption padding into ISAKMP Message
 | encrypting 304 using OAKLEY_AES_CBC
-| next IV:  d3 a8 5b e3  27 7e 28 f2  f6 99 ad d4  f2 8f 8b 82
+| next IV:  49 83 08 b4  f4 54 d2 9e  5a 08 7a 30  27 5b 13 a6
 | emitting length of ISAKMP Message: 332
 | complete state transition with STF_OK
 ./parentM3 transition from state STATE_MAIN_I2 to state STATE_MAIN_I3
@@ -601,24 +617,24 @@ sending 332 bytes for STATE_MAIN_I2 through eth0:500 [93.184.216.34:55044] to 13
 |   80 01 02 03  04 05 06 07  de bc 58 3a  8f 40 d0 cf
 |   05 10 02 01  00 00 00 00  00 00 01 4c  a7 8f 70 19
 |   92 e2 f9 56  9a 8b 57 a6  63 2d 10 a8  7e 45 6f d7
-|   fd 5e cb ee  29 1a c8 f8  e8 3a d5 f4  cb c4 c4 8b
-|   86 47 27 df  0b 0f 21 43  46 41 de 76  92 41 99 91
-|   55 97 4a 2f  d7 37 57 38  25 9a 21 01  82 b1 7b 86
-|   2f 27 88 81  20 fd fa 5f  4a 7a ee df  ea e9 4d 7b
-|   51 10 22 60  eb 25 9b bc  40 90 44 ea  01 17 db 98
-|   2e 10 3f 2b  6f 6d 21 2b  0f da 07 e1  41 61 57 33
-|   31 a4 a3 3e  32 0a 78 3b  4d f6 38 8d  86 4a 3c c3
-|   e5 1f 66 79  fd 65 11 f2  be 2a 0b ac  75 af 16 a5
-|   a2 21 3f 2d  b4 a5 5e dc  de cd 79 4f  49 73 40 74
-|   88 7d d3 56  35 94 f2 17  39 5c 54 d8  8e 25 11 a7
-|   b3 f1 94 79  22 f0 a3 24  5b 69 df 56  77 07 9d c7
-|   a0 36 4b bc  ac 01 ce 03  63 6e 07 2a  1e f9 f3 77
-|   a6 49 a2 3e  3e 67 2e dc  49 38 7d 46  31 64 9e 17
-|   9e 06 15 d2  dd 5c f9 38  00 0a f6 bb  4d 86 04 ef
-|   88 4c 38 e9  4f af 44 68  7c 0f 36 4b  33 17 e2 09
-|   56 8e 05 31  93 96 2b 7d  e6 e3 97 92  eb 11 d4 3d
-|   c0 b3 cc 18  d1 f2 ca d0  07 a0 71 71  d3 a8 5b e3
-|   27 7e 28 f2  f6 99 ad d4  f2 8f 8b 82
+|   fd 5e cb ee  29 1a c8 f8  e8 3a d5 f4  8b d1 17 3c
+|   0a d1 18 60  07 74 50 0b  69 25 0a 37  8a ed c3 55
+|   72 57 ef 15  63 94 15 f1  99 ef b7 b6  dc 81 95 c5
+|   d3 d9 0e ee  13 18 a7 c5  f4 fb 45 e8  d8 18 39 ba
+|   32 95 14 a9  2f a8 7d b2  cd 99 9e 49  92 37 a6 cc
+|   5e c1 0a 05  2c 5d fa 03  41 87 8e 0d  42 41 7a e3
+|   82 a6 75 df  d2 39 9a 63  24 7c da 1c  74 d0 39 25
+|   12 c6 46 5c  43 7a b1 88  55 50 4a 90  69 45 8e c7
+|   ce 84 92 1a  e0 65 99 d6  ed 0e 8f 5e  c7 61 7d 70
+|   13 f8 a4 5c  02 5b ea 6d  5e 4d 73 c8  11 af c7 26
+|   0f bd e1 b6  28 c7 ac 01  e9 ab ee 68  01 69 e5 c5
+|   bd dc ec fd  f0 f1 51 01  28 a7 72 94  58 fe a0 22
+|   03 91 ca 10  a8 d6 e4 eb  ce ce c7 97  bc e1 84 a3
+|   c2 bb 7f 39  0e fa 2b 47  54 b1 c7 08  85 21 38 1b
+|   b6 80 8a fd  e8 e2 d9 28  67 23 5a 1b  e1 bf 1c b9
+|   55 a1 06 d2  90 f1 09 e1  19 33 df 41  27 1b f1 94
+|   16 9b e9 5d  20 4d 27 65  46 39 2c 49  49 83 08 b4
+|   f4 54 d2 9e  5a 08 7a 30  27 5b 13 a6
 ./parentM3 STATE_MAIN_I3: sent MI3, expecting MR3
 | modecfg pull: noquirk policy:push not-client
 | phase 1 is done, looking for phase 2 to unpend
@@ -661,8 +677,8 @@ RC=0 #1: "t4901":500 IKEv1.0 STATE_MAIN_I3 (sent MI3, expecting MR3); none in -1
 ./parentM3 leak: vid->data, item size: X
 ./parentM3 leak: sa in main_outI1, item size: X
 ./parentM3 leak: v1 policy proposal conj, item size: X
-./parentM3 leak: db_context->attrs (expand), item size: X
 ./parentM3 leak: db_context->trans (expand), item size: X
+./parentM3 leak: db_context->attrs (expand), item size: X
 ./parentM3 leak: db_context, item size: X
 ./parentM3 leak: db2_expand->attrs, item size: X
 ./parentM3 leak: db_context->trans (expand), item size: X

--- a/tests/unit/libpluto/lp92-v1sha512M1/I1-dump.txt
+++ b/tests/unit/libpluto/lp92-v1sha512M1/I1-dump.txt
@@ -1,8 +1,8 @@
-IP (tos 0x0, ttl 64, id 0, offset 0, flags [none], proto UDP (17), length 244, bad cksum 0 (->8375)!)
+IP (tos 0x0, ttl 64, id 0, offset 0, flags [none], proto UDP (17), length 248, bad cksum 0 (->8371)!)
     93.184.216.34.55044 > 192.168.0.1.500: isakmp 1.0 msgid 00000000: phase 1 I ident:
     (sa: doi=ipsec situation=identity
         (p: #0 protoid=isakmp transform=1
-            (t: #0 id=ike (type=lifetype value=sec)(type=lifeduration value=0e10)(type=auth value=rsa sig)(type=enc value=aes)(type=hash value=sha2-512)(type=group desc value=modp4096))))
+            (t: #0 id=ike (type=lifetype value=sec)(type=lifeduration value=0e10)(type=auth value=rsa sig)(type=enc value=aes)(type=keylen value=0100)(type=hash value=sha2-512)(type=group desc value=modp4096))))
     (vid: len=12)
     (vid: len=16)
     (vid: len=16)

--- a/tests/unit/libpluto/lp92-v1sha512M1/output1.txt
+++ b/tests/unit/libpluto/lp92-v1sha512M1/output1.txt
@@ -113,6 +113,9 @@ RC=0 "home512":   ESP algorithms loaded: 3des(3)_192-hmac_md5_96(1)_128
 |    length/value: 7
 |     [7 is OAKLEY_AES_CBC]
 | ******emit ISAKMP Oakley attribute:
+|    af+type: OAKLEY_KEY_LENGTH
+|    length/value: 256
+| ******emit ISAKMP Oakley attribute:
 |    af+type: OAKLEY_HASH_ALGORITHM
 |    length/value: 6
 |     [6 is OAKLEY_SHA2_512]
@@ -120,9 +123,9 @@ RC=0 "home512":   ESP algorithms loaded: 3des(3)_192-hmac_md5_96(1)_128
 |    af+type: OAKLEY_GROUP_DESCRIPTION
 |    length/value: 16
 |     [16 is OAKLEY_GROUP_MODP4096]
-| emitting length of ISAKMP Transform Payload (ISAKMP): 32
-| emitting length of ISAKMP Proposal Payload: 40
-| emitting length of ISAKMP Security Association Payload: 52
+| emitting length of ISAKMP Transform Payload (ISAKMP): 36
+| emitting length of ISAKMP Proposal Payload: 44
+| emitting length of ISAKMP Security Association Payload: 56
 | ***emit ISAKMP Vendor ID Payload:
 | emitting 12 raw bytes of Vendor ID into ISAKMP Vendor ID Payload
 | Vendor ID  4f 45 ab ab  ab ab ab ab  ab ab ab ab
@@ -157,22 +160,22 @@ RC=0 "home512":   ESP algorithms loaded: 3des(3)_192-hmac_md5_96(1)_128
 | emitting 16 raw bytes of V_ID into ISAKMP Vendor ID Payload
 | V_ID  44 85 15 2d  18 b6 bb cd  0b e8 a8 46  95 79 dd cc
 | emitting length of ISAKMP Vendor ID Payload: 20
-| emitting length of ISAKMP Message: 216
-sending 216 bytes for main_outI1 through eth0:500 [93.184.216.34:55044] to 192.168.0.1:500 (using #1)
+| emitting length of ISAKMP Message: 220
+sending 220 bytes for main_outI1 through eth0:500 [93.184.216.34:55044] to 192.168.0.1:500 (using #1)
 |   80 01 02 03  04 05 06 07  00 00 00 00  00 00 00 00
-|   01 10 02 00  00 00 00 00  00 00 00 d8  0d 00 00 34
-|   00 00 00 01  00 00 00 01  00 00 00 28  00 01 00 01
-|   00 00 00 20  00 01 00 00  80 0b 00 01  80 0c 0e 10
-|   80 03 00 03  80 01 00 07  80 02 00 06  80 04 00 10
-|   0d 00 00 10  4f 45 ab ab  ab ab ab ab  ab ab ab ab
-|   0d 00 00 14  af ca d7 13  68 a1 f1 c9  6b 86 96 fc
-|   77 57 01 00  0d 00 00 14  4a 13 1c 81  07 03 58 45
-|   5c 57 28 f2  0e 95 45 2f  0d 00 00 14  7d 94 19 a6
-|   53 10 ca 6f  2c 17 9d 92  15 52 9d 56  0d 00 00 14
-|   90 cb 80 91  3e bb 69 6e  08 63 81 b5  ec 42 7b 1f
-|   0d 00 00 14  cd 60 46 43  35 df 21 f8  7c fd b2 fc
-|   68 b6 a4 48  00 00 00 14  44 85 15 2d  18 b6 bb cd
-|   0b e8 a8 46  95 79 dd cc
+|   01 10 02 00  00 00 00 00  00 00 00 dc  0d 00 00 38
+|   00 00 00 01  00 00 00 01  00 00 00 2c  00 01 00 01
+|   00 00 00 24  00 01 00 00  80 0b 00 01  80 0c 0e 10
+|   80 03 00 03  80 01 00 07  80 0e 01 00  80 02 00 06
+|   80 04 00 10  0d 00 00 10  4f 45 70 6c  75 74 6f 75
+|   6e 69 74 30  0d 00 00 14  af ca d7 13  68 a1 f1 c9
+|   6b 86 96 fc  77 57 01 00  0d 00 00 14  4a 13 1c 81
+|   07 03 58 45  5c 57 28 f2  0e 95 45 2f  0d 00 00 14
+|   7d 94 19 a6  53 10 ca 6f  2c 17 9d 92  15 52 9d 56
+|   0d 00 00 14  90 cb 80 91  3e bb 69 6e  08 63 81 b5
+|   ec 42 7b 1f  0d 00 00 14  cd 60 46 43  35 df 21 f8
+|   7c fd b2 fc  68 b6 a4 48  00 00 00 14  44 85 15 2d
+|   18 b6 bb cd  0b e8 a8 46  95 79 dd cc
 RC=105 STATE_MAIN_I1: initiate
 ./v1sha512M1 deleting state #1 (STATE_MAIN_I1)
 | removing state object #1


### PR DESCRIPTION
This fixes AES256 IKE proposals (wo#10876), IKEv1 auth ID mapping (wo#10844) and restores the NULL cipher (wo#10850)