### PR TITLE
Add check null pointer of parent structure.

### DIFF
--- a/programs/pluto/ikev1_quick.c
+++ b/programs/pluto/ikev1_quick.c
@@ -2631,6 +2631,9 @@ quick_inR1_outI2_cryptotail(struct dh_continuation *dh
    /* Derive new keying material */
     compute_keymats(st);
 
+    if (md->pst == NULL)
+	return STF_INTERNAL_ERROR;
+
     /* Tell the kernel to establish the inbound, outbound, and routing part
      * of the new SA (unless the commit bit is set -- which we don't support).
      * We do this before any state updating so that


### PR DESCRIPTION
We have segfault in setup_half_ipsec_sa if parent st is NULL.
Core was generated by `/usr/local/libexec/ipsec/pluto --nofork --secretsfile /etc/ipsec.secrets --ipse'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  setup_half_ipsec_sa (parent_st=parent_st@entry=0x0, st=st@entry=0x55bfdfa00050, sr=sr@entry=0x7ffeaece2d30, inbound=inbound@entry=1) at /usr/src/staging/openswan-2.6.52.3/programs/pluto/kernel.c:1718
1718	    const char *inbound_str = inbound ? "inbound" : "outbound";
(gdb) bt
#0  setup_half_ipsec_sa (parent_st=parent_st@entry=0x0, st=st@entry=0x55bfdfa00050, sr=sr@entry=0x7ffeaece2d30, inbound=inbound@entry=1) at /usr/src/staging/openswan-2.6.52.3/programs/pluto/kernel.c:1718
#1  0x000055bfdf7591a8 in install_ipsec_sa (parent_st=0x0, st=st@entry=0x55bfdfa00050, inbound_also=inbound_also@entry=1) at /usr/src/staging/openswan-2.6.52.3/programs/pluto/kernel.c:3020
#2  0x000055bfdf73e6a7 in quick_inR1_outI2_cryptotail (r=r@entry=0x7ffeaece31e0, dh=<optimized out>) at /usr/src/staging/openswan-2.6.52.3/programs/pluto/ikev1_quick.c:2639
#3  0x000055bfdf73e96e in quick_inR1_outI2_continue (pcrc=0x55bfdf9c9df0, r=0x7ffeaece31e0, ugh=0x0) at /usr/src/staging/openswan-2.6.52.3/programs/pluto/ikev1_quick.c:2472
#4  0x000055bfdf769d2f in handle_helper_comm (w=w@entry=0x55bfdf999440) at /usr/src/staging/openswan-2.6.52.3/programs/pluto/pluto_crypt.c:827
#5  0x000055bfdf76ab3b in pluto_crypto_helper_ready (readfds=readfds@entry=0x7ffeaece4890) at /usr/src/staging/openswan-2.6.52.3/programs/pluto/pluto_crypt.c:1101
#6  0x000055bfdf72c9e9 in call_server () at /usr/src/staging/openswan-2.6.52.3/programs/pluto/server.c:798
#7  0x000055bfdf716faf in main (argc=<optimized out>, argv=<optimized out>) at /usr/src/staging/openswan-2.6.52.3/programs/pluto/plutomain.c:1134

(gdb) frame 0
(gdb) p parent_st
$17 = (struct state *) 0x0

(gdb) frame 1
#1  0x000055bfdf7591a8 in install_ipsec_sa (parent_st=0x0, st=st@entry=0x55bfdfa00050, inbound_also=inbound_also@entry=1) at /usr/src/staging/openswan-2.6.52.3/programs/pluto/kernel.c:3020
3020		if(!setup_half_ipsec_sa(parent_st, st, sr, TRUE)) {

(gdb) p parent_st
$3 = (struct state *) 0x0

(gdb) frame 2
#2  0x000055bfdf73e6a7 in quick_inR1_outI2_cryptotail (r=r@entry=0x7ffeaece31e0, dh=<optimized out>) at /usr/src/staging/openswan-2.6.52.3/programs/pluto/ikev1_quick.c:2639
2639	    if (!install_ipsec_sa(md->pst, st, TRUE))
(gdb) p md->pst
$18 = (struct state *) 0x0
