### PR TITLE
Pass the correct arguments to _startnetkey if klips fails

### DIFF
--- a/programs/_startklips/_startklips.in
+++ b/programs/_startklips/_startklips.in
@@ -17,6 +17,7 @@
 test $IPSEC_INIT_SCRIPT_DEBUG && set -v -x
 
 me='ipsec _startklips'		# for messages
+orig_args=$@
 
 # KLIPS-related paths
 sysflags=/proc/sys/net/ipsec
@@ -372,7 +373,7 @@ then
 		exit 1
 	else
 		echo "NETKEY support found. Use protostack=netkey in /etc/ipsec.conf to avoid attempts to use KLIPS. Attempting to continue with NETKEY"
-		exec ipsec _startnetkey
+		exec ipsec _startnetkey $orig_args
 	fi
 fi
 


### PR DESCRIPTION
I'd say this was broken for the majority of users, and made a few features like left=%defaultroute not work.
With a modularized kernel the default is still to attempt klips first.  Falling back to netkey failed to pass along the correct arguments to _startnetkey that create the contents of /var/run/pluto/ipsec.info

I've opened another bug suggestion to switch the default ipsec stack to netkey.