### PR TITLE
Fix test link errors on gcc10

### DIFF
--- a/include/pluto/ike_alg.h
+++ b/include/pluto/ike_alg.h
@@ -10,8 +10,8 @@ struct ike_alg {
     const char *name;
     const char *officname;
     enum ikev2_trans_type algo_type;
-    u_int16_t                  ikev1_algo_id;  /* IKEv1 number */
-    enum ikev2_trans_type_encr algo_v2id;
+    u_int16_t ikev1_algo_id;  /* IKEv1 number */
+    unsigned algo_v2id;
     struct ike_alg *algo_next;
 };
 
@@ -115,7 +115,7 @@ int ike_alg_register_enc(struct ike_encr_desc *e);
 int ike_alg_register_integ(struct ike_integ_desc *a);
 int ike_alg_register_prf(struct ike_prf_desc *a);
 struct ike_alg *ike_alg_ikev2_find(enum ikev2_trans_type algo_type
-				   , enum ikev2_trans_type_encr algo_v2id
+				   , unsigned algo_v2id
 				   , unsigned keysize);
 
 static __inline__ struct ike_encr_desc *ike_alg_get_encr(int alg)

--- a/lib/libcrypto/liboswcrypto/xfrm_plugin.c
+++ b/lib/libcrypto/liboswcrypto/xfrm_plugin.c
@@ -282,7 +282,7 @@ ike_alg_ikev1_find(enum ikev2_trans_type algo_type
  */
 struct ike_alg *
 ike_alg_ikev2_find(enum ikev2_trans_type algo_type
-		   , enum ikev2_trans_type_encr algo_v2id
+		   , unsigned algo_v2id
 		   , unsigned keysize __attribute__((unused)))
 {
 	struct ike_alg *e=ike_alg_base[algo_type];

--- a/programs/pluto/spdb_v1_struct.c
+++ b/programs/pluto/spdb_v1_struct.c
@@ -1747,7 +1747,7 @@ init_am_st_oakley(struct state *st, lset_t policy)
 
     passert(hash->type.oakley == OAKLEY_HASH_ALGORITHM);
     ta.prf_hash = hash->val;               /* OAKLEY_HASH_ALGORITHM */
-    ta.prf_hasher = crypto_get_hasher(ta.prf_hash);
+    ta.prf_hasher = crypto_get_hasher((enum ikev2_trans_type_integ)ta.prf_hash);
     passert(ta.prf_hasher != NULL);
 
     passert(auth->type.oakley == OAKLEY_AUTHENTICATION_METHOD);

--- a/tests/unit/libalgoparse/ap06-algo2ikev2/Makefile
+++ b/tests/unit/libalgoparse/ap06-algo2ikev2/Makefile
@@ -35,6 +35,9 @@ TESTNUMBER=ap06-algo2ikev2
 TESTNAME=algo2ikev2
 UNITTESTARGS=
 
+EF_DISABLE_BANNER=1
+export EF_DISABLE_BANNER
+
 programs ${TESTNAME}: ${TESTNAME}.c
 	@mkdir -p OUTPUT
 	@echo CC ${TESTNAME}.c

--- a/tests/unit/libalgoparse/ap06-algo2ikev2/output.txt
+++ b/tests/unit/libalgoparse/ap06-algo2ikev2/output.txt
@@ -1,5 +1,3 @@
-
-  Electric Fence 2.2 Copyright (C) 1987-1999 Bruce Perens <bruce@perens.com>
 ike_alg_register_enc(): Activating OAKLEY_AES_CBC: Ok (ret=0)
 ike_alg_register_hash(): Activating OAKLEY_SHA2_512: Ok (ret=0)
 ike_alg_register_prf(): Activating prf-hmac-sha2-512: Ok (ret=0)

--- a/tests/unit/libpluto/lp02-parentI1/Makefile
+++ b/tests/unit/libpluto/lp02-parentI1/Makefile
@@ -53,7 +53,7 @@ programs ${TESTNAME}: ${TESTNAME}.c ${EXTRAOBJS} ../seam_*.c
 check:	${WHACKFILE} OUTPUT ${EXTRAOBJS} ${TESTNAME}
 	ulimit -c unlimited && ./${TESTNAME} ${UNITTEST1ARGS} >OUTPUT/${TESTNAME}.txt 2>&1
 	@${FILTERS} OUTPUT/${TESTNAME}.txt | diff - output1.txt
-	@tcpdump -n -t -v -r OUTPUT/${TESTNAME}.pcap | tee OUTPUT/I1-dump.txt | sed -f ${TESTUTILS}/sanity.sed | diff - I1-dump.txt
+	@tcpdump -nn -t -v -r OUTPUT/${TESTNAME}.pcap | tee OUTPUT/I1-dump.txt | sed -f ${TESTUTILS}/sanity.sed | diff -u - I1-dump.txt
 
 ${TESTNAME}.E:
 	@${CC} -E -c -g -o ${TESTNAME}.E -O0 ${TESTNAME}.c ${EXTRAFLAGS}

--- a/tests/unit/libpluto/lp02-parentI1/parentI1_head.c
+++ b/tests/unit/libpluto/lp02-parentI1/parentI1_head.c
@@ -27,10 +27,7 @@
 #include "seam_natt.c"
 #include "seam_kernelalgs.c"
 
-u_int8_t reply_buffer[MAX_OUTPUT_UDP_SIZE];
-
-
- /*
+/*
  * Local Variables:
  * c-style: pluto
  * c-basic-offset: 4

--- a/tests/unit/libpluto/lp07-orient/orienttest_head.c
+++ b/tests/unit/libpluto/lp07-orient/orienttest_head.c
@@ -35,6 +35,7 @@
 #include "seam_dnskey.c"
 #include "seam_natt.c"
 #include "seam_rsasig.c"
+#include "seam_io.c"
 
 #include "seam_gi_sha1.c"
 #include "seam_finish.c"

--- a/tests/unit/libpluto/lp08-parentR1/Makefile
+++ b/tests/unit/libpluto/lp08-parentR1/Makefile
@@ -53,7 +53,7 @@ OUTPUT/R1-dump.txt:	${WHACKFILE} ${TESTNAME}
 	@echo "set args "${UNITTEST1ARGS} >>.gdb1init
 	ulimit -c unlimited && ./${TESTNAME} ${UNITTEST1ARGS} >OUTPUT/${TESTNAME}_1.txt 2>&1
 	@${FILTERS} OUTPUT/${TESTNAME}_1.txt | diff - output1.txt
-	@tcpdump -n -t -v -r OUTPUT/${TESTNAME}.pcap | tee OUTPUT/R1-dump.txt | sed -f ${TESTUTILS}/sanity.sed | diff - R1-dump.txt
+	@tcpdump -nn -t -v -r OUTPUT/${TESTNAME}.pcap | tee OUTPUT/R1-dump.txt | sed -f ${TESTUTILS}/sanity.sed | diff - R1-dump.txt
 
 ${WHACKFILE}: ${SAMPLEDIR}/${ENDNAME}.conf OUTPUT
 	${READWRITE} --rootdir=${SAMPLEDIR}/${ENDNAME} --config ${SAMPLEDIR}/${ENDNAME}.conf --whackout=${WHACKFILE} ${CONNNAME}

--- a/tests/unit/libpluto/lp08-parentR1/parentR1_main.c
+++ b/tests/unit/libpluto/lp08-parentR1/parentR1_main.c
@@ -1,4 +1,3 @@
-u_int8_t reply_buffer[MAX_OUTPUT_UDP_SIZE];
 
 #include <pcap.h>
 

--- a/tests/unit/libpluto/lp10-parentI2/Makefile
+++ b/tests/unit/libpluto/lp10-parentI2/Makefile
@@ -59,7 +59,7 @@ OUTPUT/I2-dump.txt:	${WHACKFILE} ${TESTNAME}
 	@echo "set args "${UNITTEST1ARGS} >>.gdb1init
 	ulimit -c unlimited && ./${TESTNAME} ${UNITTEST1ARGS} >OUTPUT/${TESTNAME}_1.txt 2>&1
 	@${FILTERS} OUTPUT/${TESTNAME}_1.txt | diff - output1.txt
-	tcpdump -n -t -v -r OUTPUT/${TESTNAME}.pcap | tee OUTPUT/I2-dump.txt | sed -f ${TESTUTILS}/sanity.sed | diff - I2-dump.txt
+	tcpdump -nn -t -v -r OUTPUT/${TESTNAME}.pcap | tee OUTPUT/I2-dump.txt | sed -f ${TESTUTILS}/sanity.sed | diff - I2-dump.txt
 
 ${WHACKFILE}:
 	@mkdir -p OUTPUT

--- a/tests/unit/libpluto/lp10-parentI2/parentI2_head.c
+++ b/tests/unit/libpluto/lp10-parentI2/parentI2_head.c
@@ -29,7 +29,6 @@
 #include "seam_kernelalgs.c"
 #include "seam_exitlog.c"
 
-u_int8_t reply_buffer[MAX_OUTPUT_UDP_SIZE];
 #ifndef SAMPLEDIR
 #define SAMPLEDIR "../samples/"
 #endif

--- a/tests/unit/libpluto/lp11-parentI2dup/Makefile
+++ b/tests/unit/libpluto/lp11-parentI2dup/Makefile
@@ -46,7 +46,7 @@ OUTPUT/I2-dump.txt:	${WHACKFILE} ${TESTNAME}
 	@echo "set args "${UNITTEST1ARGS} >>.gdb1init
 	ulimit -c unlimited && ./${TESTNAME} ${UNITTEST1ARGS} >OUTPUT/${TESTNAME}_1.txt 2>&1
 	@sed -f ${TESTUTILS}/leak-detective.sed -f ${TESTUTILS}/whack-processing.sed OUTPUT/${TESTNAME}_1.txt | diff - output1.txt
-	tcpdump -n -t -v -r OUTPUT/parentI2.pcap | tee OUTPUT/I2-dump.txt | sed -f ${TESTUTILS}/sanity.sed | diff - I2-dump.txt
+	tcpdump -nn -t -v -r OUTPUT/parentI2.pcap | tee OUTPUT/I2-dump.txt | sed -f ${TESTUTILS}/sanity.sed | diff - I2-dump.txt
 
 ${WHACKFILE}:
 	@mkdir -p OUTPUT

--- a/tests/unit/libpluto/lp11-parentI2dup/parentI2duplicate.c
+++ b/tests/unit/libpluto/lp11-parentI2dup/parentI2duplicate.c
@@ -32,8 +32,6 @@
 
 #include "seam_rsasig.c"
 
-u_int8_t reply_buffer[MAX_OUTPUT_UDP_SIZE];
-
 #include "seam_gi_sha256_group14.c"
 #include "seam_finish.c"
 

--- a/tests/unit/libpluto/lp117-childanypolicy/Makefile
+++ b/tests/unit/libpluto/lp117-childanypolicy/Makefile
@@ -46,7 +46,7 @@ OUTPUT/R2-dump.txt:	${WHACKFILE} ${TESTNAME}
 	@echo "file ${TESTNAME}"          >.gdb1init
 	@echo "set args "${UNITTEST1ARGS} >>.gdb1init
 	ulimit -c unlimited && ./${TESTNAME} ${UNITTEST1ARGS} >OUTPUT/${TESTNAME}_1.txt 2>&1
-	tcpdump -n -t -v -r ${UNITTEST1PCAP} | tee OUTPUT/R2-dump.txt | sed -f ${TESTUTILS}/sanity.sed | diff - R2-dump.txt
+	tcpdump -nn -t -v -r ${UNITTEST1PCAP} | tee OUTPUT/R2-dump.txt | sed -f ${TESTUTILS}/sanity.sed | diff - R2-dump.txt
 	@${FILTERS} OUTPUT/${TESTNAME}_1.txt | diff - output1.txt
 
 ifneq (${UNITTEST2PCAP},)
@@ -57,7 +57,7 @@ OUTPUT/R2-any.txt:	${WHACKFILE} ${TESTNAME}
 	@echo "file ${TESTNAME}"          >.gdb2init
 	@echo "set args "${UNITTEST2ARGS} >>.gdb2init
 	ulimit -c unlimited && ./${TESTNAME} ${UNITTEST2ARGS} >OUTPUT/${TESTNAME}_2.txt 2>&1
-	tcpdump -n -t -v -r ${UNITTEST2PCAP} | tee OUTPUT/R2-any.txt | sed -f ${TESTUTILS}/sanity.sed | diff - R2-any.txt
+	tcpdump -nn -t -v -r ${UNITTEST2PCAP} | tee OUTPUT/R2-any.txt | sed -f ${TESTUTILS}/sanity.sed | diff - R2-any.txt
 	@${FILTERS} OUTPUT/${TESTNAME}_2.txt | diff - output2.txt
 endif
 

--- a/tests/unit/libpluto/lp12-parentR2/Makefile
+++ b/tests/unit/libpluto/lp12-parentR2/Makefile
@@ -54,7 +54,7 @@ OUTPUT/R2-dump.txt:	${WHACKFILE} ${TESTNAME}
 	@echo "set args "${UNITTEST1ARGS} >>.gdb1init
 	ulimit -c unlimited && ./${TESTNAME} ${UNITTEST1ARGS} >OUTPUT/${TESTNAME}_1.txt 2>&1
 	@${FILTERS} OUTPUT/${TESTNAME}_1.txt | diff - output1.txt
-	tcpdump -n -t -v -r OUTPUT/${TESTNAME}.pcap | tee OUTPUT/R2-dump.txt | sed -f ${TESTUTILS}/sanity.sed | diff - R2-dump.txt
+	tcpdump -nn -t -v -r OUTPUT/${TESTNAME}.pcap | tee OUTPUT/R2-dump.txt | sed -f ${TESTUTILS}/sanity.sed | diff - R2-dump.txt
 
 ${WHACKFILE}:
 	@mkdir -p OUTPUT

--- a/tests/unit/libpluto/lp12-parentR2/parentR2_main.c
+++ b/tests/unit/libpluto/lp12-parentR2/parentR2_main.c
@@ -1,4 +1,3 @@
-u_int8_t reply_buffer[MAX_OUTPUT_UDP_SIZE];
 
 /* this is replicated in the unit test cases since
  * the patching up of the crypto values is case specific */

--- a/tests/unit/libpluto/lp13-parentI3/Makefile
+++ b/tests/unit/libpluto/lp13-parentI3/Makefile
@@ -46,7 +46,7 @@ OUTPUT/${TESTNAME}_1.txt:	${WHACKFILE} ${TESTNAME} output1.txt
 	@echo "file ${TESTNAME}"          >.gdb1init
 	@echo "set args "${UNITTEST1ARGS} >>.gdb1init
 	ulimit -c unlimited && ./${TESTNAME} ${UNITTEST1ARGS} >OUTPUT/${TESTNAME}_1.txt 2>&1
-	@if [ -f OUTPUT/${TESTNAME}.pcap ]; then tcpdump -n -t -v -r OUTPUT/${TESTNAME}.pcap | tee OUTPUT/I2-dump.txt | sed -f ${TESTUTILS}/sanity.sed | diff - I2-dump.txt; fi
+	@if [ -f OUTPUT/${TESTNAME}.pcap ]; then tcpdump -nn -t -v -r OUTPUT/${TESTNAME}.pcap | tee OUTPUT/I2-dump.txt | sed -f ${TESTUTILS}/sanity.sed | diff - I2-dump.txt; fi
 	@${FILTERS} OUTPUT/${TESTNAME}_1.txt | diff - output1.txt
 
 ${WHACKFILE}:

--- a/tests/unit/libpluto/lp13-parentI3/parentI3_head.c
+++ b/tests/unit/libpluto/lp13-parentI3/parentI3_head.c
@@ -33,9 +33,6 @@
 #include "seam_dnskey.c"
 #include "seam_kernelalgs.c"
 
-u_int8_t reply_buffer[MAX_OUTPUT_UDP_SIZE];
-
-
  /*
  * Local Variables:
  * c-style: pluto

--- a/tests/unit/libpluto/lp133-dnsload2/dnscpeI1.c
+++ b/tests/unit/libpluto/lp133-dnsload2/dnscpeI1.c
@@ -26,7 +26,7 @@ static void init_fake_secrets(void)
 			       , NULL, NULL);
 }
 
-unsigned int sort_dns_answers;
+extern unsigned int sort_dns_answers;
 
 int main(int argc, char *argv[])
 {

--- a/tests/unit/libpluto/lp15-respondself/Makefile
+++ b/tests/unit/libpluto/lp15-respondself/Makefile
@@ -47,7 +47,7 @@ OUTPUT/R1-dump.txt:	${WHACKFILE} ${TESTNAME}
 	@echo "set args "${UNITTEST1ARGS} >>.gdb1init
 	ulimit -c unlimited && ./${TESTNAME} ${UNITTEST1ARGS} >OUTPUT/${TESTNAME}_1.txt 2>&1
 	@${FILTERS} OUTPUT/${TESTNAME}_1.txt | diff - output1.txt
-	tcpdump -n -t -v -r OUTPUT/${TESTNAME}.pcap | tee OUTPUT/R1-dump.txt | sed -f ${TESTUTILS}/sanity.sed | diff - R1-dump.txt
+	tcpdump -nn -t -v -r OUTPUT/${TESTNAME}.pcap | tee OUTPUT/R1-dump.txt | sed -f ${TESTUTILS}/sanity.sed | diff - R1-dump.txt
 
 ${WHACKFILE}: ${SAMPLEDIR}/${ENDNAME}.conf OUTPUT
 	${READWRITE} --rootdir=${SAMPLEDIR}/${ENDNAME} --config ${SAMPLEDIR}/${ENDNAME}.conf --whackout=${WHACKFILE} ${CONNNAME}

--- a/tests/unit/libpluto/lp30-dnskick/kickdns.c
+++ b/tests/unit/libpluto/lp30-dnskick/kickdns.c
@@ -25,10 +25,8 @@
 
 #include "whackmsgtestlib.c"
 #include "seam_timer.c"
-#include "seam_vendor.c"
 #include "seam_pending.c"
 #include "seam_kernel.c"
-#include "seam_io.c"
 #include "seam_log.c"
 #include "seam_west.c"
 #include "seam_xauth.c"
@@ -47,6 +45,7 @@
 #include "seam_x509.c"
 #include "seam_delete.c"
 #include "seam_ke.c"
+#include "seam_io.c"
 
 const char *progname=NULL;
 int verbose=0;

--- a/tests/unit/libpluto/lp31-IDhostpair/IDhostpair.c
+++ b/tests/unit/libpluto/lp31-IDhostpair/IDhostpair.c
@@ -17,7 +17,6 @@
 
 #include "whackmsgtestlib.c"
 #include "seam_timer.c"
-#include "seam_vendor.c"
 #include "seam_pending.c"
 #include "seam_ikev1.c"
 #include "seam_crypt.c"

--- a/tests/unit/libpluto/lp33-IDanypair/IDhostpair.c
+++ b/tests/unit/libpluto/lp33-IDanypair/IDhostpair.c
@@ -17,7 +17,6 @@
 
 #include "whackmsgtestlib.c"
 #include "seam_timer.c"
-#include "seam_vendor.c"
 #include "seam_pending.c"
 #include "seam_initiate.c"
 #include "seam_ikev1.c"

--- a/tests/unit/libpluto/lp34-orientafterlisten/orienttest.c
+++ b/tests/unit/libpluto/lp34-orientafterlisten/orienttest.c
@@ -35,6 +35,7 @@
 #include "seam_dnskey.c"
 #include "seam_natt.c"
 #include "seam_rsasig.c"
+#include "seam_io.c"
 
 #include "seam_gi_sha1.c"
 #include "seam_finish.c"

--- a/tests/unit/libpluto/lp40-orientafterprivate/orienttest.c
+++ b/tests/unit/libpluto/lp40-orientafterprivate/orienttest.c
@@ -40,8 +40,7 @@
 
 #include "seam_gi_sha1.c"
 #include "seam_finish.c"
-
-u_int8_t reply_buffer[MAX_OUTPUT_UDP_SIZE];
+#include "seam_io.c"
 
 int main(int argc, char *argv[])
 {

--- a/tests/unit/libpluto/lp55-davecert-gatewayID-R2/davecertR2-id.c
+++ b/tests/unit/libpluto/lp55-davecert-gatewayID-R2/davecertR2-id.c
@@ -13,9 +13,6 @@ static void init_local_interface(void)
     init_jamesjohnson_interface();
 }
 
-bool now_regression;
-time_t regression_time;
-
 static void init_fake_secrets(void)
 {
     prompt_pass_t pass;

--- a/tests/unit/libpluto/lp60-bestif/bestif.c
+++ b/tests/unit/libpluto/lp60-bestif/bestif.c
@@ -35,11 +35,7 @@
 #include "seam_finish.c"
 #include "seam_natt.c"
 #include "seam_rsasig.c"
-
-
-u_int8_t reply_buffer[MAX_OUTPUT_UDP_SIZE];
-
-
+#include "seam_io.c"
 #include "seam_iflist.c"
 
 /* include directly to get static functions */

--- a/tests/unit/libpluto/lp77-del-matching-st/add2sa-del1sa_head.c
+++ b/tests/unit/libpluto/lp77-del-matching-st/add2sa-del1sa_head.c
@@ -72,9 +72,7 @@
 #endif
 #include "seam_exitlog.c"
 #include "seam_natt.c"
-
-u_int8_t reply_buffer[MAX_OUTPUT_UDP_SIZE];
-
+#include "seam_io.c"
 
  /*
  * Local Variables:

--- a/tests/unit/libpluto/seam_commhandle.c
+++ b/tests/unit/libpluto/seam_commhandle.c
@@ -2,7 +2,6 @@
 #define __seam_commhandle_c__
 #include "demux.h"
 
-#include "seam_io.c"
 unsigned int dlt_type;
 pcap_t *pt;
 

--- a/tests/unit/libpluto/seam_demux.c
+++ b/tests/unit/libpluto/seam_demux.c
@@ -8,7 +8,6 @@
 #include "pluto/log.h"
 #include "id.h"
 
-pb_stream      reply_stream;
 time_t         packet_time=0;
 pcap_dumper_t *packet_save = NULL;
 

--- a/tests/unit/libpluto/seam_io.c
+++ b/tests/unit/libpluto/seam_io.c
@@ -1,4 +1,5 @@
 #ifndef __seam_io_c__
 #define __seam_io_c__
 u_int8_t reply_buffer[MAX_OUTPUT_UDP_SIZE];
+pb_stream      reply_stream;
 #endif

--- a/tests/unit/policy/pol01-sarespond/sarespond.c
+++ b/tests/unit/policy/pol01-sarespond/sarespond.c
@@ -58,8 +58,6 @@
 #include "seam_dh_v2.c"
 #include "seam_rsasig.c"
 
-u_int8_t reply_buffer[MAX_OUTPUT_UDP_SIZE];
-
 #include "seam_debug.c"
 
 #define TESTNAME "sarespond"


### PR DESCRIPTION
This series fixes some warnings related to enum conversions.  These are harmless, but easy to work around.

It also fixes some test link issues with gcc10 and tcpdump issues I saw with fedora33.