### PR TITLE
when looking for a mask for ::/0, bitstomask6 routine gets it wrong

### DIFF
--- a/lib/libopenswan/goodmask.c
+++ b/lib/libopenswan/goodmask.c
@@ -160,9 +160,9 @@ int n;
 	}
 	else {
 		result.s6_addr32[0] = 0;
-		result.s6_addr32[0] = 0;
-		result.s6_addr32[0] = 0;
-		result.s6_addr32[0] = 0;
+		result.s6_addr32[1] = 0;
+		result.s6_addr32[2] = 0;
+		result.s6_addr32[3] = 0;
 	}
 
 	return result;


### PR DESCRIPTION
decade old typo discovered
